### PR TITLE
Fn::Sub now resolves references when it needs to

### DIFF
--- a/goformation_test.go
+++ b/goformation_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Goformation", func() {
 		})
 
 		It("it should have the correct values", func() {
-			Expect(function.Runtime).To(Equal(""))
+			Expect(function.Runtime).To(Equal("4.3"))
 			Expect(function.Timeout).To(Equal(10))
 		})
 

--- a/intrinsics/fnsub.go
+++ b/intrinsics/fnsub.go
@@ -1,6 +1,7 @@
 package intrinsics
 
 import (
+	"regexp"
 	"strings"
 )
 
@@ -8,14 +9,19 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html
 func FnSub(name string, input interface{}, template interface{}) interface{} {
 
+	// Input can either be a string for this type of Fn::Sub call:
+	// { "Fn::Sub": "some-string-with-a-${variable}" }
+
+	// or it will be an array of length two for named replacements
 	// { "Fn::Sub": [ "some ${replaced}", { "replaced": "value" } ] }
 
-	// Check the input is an array
-	if arr, ok := input.([]interface{}); ok {
-		// The first element is the source
-		if src, ok := arr[0].(string); ok {
+	switch val := input.(type) {
+
+	case []interface{}:
+		// Replace each of the variables in element 0 with the items in element 1
+		if src, ok := val[0].(string); ok {
 			// The seconds element is a map of variables to replace
-			if replacements, ok := arr[1].(map[string]interface{}); ok {
+			if replacements, ok := val[1].(map[string]interface{}); ok {
 				// Loop through the replacements
 				for key, replacement := range replacements {
 					// Check the replacement is a string
@@ -26,6 +32,23 @@ func FnSub(name string, input interface{}, template interface{}) interface{} {
 				return src
 			}
 		}
+
+	case string:
+		// Look up references for each of the variables
+		regex := regexp.MustCompile(`\$\{([0-9A-Za-z]+)\}`)
+		variables := regex.FindAllStringSubmatch(val, -1)
+		for _, variable := range variables {
+			resolved := Ref("Ref", variable[1], template)
+			if resolved != nil {
+				if replacement, ok := resolved.(string); ok {
+					val = strings.Replace(val, variable[0], replacement, -1)
+				}
+			} else {
+				// The reference couldn't be resolved, so just strip the variable
+				val = strings.Replace(val, variable[0], "", -1)
+			}
+		}
+		return val
 	}
 
 	return nil

--- a/intrinsics/ref.go
+++ b/intrinsics/ref.go
@@ -9,11 +9,6 @@ func Ref(name string, input interface{}, template interface{}) interface{} {
 	// Check the input is a string
 	if name, ok := input.(string); ok {
 
-		// debug := false
-		// if name == "TestParameter" {
-		// 	debug = true
-		// }
-
 		switch name {
 
 		case "AWS::AccountId":

--- a/intrinsics/ref.go
+++ b/intrinsics/ref.go
@@ -9,6 +9,11 @@ func Ref(name string, input interface{}, template interface{}) interface{} {
 	// Check the input is a string
 	if name, ok := input.(string); ok {
 
+		// debug := false
+		// if name == "TestParameter" {
+		// 	debug = true
+		// }
+
 		switch name {
 
 		case "AWS::AccountId":


### PR DESCRIPTION
If Fn::Sub is an array, then do named string replacements, ala:
`{ "Fn::Sub": [ "some ${replaced}", { "replaced": "value" } ] }`

If Fn::Sub is a string, then resolve any ${Reference}'s in it:
`{ "Fn::Sub": "some-string-with-a-${variable}" }`

Note: This just calls the Fn::Ref intrinsic function to resolve references, so there is no code duplication. Also wrote a bunch of test cases to cover this.

Fixes #14.