### PR TITLE
Implemented most of the intrinsic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Our aim is to automatically update GoFormation whenever the AWS CloudFormation R
 
 ### AWS CloudFormation Intrinsic Functions
 
+The following [AWS CloudFormation Intrinsic Functions](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) are supported in GoFormation:
+
 - [x] [Fn::Base64](intrinsics/fnbase64.go)
 - [x] [Fn::FindInMap](intrinsics/fnfindinmap.go)
 - [x] [Fn::Join](intrinsics/fnjoin.go)

--- a/README.md
+++ b/README.md
@@ -8,15 +8,11 @@
         - [Marhsalling CloudFormation/SAM described with Go structs, into YAML/JSON](#marhsalling-cloudformationsam-described-with-go-structs-into-yamljson)
         - [Unmarhalling CloudFormation YAML/JSON into Go structs](#unmarhalling-cloudformation-yamljson-into-go-structs)
     - [Updating CloudFormation / SAM Resources in GoFormation](#updating-cloudformation-sam-resources-in-goformation)
+    - [Advanced](#advanced)
+        - [AWS CloudFormation Intrinsic Functions](#aws-cloudformation-intrinsic-functions)
+        - [Resolving References (Ref)](#resolving-references-ref)
+        - [Warning: YAML short form intrinsic functions (e.g. !Sub)](#warning-yaml-short-form-intrinsic-functions-eg-sub)
     - [Contributing](#contributing)
-
-
-> WARNING: This library does not currently implement any processing of CloudFormation Intrinsic Functions.
-> 
-> Intrinsic functions in YAML short form (e.g. !Sub) will choke the parser.
-> Intrinsic functions in long or short form, in JSON or YAML templates will be replaced will nil values.
-> 
-> This is something that we are working on as a priority, but depends on patching Go's YAML parser.
 
 ## Main features
 
@@ -180,6 +176,42 @@ Generated JSON Schema: schema/cloudformation.schema.json
 ```
 
 Our aim is to automatically update GoFormation whenever the AWS CloudFormation Resource Specification changes, via an automated pull request to this repository. This is not currently in place. 
+
+## Advanced
+
+### AWS CloudFormation Intrinsic Functions
+
+- [x] [Fn::Base64](intrinsics/fnbase64.go)
+- [x] [Fn::FindInMap](intrinsics/fnfindinmap.go)
+- [x] [Fn::Join](intrinsics/fnjoin.go)
+- [x] [Fn::Select](intrinsics/fnselect.go)
+- [x] [Fn::Split](intrinsics/fnsplit.go)
+- [x] [Fn::Sub](intrinsics/fnsub.go)
+- [x] [Ref](intrinsics/ref.go) 
+- [ ] Fn::And      
+- [ ] Fn::Equals  
+- [ ] Fn::If     
+- [ ] Fn::Not      
+- [ ] Fn::Or       
+- [ ] Fn::GetAtt   
+- [ ] Fn::GetAZs   
+- [ ] Fn::ImportValue
+
+Any unsupported parameters will return `nil`.
+
+### Resolving References (Ref)
+
+The intrinsic 'Ref' function as implemented will resolve all of the [pseudo parameters](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html) such as `AWS::AccountId` with their default value as listed on [the bottom of this page](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html).
+
+If a reference is not a pseudo parameter, Goformation will try to resolve it within the AWS CloudFormation template. **Currently, this implementation only searches for `Parameters` with a name that matches the ref, and returns the `Default` if it has one.**
+
+### Warning: YAML short form intrinsic functions (e.g. !Sub)
+
+While this library supports both JSON and YAML AWS CloudFormation templates, it cannot handle short form intrinsic functions in YAML templates (e.g. `!Sub`). 
+
+We will be adding support soon, however we need to patch Go's YAML library as it doesn't currently support tags.
+
+If you use a short form intrinsic function today, you'll either get the unresolved value (if the recieving field is a string field), or the template will fail to parse (if it's recieving field is a non-string field).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The following [AWS CloudFormation Intrinsic Functions](http://docs.aws.amazon.co
 - [ ] Fn::GetAZs   
 - [ ] Fn::ImportValue
 
-Any unsupported parameters will return `nil`.
+Any unsupported intrinsic functions will return `nil`.
 
 #### Resolving References (Ref)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@
         - [Unmarhalling CloudFormation YAML/JSON into Go structs](#unmarhalling-cloudformation-yamljson-into-go-structs)
     - [Updating CloudFormation / SAM Resources in GoFormation](#updating-cloudformation-sam-resources-in-goformation)
     - [Contributing](#contributing)
-  
+
+
+> WARNING: This library does not currently implement any processing of CloudFormation Intrinsic Functions.
+> 
+> Intrinsic functions in YAML short form (e.g. !Sub) will choke the parser.
+> Intrinsic functions in long or short form, in JSON or YAML templates will be replaced will nil values.
+> 
+> This is something that we are working on as a priority, but depends on patching Go's YAML parser.
+
 ## Main features
 
 * Describe CloudFormation / SAM templates as Go structs, and then turn it into JSON/YAML

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
     - [Updating CloudFormation / SAM Resources in GoFormation](#updating-cloudformation-sam-resources-in-goformation)
     - [Advanced](#advanced)
         - [AWS CloudFormation Intrinsic Functions](#aws-cloudformation-intrinsic-functions)
-        - [Resolving References (Ref)](#resolving-references-ref)
-        - [Warning: YAML short form intrinsic functions (e.g. !Sub)](#warning-yaml-short-form-intrinsic-functions-eg-sub)
+            - [Resolving References (Ref)](#resolving-references-ref)
+            - [Warning: YAML short form intrinsic functions (e.g. !Sub)](#warning-yaml-short-form-intrinsic-functions-eg-sub)
     - [Contributing](#contributing)
 
 ## Main features
@@ -199,13 +199,13 @@ Our aim is to automatically update GoFormation whenever the AWS CloudFormation R
 
 Any unsupported parameters will return `nil`.
 
-### Resolving References (Ref)
+#### Resolving References (Ref)
 
 The intrinsic 'Ref' function as implemented will resolve all of the [pseudo parameters](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html) such as `AWS::AccountId` with their default value as listed on [the bottom of this page](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html).
 
 If a reference is not a pseudo parameter, Goformation will try to resolve it within the AWS CloudFormation template. **Currently, this implementation only searches for `Parameters` with a name that matches the ref, and returns the `Default` if it has one.**
 
-### Warning: YAML short form intrinsic functions (e.g. !Sub)
+#### Warning: YAML short form intrinsic functions (e.g. !Sub)
 
 While this library supports both JSON and YAML AWS CloudFormation templates, it cannot handle short form intrinsic functions in YAML templates (e.g. `!Sub`). 
 

--- a/cloudformation/awsserverlessfunction_stringoriampolicydocumentorlistofstringorlistofiampolicydocument.go
+++ b/cloudformation/awsserverlessfunction_stringoriampolicydocumentorlistofstringorlistofiampolicydocument.go
@@ -66,6 +66,8 @@ func (r *AWSServerlessFunction_StringOrIAMPolicyDocumentOrListOfStringOrListOfIA
 
 	case []interface{}:
 
+		mapstructure.Decode(val, &r.StringArray)
+
 		mapstructure.Decode(val, &r.IAMPolicyDocumentArray)
 
 	}

--- a/cloudformation/awsserverlessfunction_stringorlistofstring.go
+++ b/cloudformation/awsserverlessfunction_stringorlistofstring.go
@@ -2,6 +2,8 @@ package cloudformation
 
 import (
 	"encoding/json"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 // AWSServerlessFunction_StringOrListOfString is a helper struct that can hold either a String or String value
@@ -49,6 +51,8 @@ func (r *AWSServerlessFunction_StringOrListOfString) UnmarshalJSON(b []byte) err
 	case map[string]interface{}:
 
 	case []interface{}:
+
+		mapstructure.Decode(val, &r.StringArray)
 
 	}
 

--- a/generate/templates/polymorphic-property.template
+++ b/generate/templates/polymorphic-property.template
@@ -2,7 +2,7 @@ package cloudformation
 
 import (
 	"encoding/json"
-	{{ if (or .Property.Types .Property.ItemTypes)}}
+	{{ if (or .Property.Types .Property.ItemTypes .Property.PrimitiveItemTypes)}}
 	"github.com/mitchellh/mapstructure"
 	{{end}}
 )
@@ -84,6 +84,9 @@ func (r *{{.Name}}) UnmarshalJSON(b []byte) error {
 		{{end}}
 
 		case []interface{}:
+		{{range $type := $.Property.PrimitiveItemTypes}}
+			mapstructure.Decode(val, &r.{{$type}}Array)
+		{{end}}
 		{{range $type := $.Property.ItemTypes}}
 			mapstructure.Decode(val, &r.{{$type}}Array)
 		{{end}}

--- a/goformation.go
+++ b/goformation.go
@@ -27,7 +27,10 @@ func Open(filename string) (*cloudformation.Template, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid YAML template: %s", err)
 		}
+
 	}
+
+	// fmt.Printf(string(data) + "\n")
 
 	return Parse(data)
 

--- a/goformation.go
+++ b/goformation.go
@@ -30,8 +30,6 @@ func Open(filename string) (*cloudformation.Template, error) {
 
 	}
 
-	// fmt.Printf(string(data) + "\n")
-
 	return Parse(data)
 
 }

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -11,6 +11,53 @@ import (
 
 var _ = Describe("Goformation", func() {
 
+	Context("with a Serverless function matching 2016-10-31 specification", func() {
+
+		template, err := goformation.Open("test/yaml/aws-serverless-function-2016-10-31.yaml")
+		It("should successfully validate the SAM template", func() {
+			Expect(err).To(BeNil())
+			Expect(template).ShouldNot(BeNil())
+		})
+
+		functions := template.GetAllAWSServerlessFunctionResources()
+
+		It("should have exactly one function", func() {
+			Expect(functions).To(HaveLen(1))
+			Expect(functions).To(HaveKey("Function20161031"))
+		})
+
+		f := functions["Function20161031"]
+
+		It("should correctly parse all of the function properties", func() {
+
+			Expect(f.Handler).To(Equal("file.method"))
+			Expect(f.Runtime).To(Equal("nodejs"))
+			Expect(f.FunctionName).To(Equal("functionname"))
+			Expect(f.Description).To(Equal("description"))
+			Expect(f.MemorySize).To(Equal(128))
+			Expect(f.Timeout).To(Equal(30))
+			Expect(f.Role).To(Equal("aws::arn::123456789012::some/role"))
+			Expect(f.Policies.StringArray).To(PointTo(ContainElement("AmazonDynamoDBFullAccess")))
+			Expect(f.Environment).ToNot(BeNil())
+			Expect(f.Environment.Variables).To(HaveKeyWithValue("NAME", "VALUE"))
+
+		})
+
+		It("should correctly parse all of the function API event sources/endpoints", func() {
+
+			Expect(f.Events).ToNot(BeNil())
+			Expect(f.Events).To(HaveKey("TestApi"))
+			Expect(f.Events["TestApi"].Type).To(Equal("Api"))
+			Expect(f.Events["TestApi"].Properties.ApiEvent).ToNot(BeNil())
+
+			event := f.Events["TestApi"].Properties.ApiEvent
+			Expect(event.Method).To(Equal("any"))
+			Expect(event.Path).To(Equal("/testing"))
+
+		})
+
+	})
+
 	Context("with an AWS CloudFormation template that contains multiple resources", func() {
 
 		Context("described as Go structs", func() {

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -182,6 +182,29 @@ var _ = Describe("Goformation", func() {
 		}
 	})
 
+	// pmaddox@ 2017-08-17:
+	// Commented out until we have support for YAML tag intrinsic functions (e.g. !Sub)
+	// Context("with a YAML template containing intrinsic tags (e.g. !Sub)", func() {
+
+	// 	template, err := goformation.Open("test/yaml/yaml-intrinsic-tags.yaml")
+	// 	It("should successfully validate the SAM template", func() {
+	// 		Expect(err).To(BeNil())
+	// 		Expect(template).ShouldNot(PointTo(BeNil()))
+	// 	})
+
+	// 	function, err := template.GetAWSServerlessFunctionWithName("IntrinsicFunctionTest")
+	// 	It("should have a function named 'IntrinsicFunctionTest'", func() {
+	// 		Expect(function).To(Not(BeNil()))
+	// 		Expect(err).To(BeNil())
+	// 	})
+
+	// 	It("it should have the correct values", func() {
+	// 		Expect(function.Runtime).To(Equal(""))
+	// 		Expect(function.Timeout).To(Equal(0))
+	// 	})
+
+	// })
+
 	Context("with a Serverless template containing different CodeUri formats", func() {
 
 		template, err := goformation.Open("test/yaml/aws-serverless-function-string-or-s3-location.yaml")

--- a/intrinsics/fnbase64.go
+++ b/intrinsics/fnbase64.go
@@ -1,0 +1,18 @@
+package intrinsics
+
+import "encoding/base64"
+
+// FnBase64 resolves the 'Fn::Base64' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-base64.htmlpackage intrinsics
+func FnBase64(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::Base64" : valueToEncode }
+
+	// Check the input is a string
+	if src, ok := input.(string); ok {
+		return base64.StdEncoding.EncodeToString([]byte(src))
+	}
+
+	return nil
+
+}

--- a/intrinsics/fnfindinmap.go
+++ b/intrinsics/fnfindinmap.go
@@ -1,0 +1,55 @@
+package intrinsics
+
+// FnFindInMap resolves the 'Fn::FindInMap' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html
+func FnFindInMap(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::FindInMap" : [ "MapName", "TopLevelKey", "SecondLevelKey"] }
+
+	// "Mappings" : {
+	// 	"RegionMap" : {
+	// 		"us-east-1" : { "32" : "ami-6411e20d", "64" : "ami-7a11e213" },
+	// 		"us-west-1" : { "32" : "ami-c9c7978c", "64" : "ami-cfc7978a" },
+	// 		"eu-west-1" : { "32" : "ami-37c2f643", "64" : "ami-31c2f645" },
+	// 		"ap-southeast-1" : { "32" : "ami-66f28c34", "64" : "ami-60f28c32" },
+	// 		"ap-northeast-1" : { "32" : "ami-9c03a89d", "64" : "ami-a003a8a1" }
+	// 	}
+	// }
+
+	// Holy nesting batman! I'm sure there's a better way to do this... :)
+
+	// Check that the input is an array
+	if arr, ok := input.([]interface{}); ok {
+		// The first element should be the map name
+		if mapname, ok := arr[0].(string); ok {
+			// The second element should be the first level map key
+			if key1, ok := arr[1].(string); ok {
+				// The third element should be the second level map key
+				if key2, ok := arr[2].(string); ok {
+					// Check the map exists in the CloudFormation template
+					if tmpl, ok := template.(map[string]interface{}); ok {
+						if mappings, ok := tmpl["Mappings"]; ok {
+							if mapmap, ok := mappings.(map[string]interface{}); ok {
+								if found, ok := mapmap[mapname]; ok {
+									if foundmap, ok := found.(map[string]interface{}); ok {
+										// Ok, we've got the map, check the first key exists
+										if foundkey1, ok := foundmap[key1]; ok {
+											if foundkey1map, ok := foundkey1.(map[string]interface{}); ok {
+												if foundkey2, ok := foundkey1map[key2]; ok {
+													return foundkey2
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+
+}

--- a/intrinsics/fnjoin.go
+++ b/intrinsics/fnjoin.go
@@ -1,0 +1,20 @@
+package intrinsics
+
+// FnJoin resolves the 'Fn::Join' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-join.html
+func FnJoin(name string, input interface{}, template interface{}) interface{} {
+
+	result := ""
+
+	// Check the input is an array
+	if arr, ok := input.([]interface{}); ok {
+		for _, value := range arr {
+			if str, ok := value.(string); ok {
+				result += str
+			}
+		}
+	}
+
+	return result
+
+}

--- a/intrinsics/fnselect.go
+++ b/intrinsics/fnselect.go
@@ -1,0 +1,26 @@
+package intrinsics
+
+// FnSelect resolves the 'Fn::Select' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-select.html
+func FnSelect(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::Select" : [ index, listOfObjects ] }
+
+	// Check that the input is an array
+	if arr, ok := input.([]interface{}); ok {
+		// The first element should be the index
+		if index64, ok := arr[0].(float64); ok {
+			index := int(index64)
+			// The second element is the array of objects to search
+			if objects, ok := arr[1].([]interface{}); ok {
+				// Check the requested element is in bounds
+				if index < len(objects) {
+					return objects[index]
+				}
+			}
+		}
+	}
+
+	return nil
+
+}

--- a/intrinsics/fnsplit.go
+++ b/intrinsics/fnsplit.go
@@ -1,0 +1,24 @@
+package intrinsics
+
+import "strings"
+
+// FnSplit resolves the 'Fn::Split' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-split.html
+func FnSplit(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::Split" : [ "delimiter", "source string" ] }
+
+	// Check that the input is an array
+	if arr, ok := input.([]interface{}); ok {
+		// The first element should be a string (the delimiter)
+		if delim, ok := arr[0].(string); ok {
+			// The second element should be a string (the content to join)
+			if str, ok := arr[1].(string); ok {
+				return strings.Split(str, delim)
+			}
+		}
+	}
+
+	return []string{}
+
+}

--- a/intrinsics/fnsub.go
+++ b/intrinsics/fnsub.go
@@ -1,0 +1,33 @@
+package intrinsics
+
+import (
+	"strings"
+)
+
+// FnSub resolves the 'Fn::Sub' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html
+func FnSub(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::Sub": [ "some ${replaced}", { "replaced": "value" } ] }
+
+	// Check the input is an array
+	if arr, ok := input.([]interface{}); ok {
+		// The first element is the source
+		if src, ok := arr[0].(string); ok {
+			// The seconds element is a map of variables to replace
+			if replacements, ok := arr[1].(map[string]interface{}); ok {
+				// Loop through the replacements
+				for key, replacement := range replacements {
+					// Check the replacement is a string
+					if value, ok := replacement.(string); ok {
+						src = strings.Replace(src, "${"+key+"}", value, -1)
+					}
+				}
+				return src
+			}
+		}
+	}
+
+	return nil
+
+}

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -40,8 +40,7 @@ type ProcessorOptions struct {
 // nonResolvingHandler is a simple example of an intrinsic function handler function
 // that refuses to resolve any intrinsic functions, and just returns a basic string.
 func nonResolvingHandler(name string, input interface{}) interface{} {
-	result := fmt.Sprintf("%s intrinsic function is unsupported", name)
-	return result
+	return nil
 }
 
 // Process recursively searches through a byte array for all AWS CloudFormation

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -9,7 +9,7 @@ import (
 // the response that should be placed in it's place. An intrinsic handler function
 // is passed the name of the intrinsic function (e.g. Fn::Join), and the object
 // to apply it to (as an interface{}), and should return the resolved object (as an interface{}).
-type IntrinsicHandler func(string, interface{}) interface{}
+type IntrinsicHandler func(string, interface{}, interface{}) interface{}
 
 // IntrinsicFunctionHandlers is a map of all the possible AWS CloudFormation intrinsic
 // functions, and a handler function that is invoked to resolve.
@@ -39,7 +39,7 @@ type ProcessorOptions struct {
 
 // nonResolvingHandler is a simple example of an intrinsic function handler function
 // that refuses to resolve any intrinsic functions, and just returns a basic string.
-func nonResolvingHandler(name string, input interface{}) interface{} {
+func nonResolvingHandler(name string, input interface{}, template interface{}) interface{} {
 	return nil
 }
 
@@ -55,7 +55,7 @@ func Process(input []byte, options *ProcessorOptions) ([]byte, error) {
 	}
 
 	// Process all of the intrinsic functions
-	processed := search(unmarshalled, options)
+	processed := search(unmarshalled, unmarshalled, options)
 
 	// And return the result back as a []byte of JSON
 	result, err := json.MarshalIndent(processed, "", "  ")
@@ -71,7 +71,7 @@ func Process(input []byte, options *ProcessorOptions) ([]byte, error) {
 // an intrinsic function. If it finds one, it calls the provided handler function, passing
 // it the type of intrinsic function (e.g. 'Fn::Join'), and the contents. The intrinsic
 // handler is expected to return the value that is supposed to be there.
-func search(input interface{}, options *ProcessorOptions) interface{} {
+func search(input interface{}, template interface{}, options *ProcessorOptions) interface{} {
 
 	switch value := input.(type) {
 
@@ -88,11 +88,11 @@ func search(input interface{}, options *ProcessorOptions) interface{} {
 			if h, ok := handler(key, options); ok {
 				// This is an intrinsic function, so replace the intrinsic function object
 				// with the result of calling the intrinsic function handler for this type
-				return h(key, search(val, options))
+				return h(key, template, search(val, template, options))
 			}
 
 			// This is not an intrinsic function, recurse through it normally
-			processed[key] = search(val, options)
+			processed[key] = search(val, template, options)
 
 		}
 		return processed
@@ -102,7 +102,7 @@ func search(input interface{}, options *ProcessorOptions) interface{} {
 		// We found an array in the JSON - recurse through it's elements looking for intrinsic functions
 		processed := []interface{}{}
 		for _, val := range value {
-			processed = append(processed, search(val, options))
+			processed = append(processed, search(val, template, options))
 		}
 		return processed
 

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -14,21 +14,21 @@ type IntrinsicHandler func(string, interface{}, interface{}) interface{}
 // IntrinsicFunctionHandlers is a map of all the possible AWS CloudFormation intrinsic
 // functions, and a handler function that is invoked to resolve.
 var defaultIntrinsicHandlers = map[string]IntrinsicHandler{
-	"Fn::Base64":      nonResolvingHandler,
+	"Fn::Base64":      FnBase64,
 	"Fn::And":         nonResolvingHandler,
 	"Fn::Equals":      nonResolvingHandler,
 	"Fn::If":          nonResolvingHandler,
 	"Fn::Not":         nonResolvingHandler,
 	"Fn::Or":          nonResolvingHandler,
-	"Fn::FindInMap":   nonResolvingHandler,
+	"Fn::FindInMap":   FnFindInMap,
 	"Fn::GetAtt":      nonResolvingHandler,
 	"Fn::GetAZs":      nonResolvingHandler,
 	"Fn::ImportValue": nonResolvingHandler,
-	"Fn::Join":        nonResolvingHandler,
-	"Fn::Select":      nonResolvingHandler,
-	"Fn::Split":       nonResolvingHandler,
-	"Fn::Sub":         nonResolvingHandler,
-	"Ref":             nonResolvingHandler,
+	"Fn::Join":        FnJoin,
+	"Fn::Select":      FnSelect,
+	"Fn::Split":       FnSplit,
+	"Fn::Sub":         FnSub,
+	"Ref":             Ref,
 }
 
 // ProcessorOptions allows customisation of the intrinsic function processor behaviour.
@@ -88,7 +88,7 @@ func search(input interface{}, template interface{}, options *ProcessorOptions) 
 			if h, ok := handler(key, options); ok {
 				// This is an intrinsic function, so replace the intrinsic function object
 				// with the result of calling the intrinsic function handler for this type
-				return h(key, template, search(val, template, options))
+				return h(key, search(val, template, options), template)
 			}
 
 			// This is not an intrinsic function, recurse through it normally

--- a/intrinsics/intrinsics_test.go
+++ b/intrinsics/intrinsics_test.go
@@ -1,6 +1,7 @@
 package intrinsics_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 
 	. "github.com/awslabs/goformation/intrinsics"
@@ -12,12 +13,68 @@ import (
 var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 	Context("with a template that contains invalid JSON", func() {
-		const template = `{`
-		processed, err := Process([]byte(template), nil)
+		input := `{`
+		processed, err := Process([]byte(input), nil)
 		It("should fail to process the template", func() {
 			Expect(processed).To(BeNil())
 			Expect(err).ToNot(BeNil())
 		})
+	})
+
+	Context("with a template that contains a 'Ref' intrinsic function", func() {
+
+		input := `{"Parameters":{"FunctionTimeout":{"Type":"Number","Default":120}},"Resources":{"MyServerlessFunction":{"Type":"AWS::Serverless::Function","Properties":{"Runtime":"nodejs6.10","Timeout":{"Ref":"FunctionTimeout"}}}}}`
+		processed, err := Process([]byte(input), nil)
+		It("should successfully process the template", func() {
+			Expect(processed).ShouldNot(BeNil())
+			Expect(err).Should(BeNil())
+		})
+
+		var result interface{}
+		err = json.Unmarshal(processed, &result)
+		It("should be valid JSON, and marshal to a Go type", func() {
+			Expect(processed).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		template := result.(map[string]interface{})
+		resources := template["Resources"].(map[string]interface{})
+		resource := resources["MyServerlessFunction"].(map[string]interface{})
+		properties := resource["Properties"].(map[string]interface{})
+
+		It("should have the correct values", func() {
+			Expect(properties["Timeout"]).To(Equal(float64(120)))
+			Expect(properties["Runtime"]).To(Equal("nodejs6.10"))
+		})
+
+	})
+
+	Context("with a template that contains a 'Ref' intrinsic function with a 'Fn::Join' inside it", func() {
+
+		input := `{"Parameters":{"FunctionTimeout":{"Type":"Number","Default":120}},"Resources":{"MyServerlessFunction":{"Type":"AWS::Serverless::Function","Properties":{"Runtime":"nodejs6.10","Timeout":{"Ref":{"Fn::Join":["Function","Timeout"]}}}}}}`
+		processed, err := Process([]byte(input), nil)
+		It("should successfully process the template", func() {
+			Expect(processed).ShouldNot(BeNil())
+			Expect(err).Should(BeNil())
+		})
+
+		var result interface{}
+		err = json.Unmarshal(processed, &result)
+		It("should be valid JSON, and marshal to a Go type", func() {
+			Expect(processed).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		template := result.(map[string]interface{})
+		resources := template["Resources"].(map[string]interface{})
+		resource := resources["MyServerlessFunction"].(map[string]interface{})
+		properties := resource["Properties"].(map[string]interface{})
+
+		It("should have the correct values", func() {
+			Expect(properties["Timeout"]).To(Equal(float64(120)))
+			Expect(properties["Runtime"]).To(Equal("nodejs6.10"))
+		})
+
 	})
 
 	// pmaddox@ 2017-08-17:
@@ -51,6 +108,15 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 	Context("with a template that contains primitives, intrinsics, and nested intrinsics", func() {
 
 		const template = `{
+			"Mappings" : {
+				"RegionMap" : {
+					"us-east-1" : { "32" : "ami-6411e20d", "64" : "ami-7a11e213" },
+					"us-west-1" : { "32" : "ami-c9c7978c", "64" : "ami-cfc7978a" },
+					"eu-west-1" : { "32" : "ami-37c2f643", "64" : "ami-31c2f645" },
+					"ap-southeast-1" : { "32" : "ami-66f28c34", "64" : "ami-60f28c32" },
+					"ap-northeast-1" : { "32" : "ami-9c03a89d", "64" : "ami-a003a8a1" }
+				}
+			},
 			"Resources": {
 				"ExampleResource": {
 					"Type": "AWS::Example::Resource",
@@ -60,7 +126,17 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 						"NumberProperty": 123.45,
 						"JoinIntrinsicProperty": { "Fn::Join": [ "some", "name" ] },				
 						"JoinNestedIntrinsicProperty": { "Fn::Join": [ "some", { "Fn::Join": [ "joined", "value" ] } ] },
-						"SubIntrinsicProperty": { "Fn::Sub": [ "some ${value}", { "value": "value" } ] }			
+						"SubIntrinsicProperty": { "Fn::Sub": [ "some ${replaced}", { "replaced": "value" } ] },
+						"SplitIntrinsicProperty": { "Fn::Split" : [ ",", "some,string,to,be,split" ] },
+						"SelectIntrinsicProperty": { "Fn::Select" : [ 1, [ 0, 1, 2, 3 ] ] },
+						"FindInMapIntrinsicProperty": { "Fn::FindInMap" : [ "RegionMap", "eu-west-1", "64"] },
+						"Base64IntrinsicProperty": { "Fn::Base64" : "some-string-to-base64" },
+						"RefAWSAccountId": { "Ref": "AWS::AccountId" },
+						"RefAWSNotificationARNs": { "Ref": "AWS::NotificationARNs" },
+						"RefNoValue": { "Ref": "AWS::NoValue" },
+						"RefAWSRegion": { "Ref": "AWS::Region" },
+						"RefAWSStackId": { "Ref": "AWS::StackId" },
+						"RefAWSStackName": { "Ref": "AWS::StackName" }	
 					}
 				}
 			}
@@ -76,7 +152,6 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 			var result interface{}
 			err = json.Unmarshal(processed, &result)
-
 			It("should be valid JSON, and marshal to a Go type", func() {
 				Expect(processed).ToNot(BeNil())
 				Expect(err).To(BeNil())
@@ -100,15 +175,66 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 			})
 
 			It("should have the correct value for a Fn::Join intrinsic property", func() {
-				Expect(properties["JoinIntrinsicProperty"]).To(BeNil())
+				Expect(properties["JoinIntrinsicProperty"]).To(Equal("somename"))
 			})
 
 			It("should have the correct value for a nested Fn::Join intrinsic property", func() {
-				Expect(properties["JoinNestedIntrinsicProperty"]).To(BeNil())
+				Expect(properties["JoinNestedIntrinsicProperty"]).To(Equal("somejoinedvalue"))
 			})
 
 			It("should have the correct value for a Fn::Sub intrinsic property", func() {
-				Expect(properties["SubIntrinsicProperty"]).To(BeNil())
+				Expect(properties["SubIntrinsicProperty"]).To(Equal("some value"))
+			})
+
+			It("should have the correct value for a Fn::Split intrinsic property", func() {
+				Expect(properties["SplitIntrinsicProperty"]).To(HaveLen(5))
+				results := []string{}
+				for _, element := range properties["SplitIntrinsicProperty"].([]interface{}) {
+					if str, ok := element.(string); ok {
+						results = append(results, str)
+					}
+				}
+				Expect(results).To(Equal([]string{"some", "string", "to", "be", "split"}))
+			})
+
+			It("should have the correct value for a Fn::Select intrinsic property", func() {
+				Expect(properties["SelectIntrinsicProperty"]).To(Equal(float64(1)))
+			})
+
+			It("should have the correct value for a Fn::FindInMap intrinsic property", func() {
+				Expect(properties["FindInMapIntrinsicProperty"]).To(Equal("ami-31c2f645"))
+			})
+
+			It("should have the correct value for a Fn::Base64 intrinsic property", func() {
+				encoded, ok := properties["Base64IntrinsicProperty"].(string)
+				Expect(ok).ToNot(BeNil())
+				decoded, err := base64.StdEncoding.DecodeString(encoded)
+				Expect(string(decoded)).To(Equal("some-string-to-base64"))
+				Expect(err).To(BeNil())
+			})
+
+			It("should have the correct value for a AWS::AccountId pseudo parameter intrinsic property", func() {
+				Expect(properties["RefAWSAccountId"]).To(Equal("123456789012"))
+			})
+
+			It("should have the correct value for a AWS::NotificationARNs pseudo parameter intrinsic property", func() {
+				Expect(properties["RefAWSNotificationARNs"]).To(ContainElement("arn:aws:sns:us-east-1:123456789012:MyTopic"))
+			})
+
+			It("should have the correct value for a AWS::NoValue pseudo parameter intrinsic property", func() {
+				Expect(properties["RefAWSNoValue"]).To(BeNil())
+			})
+
+			It("should have the correct value for a AWS::Region pseudo parameter intrinsic property", func() {
+				Expect(properties["RefAWSRegion"]).To(Equal("us-east-1"))
+			})
+
+			It("should have the correct value for a AWS::StackId pseudo parameter intrinsic property", func() {
+				Expect(properties["RefAWSStackId"]).To(Equal("arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/1c2fa620-982a-11e3-aff7-50e2416294e0"))
+			})
+
+			It("should have the correct value for a AWS::StackName pseudo parameter intrinsic property", func() {
+				Expect(properties["RefAWSStackName"]).To(Equal("goformation-stack"))
 			})
 
 		})
@@ -162,7 +288,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 			})
 
 			It("should have the correct value for an intrinsic property that's not supposed to be overridden", func() {
-				Expect(properties["SubIntrinsicProperty"]).To(BeNil())
+				Expect(properties["SubIntrinsicProperty"]).To(Equal("some value"))
 			})
 
 		})

--- a/intrinsics/intrinsics_test.go
+++ b/intrinsics/intrinsics_test.go
@@ -20,6 +20,34 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 		})
 	})
 
+	// pmaddox@ 2017-08-17:
+	// Commented out until we have support for YAML tag intrinsic functions (e.g. !Sub)
+	//Context("with a YAML template that contains intrinsic functions in tag form", func() {
+
+	// t := "AWSTemplateFormatVersion: '2010-09-09'\n"
+	// t += "Transform: AWS::Serverless-2016-10-31\n"
+	// t += "Description: SAM template for testing intrinsic functions with YAML tags\n"
+	// t += "Resources:\n"
+	// t += "  CodeUriWithS3LocationSpecifiedAsString:\n"
+	// t += "    Type: AWS::Serverless::Function\n"
+	// t += "    Properties:\n"
+	// t += "      Runtime: !Sub test-${runtime}\n"
+	// t += "      Timeout: !Ref ThisWontResolve\n"
+
+	// data, err := yaml.YAMLToJSON([]byte(t))
+	// It("should successfully convert YAML to JSON", func() {
+	// 	Expect(data).ShouldNot(BeNil())
+	// 	Expect(err).Should(BeNil())
+	// })
+
+	// processed, err := Process(data, nil)
+	// It("should successfully process the template", func() {
+	// 	Expect(processed).ShouldNot(BeNil())
+	// 	Expect(err).Should(BeNil())
+	// })
+
+	//}
+
 	Context("with a template that contains primitives, intrinsics, and nested intrinsics", func() {
 
 		const template = `{
@@ -72,15 +100,15 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 			})
 
 			It("should have the correct value for a Fn::Join intrinsic property", func() {
-				Expect(properties["JoinIntrinsicProperty"]).To(Equal("Fn::Join intrinsic function is unsupported"))
+				Expect(properties["JoinIntrinsicProperty"]).To(BeNil())
 			})
 
 			It("should have the correct value for a nested Fn::Join intrinsic property", func() {
-				Expect(properties["JoinNestedIntrinsicProperty"]).To(Equal("Fn::Join intrinsic function is unsupported"))
+				Expect(properties["JoinNestedIntrinsicProperty"]).To(BeNil())
 			})
 
 			It("should have the correct value for a Fn::Sub intrinsic property", func() {
-				Expect(properties["SubIntrinsicProperty"]).To(Equal("Fn::Sub intrinsic function is unsupported"))
+				Expect(properties["SubIntrinsicProperty"]).To(BeNil())
 			})
 
 		})
@@ -134,7 +162,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 			})
 
 			It("should have the correct value for an intrinsic property that's not supposed to be overridden", func() {
-				Expect(properties["SubIntrinsicProperty"]).To(Equal("Fn::Sub intrinsic function is unsupported"))
+				Expect(properties["SubIntrinsicProperty"]).To(BeNil())
 			})
 
 		})

--- a/intrinsics/intrinsics_test.go
+++ b/intrinsics/intrinsics_test.go
@@ -117,7 +117,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 			opts := &ProcessorOptions{
 				IntrinsicHandlerOverrides: map[string]IntrinsicHandler{
-					"Fn::Join": func(name string, input interface{}) interface{} {
+					"Fn::Join": func(name string, input interface{}, template interface{}) interface{} {
 						return "overridden"
 					},
 				},

--- a/intrinsics/ref.go
+++ b/intrinsics/ref.go
@@ -1,0 +1,58 @@
+package intrinsics
+
+// Ref resolves the 'Ref' AWS CloudFormation intrinsic function.
+// Currently, this only resolves against CloudFormation Parameter default values
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html
+func Ref(name string, input interface{}, template interface{}) interface{} {
+
+	// Dang son, this has got more nest than a bald eagle
+	// Check the input is a string
+	if name, ok := input.(string); ok {
+
+		switch name {
+
+		case "AWS::AccountId":
+			return "123456789012"
+		case "AWS::NotificationARNs": //
+			return []string{"arn:aws:sns:us-east-1:123456789012:MyTopic"}
+		case "AWS::NoValue":
+			return nil
+		case "AWS::Region":
+			return "us-east-1"
+		case "AWS::StackId":
+			return "arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/1c2fa620-982a-11e3-aff7-50e2416294e0"
+		case "AWS::StackName":
+			return "goformation-stack"
+
+		default:
+
+			// This isn't a pseudo 'Ref' paramater, so we need to look inside the CloudFormation template
+			// to see if we can resolve the reference. This implementation just looks at the Parameters section
+			// to see if there is a parameter matching the name, and if so, return the default value.
+
+			// Check the template is a map
+			if template, ok := template.(map[string]interface{}); ok {
+				// Check there is a parameters section
+				if uparameters, ok := template["Parameters"]; ok {
+					// Check the parameters section is a map
+					if parameters, ok := uparameters.(map[string]interface{}); ok {
+						// Check there is a parameter with the same name as the Ref
+						if uparameter, ok := parameters[name]; ok {
+							// Check the parameter is a map
+							if parameter, ok := uparameter.(map[string]interface{}); ok {
+								// Check the parameter has a default
+								if def, ok := parameter["Default"]; ok {
+									return def
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+	}
+
+	return input
+
+}

--- a/test/yaml/yaml-intrinsic-tags.yaml
+++ b/test/yaml/yaml-intrinsic-tags.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: SAM template for testing intrinsic functions with YAML tags
+Resources:
+  IntrinsicFunctionTest:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: !Sub test-${runtime}
+      Timeout: !Ref ThisWontResolve


### PR DESCRIPTION
Updated the intrinsic function handler signature to include the full template `interface{}`. This will allow us to do lookups on other resources should we want to implement `!Ref` at a later date.

Intrinsic function handlers now have the signature:

```go
func handle(name string, input interface{}, template interface{}) interface{} { 

    // name is the intrinsic function type, such as Fn::Join
    // input is the resource it needs to perform the intrinsic function on
    // template is a reference to the whole template data

    // return value is the result of the intrinsic function processing that this method
    // does, and will be placed in the template where the intrinsic function was.

}
```