### PR TITLE
Add support for Fn::GetAZs intrinsic

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The following [AWS CloudFormation Intrinsic Functions](http://docs.aws.amazon.co
 - [x] [Fn::Not](intrinsics/fnnot.go)      
 - [x] [Fn::Or](intrinsics/fnor.go)       
 - [ ] Fn::GetAtt   
-- [ ] Fn::GetAZs   
+- [x] [Fn::GetAZs](intrinsics/fngetazs.go)
 - [ ] Fn::ImportValue
 
 Any unsupported intrinsic functions will return `nil`.

--- a/intrinsics/fngetazs.go
+++ b/intrinsics/fngetazs.go
@@ -1,0 +1,36 @@
+package intrinsics
+
+var AZs map[string][]interface{} = make(map[string][]interface{})
+
+func buildAZs(region string, zones ...string) (result []interface{}) {
+	for _, zone := range zones {
+		result = append(result, region+zone)
+	}
+	return
+}
+
+func init() {
+	AZs["us-east-1"] = buildAZs("us-east-1", "a", "b", "c", "d")
+	AZs["us-west-1"] = buildAZs("us-west-1", "a", "b")
+}
+
+// FnGetAZs resolves the 'Fn::GetAZs' AWS CloudFormation intrinsic function.
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html
+func FnGetAZs(name string, input interface{}, template interface{}) interface{} {
+
+	// Check the input is a string
+	if region, ok := input.(string); ok {
+		if region == "" {
+			region = "us-east-1"
+		}
+
+		if azs, ok := AZs[region]; ok {
+			return azs
+		} else {
+			//assume 3 AZs per region
+			return buildAZs(region, "a", "b", "c")
+		}
+	}
+
+	return nil
+}

--- a/intrinsics/fnselect.go
+++ b/intrinsics/fnselect.go
@@ -1,5 +1,7 @@
 package intrinsics
 
+import "strconv"
+
 // FnSelect resolves the 'Fn::Select' AWS CloudFormation intrinsic function.
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-select.html
 func FnSelect(name string, input interface{}, template interface{}) interface{} {
@@ -9,18 +11,27 @@ func FnSelect(name string, input interface{}, template interface{}) interface{} 
 	// Check that the input is an array
 	if arr, ok := input.([]interface{}); ok {
 		// The first element should be the index
+		var index int
 		if index64, ok := arr[0].(float64); ok {
-			index := int(index64)
-			// The second element is the array of objects to search
-			if objects, ok := arr[1].([]interface{}); ok {
-				// Check the requested element is in bounds
-				if index < len(objects) {
-					return objects[index]
-				}
+			index = int(index64)
+		} else if indexStr, ok := arr[0].(string); ok {
+			if c, err := strconv.Atoi(indexStr); err == nil {
+				index = c
+			} else {
+				return nil
+			}
+		} else {
+			return nil
+		}
+
+		// The second element is the array of objects to search
+		if objects, ok := arr[1].([]interface{}); ok {
+			// Check the requested element is in bounds
+			if index < len(objects) {
+				return objects[index]
 			}
 		}
 	}
 
 	return nil
-
 }

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -24,7 +24,7 @@ var defaultIntrinsicHandlers = map[string]IntrinsicHandler{
 	"Fn::Or":          FnOr,
 	"Fn::FindInMap":   FnFindInMap,
 	"Fn::GetAtt":      nonResolvingHandler,
-	"Fn::GetAZs":      nonResolvingHandler,
+	"Fn::GetAZs":      FnGetAZs,
 	"Fn::ImportValue": nonResolvingHandler,
 	"Fn::Join":        FnJoin,
 	"Fn::Select":      FnSelect,


### PR DESCRIPTION
This also changes the Fn::Select intrinsic to support specifying the index as a string.
Saw this form used in CloudFormation [documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html#w2ab2c21c28c33c17):
```javascript
{"Fn::Select" : [ "0", { "Fn::GetAZs" : "" } ]}
```