### PR TITLE
Better Fn::Sub (calls Fn::GetAtt when required)

### DIFF
--- a/intrinsics/fngetatt.go
+++ b/intrinsics/fngetatt.go
@@ -1,0 +1,9 @@
+package intrinsics
+
+// FnGetAtt is not implemented, and always returns nil.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html
+func FnGetAtt(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::GetAtt" : [ "logicalNameOfResource", "attributeName" ] }
+	return nil
+}

--- a/intrinsics/intrinsics_test.go
+++ b/intrinsics/intrinsics_test.go
@@ -94,6 +94,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 		t += "      Timeout: !Ref ThisWontResolve\n"
 		t += "      FunctionName: !Ref TestParameter\n"
 		t += "      Handler: !Sub method.${TestParameter}.${ThisWontResolve}\n"
+		t += "      Role: !Sub ${ThisWontResolve.Arn}\n"
 		t += "      CodeUri:\n"
 		t += "        Fn::Sub:\n"
 		t += "          - s3://${Bucket}/${Key}\n"
@@ -135,6 +136,11 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 		It("should resolve a reference within a !Sub", func() {
 			Expect(properties["Handler"]).To(Equal("method.test-parameter-value."))
+		})
+
+		// GetAtt isn't implemented today
+		It("should resolve a resource attribute within a !Sub", func() {
+			Expect(properties["Role"]).To(Equal(""))
 		})
 
 	})


### PR DESCRIPTION
Made Fn::Sub check if a reference is a normal reference, or if it has a. in it, then treat it as a reference attribute lookup and pass it to
Fn::GetAtt. While Fn::GetAtt isn't implemented today, this will make
Fn::Sub "just work" when it is one day implemented. Thanks sanathkr@ for
this suggestion!