### PR TITLE
Auto-updating of GoFormation resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
-
 go:
-  - 1.8
+- 1.8
+after_success:
+ - test "${TRAVIS_EVENT_TYPE}" = "cron" && ./generate/create-pull-request.sh

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
     - [Main features](#main-features)
     - [Installation](#installation)
     - [Usage](#usage)
-        - [Marhsalling CloudFormation/SAM described with Go structs, into YAML/JSON](#marhsalling-cloudformationsam-described-with-go-structs-into-yamljson)
-        - [Unmarhalling CloudFormation YAML/JSON into Go structs](#unmarhalling-cloudformation-yamljson-into-go-structs)
+        - [Marshalling CloudFormation/SAM described with Go structs, into YAML/JSON](#marshalling-cloudformationsam-described-with-go-structs-into-yamljson)
+        - [Unmarshalling CloudFormation YAML/JSON into Go structs](#unmarshalling-cloudformation-yamljson-into-go-structs)
     - [Updating CloudFormation / SAM Resources in GoFormation](#updating-cloudformation-sam-resources-in-goformation)
     - [Advanced](#advanced)
         - [AWS CloudFormation Intrinsic Functions](#aws-cloudformation-intrinsic-functions)
@@ -178,7 +178,7 @@ Generated 17 AWS SAM resources from specification v2016-10-31
 Generated JSON Schema: schema/cloudformation.schema.json
 ```
 
-Our aim is to automatically update GoFormation whenever the AWS CloudFormation Resource Specification changes, via an automated pull request to this repository. This is not currently in place. 
+The GoFormation build pipeline automatically checks for any updated AWS CloudFormation resources on a daily basis, and creates a pull request against this repository if any are found.
 
 ## Advanced
 

--- a/generate/create-pull-request.sh
+++ b/generate/create-pull-request.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# This script runs on a regular cron within Travis-CI.
+# 
+# It checks to see if any AWS CloudFormation resources have been updated, 
+# and if so, creates a new pull request to apply them back to the awslabs repo.
+
+# Bomb out on errors
+set -e
+
+# The repo/branch to create the PR against
+REPO="awslabs/goformation"
+SRC_BRANCH="master"
+DST_BRANCH="master"
+
+# Git details (for the commit)
+COMMIT_NAME="AWS GoFormation"
+COMMIT_EMAIL="goformation@amazon.com"
+COMMIT_MSG="AWS CloudFormation Update ($(date +%F))"
+
+# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
+    echo "Skipping auto generation of AWS CloudFormation resources; just doing a build."
+    exit 0
+fi
+
+# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SRC_BRANCH" ]; then
+    echo "Skipping deploy; just doing a build."
+    exit 0
+fi
+
+# Configure the Git user for any commits
+git config --global user.name "${COMMIT_NAME}"
+git config --global user.email "${COMMIT_EMAIL}"
+
+echo "Checking out github.com/${REPO}..."
+UPSTREAM_DIR=/tmp/upstream/src/github.com/awslabs/goformation
+mkdir -p ${UPSTREAM_DIR}
+git clone https://github.com/${REPO}.git ${UPSTREAM_DIR} > /dev/null 2>&1
+GOPATH=/tmp/upstream
+cd ${UPSTREAM_DIR}
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+REQUEST_BRANCH="aws-goformation-updates"
+echo "Creating new branch: ${REQUEST_BRANCH} tracking origin/${SRC_BRANCH}"
+git checkout -b ${REQUEST_BRANCH} origin/${SRC_BRANCH}
+git pull --rebase origin ${REQUEST_BRANCH} || true
+ 
+echo "Auto-generating AWS CloudFormation resources..."
+go generate
+
+# Don't proceed if there were no new resources generated/updated
+if [[ -z $(git status -s | grep "cloudformation/") ]]; then
+    echo "No changes - no pull request necessary."
+    exit 0;
+fi
+  
+echo "Changes found:"
+git status -s
+
+echo "Running tests..."
+go test -v ./...
+
+echo "Committing changes..."
+git add cloudformation/*
+git commit -m "${COMMIT_MSG}" 
+
+echo "Pushing changes..."
+git remote add origin-push https://${GITHUB_TOKEN}@github.com/${REPO}.git > /dev/null 2>&1
+git push --quiet --set-upstream origin-push ${REQUEST_BRANCH}
+
+echo "Installing GitHub Hub"
+git clone https://github.com/github/hub.git /tmp/hub
+cd /tmp/hub
+./script/build 
+
+echo "Generating Pull Request for merging ${REPO}/${REQUEST_BRANCH} to ${REPO}/${DST_BRANCH}..."
+cd ${UPSTREAM_DIR}
+echo "${COMMIT_MSG}" | /tmp/hub/bin/hub pull-request -F - /dev/null 2>&1 || true


### PR DESCRIPTION
Added a travis script that checks on a daily basis for any AWS CloudFormation updates (comparing against master branch), and if any are found, create a new pull request for them automatically.

If more changes come in before the pull request is closed/merged, the commits will be added to the pull request.

I've tested this pretty extensively in my own fork, however as all it does is open PRs, the worse that could happen is we get a few odd PR's generated over the next few days.