### PR TITLE
Generate valid CloudFormation and SAM JSON schemas

### DIFF
--- a/cloudformation/awsserverlessfunction_stringoriampolicydocumentorlistofstringorlistofiampolicydocument.go
+++ b/cloudformation/awsserverlessfunction_stringoriampolicydocumentorlistofstringorlistofiampolicydocument.go
@@ -23,16 +23,16 @@ func (r AWSServerlessFunction_StringOrIAMPolicyDocumentOrListOfStringOrListOfIAM
 		return r.String
 	}
 
-	if r.String != nil {
-		return r.String
+	if r.StringArray != nil {
+		return r.StringArray
 	}
 
 	if r.IAMPolicyDocument != nil {
 		return r.IAMPolicyDocument
 	}
 
-	if r.IAMPolicyDocument != nil {
-		return r.IAMPolicyDocument
+	if r.IAMPolicyDocumentArray != nil {
+		return r.IAMPolicyDocumentArray
 	}
 
 	return nil

--- a/cloudformation/awsserverlessfunction_stringorlistofstring.go
+++ b/cloudformation/awsserverlessfunction_stringorlistofstring.go
@@ -19,8 +19,8 @@ func (r AWSServerlessFunction_StringOrListOfString) value() interface{} {
 		return r.String
 	}
 
-	if r.String != nil {
-		return r.String
+	if r.StringArray != nil {
+		return r.StringArray
 	}
 
 	return nil

--- a/generate/main.go
+++ b/generate/main.go
@@ -9,12 +9,13 @@ func main() {
 
 	fmt.Printf("GoFormation Resource Generator\n")
 
-	specs := map[string]string{
-		"cloudformation": "https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json",
+	cloudformationSpec := "https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json"
+
+	otherSpecs := map[string]string{
 		"sam":            "file://generate/sam-2016-10-31.json",
 	}
 
-	rg, err := NewResourceGenerator(specs)
+	rg, err := NewResourceGenerator(cloudformationSpec, otherSpecs)
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err)
 		os.Exit(1)

--- a/generate/property.go
+++ b/generate/property.go
@@ -74,6 +74,7 @@ func (p Property) Schema(name, parent string) string {
 	// are required in the JSON when looping through maps
 	tmpl, err := template.New("schema-property.template").Funcs(template.FuncMap{
 		"counter": counter,
+		"convertToJSONType": convertTypeToJSON,
 	}).ParseFiles("generate/templates/schema-property.template")
 
 	var buf bytes.Buffer

--- a/generate/resource.go
+++ b/generate/resource.go
@@ -21,7 +21,7 @@ type Resource struct {
 }
 
 // Schema returns a JSON Schema for the resource (as a string)
-func (r Resource) Schema(name string) string {
+func (r Resource) Schema(name string, isCustomProperty bool) string {
 
 	// Open the schema template and setup a counter function that will
 	// available in the template to be used to detect when trailing commas
@@ -33,11 +33,13 @@ func (r Resource) Schema(name string) string {
 	var buf bytes.Buffer
 
 	templateData := struct {
-		Name     string
-		Resource Resource
+		Name             string
+		Resource         Resource
+		IsCustomProperty bool
 	}{
-		Name:     name,
-		Resource: r,
+		Name:             name,
+		Resource:         r,
+		IsCustomProperty: isCustomProperty,
 	}
 
 	// Execute the template, writing it to the buffer

--- a/generate/resource_test.go
+++ b/generate/resource_test.go
@@ -62,4 +62,49 @@ var _ = Describe("Resource", func() {
 
 	})
 
+	Context("with a custom property type resource", func() {
+
+		Context("described as Go structs", func() {
+
+			Context("with a list type", func() {
+
+				subproperty := &cloudformation.AWSServerlessFunction_S3Event{
+					Bucket: "my-bucket",
+					Events: &cloudformation.AWSServerlessFunction_StringOrListOfString{
+						StringArray: &[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:*"},
+					},
+				}
+
+				expected := []byte(`{"Bucket":"my-bucket","Events":["s3:ObjectCreated:*","s3:ObjectRemoved:*"]}`)
+
+				result, err := json.Marshal(subproperty)
+				It("should marshal to JSON successfully", func() {
+					Expect(result).To(Equal(expected))
+					Expect(err).To(BeNil())
+				})
+
+			})
+
+			Context("with a primitive type", func() {
+
+				event := "s3:ObjectCreated:*"
+				subproperty := &cloudformation.AWSServerlessFunction_S3Event{
+					Bucket: "my-bucket",
+					Events: &cloudformation.AWSServerlessFunction_StringOrListOfString{
+						String: &event,
+					},
+				}
+
+				expected := []byte(`{"Bucket":"my-bucket","Events":"s3:ObjectCreated:*"}`)
+
+				result, err := json.Marshal(subproperty)
+				It("should marshal to JSON successfully", func() {
+					Expect(result).To(Equal(expected))
+					Expect(err).To(BeNil())
+				})
+
+			})
+
+		})
+	})
 })

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -1,5 +1,6 @@
 {
     "ResourceSpecificationVersion": "2016-10-31",
+    "ResourceSpecificationTransform": "AWS::Serverless-2016-10-31",
     "ResourceTypes": {
         "AWS::Serverless::Function": {
             "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
@@ -150,7 +151,7 @@
                 },
                 "Variables" :{
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi",
-                    "Required": false,                   
+                    "Required": false,
                     "Type": "Map",
                     "PrimitiveItemType": "String",
                     "UpdateType": "Immutable"
@@ -243,7 +244,7 @@
             "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter.html",
             "Properties": {
                 "S3Key": {
-                    "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter.html",                    
+                    "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter.html",
                     "Required": true,
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"
@@ -391,7 +392,7 @@
             "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#alexaskill",
             "Properties": {
                 "Variables": {
-                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#alexaskill",                    
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#alexaskill",
                     "Required": false,
                     "Type": "Map",
                     "PrimitiveItemType": "String",

--- a/generate/spec.go
+++ b/generate/spec.go
@@ -20,6 +20,11 @@ type CloudFormationResourceSpecification struct {
 	// field, or a change to a resource, such as the making an optional resource property required.
 	ResourceSpecificationVersion string
 
+	// ResourceSpecificationTransform is not a valid key in the official AWS CloudFormation
+	// Specification.  It is used in this package to indicate the relevant Transform value to use
+	// for the resources in this spec.
+	ResourceSpecificationTransform string
+
 	// The list of resources and information about each resource's properties, such as its property names,
 	//  which properties are requires, and their update behavior. For more information, see
 	// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification-format.html#cfn-resource-specification-format-resourcetype

--- a/generate/templates/polymorphic-property.template
+++ b/generate/templates/polymorphic-property.template
@@ -7,7 +7,7 @@ import (
 	{{end}}
 )
 
-// {{.Name}} is a helper struct that can hold either a {{.TypesJoined}} value 
+// {{.Name}} is a helper struct that can hold either a {{.TypesJoined}} value
 type {{.Name}} struct {
 
 	{{range $type := $.Property.PrimitiveTypes}}
@@ -28,25 +28,25 @@ func (r {{.Name}}) value() interface{} {
 	{{range $type := $.Property.PrimitiveTypes}}
 		if r.{{$type}} != nil {
 			return r.{{$type}}
-		} 
+		}
 	{{end}}
 
 	{{range $type := $.Property.PrimitiveItemTypes}}
-		if r.{{$type}} != nil {
-			return r.{{$type}}
-		} 
+		if r.{{$type}}Array != nil {
+			return r.{{$type}}Array
+		}
 	{{end}}
 
 	{{range $type := $.Property.Types}}
 		if r.{{$type}} != nil {
 			return r.{{$type}}
-		} 
+		}
 	{{end}}
 
 	{{range $type := $.Property.ItemTypes}}
-		if r.{{$type}} != nil {
-			return r.{{$type}}
-		} 
+		if r.{{$type}}Array != nil {
+			return r.{{$type}}Array
+		}
 	{{end}}
 
 	return nil
@@ -57,9 +57,9 @@ func (r *{{.Name}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.value())
 }
 
-// Hook into the marshaller  
+// Hook into the marshaller
 func (r *{{.Name}}) UnmarshalJSON(b []byte) error {
-	
+
 	// Unmarshal into interface{} to check it's type
 	var typecheck interface{}
 	if err := json.Unmarshal(b, &typecheck); err != nil {
@@ -69,7 +69,7 @@ func (r *{{.Name}}) UnmarshalJSON(b []byte) error {
 	switch val := typecheck.(type) {
 
 		{{range $type := $.Property.PrimitiveTypes}}
-			case {{convertToGoType $type}}: 
+			case {{convertToGoType $type}}:
 			r.{{$type}} = &val
 		{{end}}
 
@@ -92,6 +92,6 @@ func (r *{{.Name}}) UnmarshalJSON(b []byte) error {
 		{{end}}
 
 	}
-		
-	return nil	
+
+	return nil
 }

--- a/generate/templates/schema-property.template
+++ b/generate/templates/schema-property.template
@@ -1,5 +1,47 @@
 "{{.Name}}": {
 
+{{if .Property.IsPolymorphic}}
+    "anyOf": [
+        {{if .Property.PrimitiveTypes}}
+            {
+                "type": [
+                    {{$length := len .Property.PrimitiveTypes}}{{$rc := counter $length}}{{range $index, $primitiveType := .Property.PrimitiveTypes}}
+                        "{{convertToJSONType $primitiveType}}"{{if call $rc}},{{end}}
+                    {{end}}
+                ]
+            }{{if (or .Property.PrimitiveItemTypes (or .Property.Types .Property.ItemTypes))}},{{end}}
+        {{end}}
+
+        {{if .Property.PrimitiveItemTypes}}
+            {{$length := len .Property.PrimitiveItemTypes}}{{$rc := counter $length}}{{range $index, $primitiveItemType := .Property.PrimitiveItemTypes}}
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "{{convertToJSONType $primitiveItemType}}"
+                    }
+                }{{if (or (call $rc) (or $.Property.Types $.Property.ItemTypes))}},{{end}}
+            {{end}}
+        {{end}}
+
+        {{if .Property.Types}}
+            {{$length := len .Property.Types}}{{$rc := counter $length}}{{range $index, $customType := .Property.Types}}
+                { "$ref": "#/definitions/{{$.Parent}}.{{$customType}}" }{{if (or (call $rc) $.Property.ItemTypes)}},{{end}}
+            {{end}}
+        {{end}}
+
+        {{if .Property.ItemTypes}}
+            {{$length := len .Property.ItemTypes}}{{$rc := counter $length}}{{range $index, $itemType := .Property.ItemTypes}}
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/{{$.Parent}}.{{$itemType}}"
+                    }
+                }{{if call $rc}},{{end}}
+            {{end}}
+        {{end}}
+    ]
+{{else}}
+
     {{if .Property.IsCustomType}}
         "$ref": "#/definitions/{{.Parent}}.{{.Property.Type}}"
     {{end}}
@@ -15,18 +57,19 @@
             "^[a-zA-Z0-9]+$": {
                 "type": "{{.Property.GetJSONPrimitiveType}}"
             }
-        }
+        },
         {{else}}
         "patternProperties": {
             "^[a-zA-Z0-9]+$": {
                 {{ if eq .Property.ItemType "Tag" }}
-                    "$ref": "#/definitions/Tag" 
+                    "$ref": "#/definitions/Tag"
                 {{else}}
-                    "$ref": "#/definitions/{{.Parent}}.{{.Property.ItemType}}" 
+                    "$ref": "#/definitions/{{.Parent}}.{{.Property.ItemType}}"
                 {{end}}
             }
-        }
+        },
         {{end}}
+        "additionalProperties": false
     {{end}}
 
     {{if .Property.IsList}}
@@ -36,14 +79,15 @@
             "type": "{{.Property.GetJSONPrimitiveType}}"
         }
         {{else}}
-        "items": { 
+        "items": {
             {{ if eq .Property.ItemType "Tag" }}
-                "$ref": "#/definitions/Tag" 
+                "$ref": "#/definitions/Tag"
              {{else}}
-                "$ref": "#/definitions/{{.Parent}}.{{.Property.ItemType}}"  
+                "$ref": "#/definitions/{{.Parent}}.{{.Property.ItemType}}"
             {{end}}
         }
         {{end}}
     {{end}}
 
+{{end}}
 }

--- a/generate/templates/schema-resource.template
+++ b/generate/templates/schema-resource.template
@@ -1,9 +1,32 @@
 "{{.Name}}": {
     "type": "object",
+    {{if .IsCustomProperty}}
     {{if .Resource.Required}}"required": [{{.Resource.Required}}],{{end}}
     "properties": {
         {{$length := len .Resource.Properties}}{{$pc := counter $length}}{{range $name, $property := .Resource.Properties}}
         {{$property.Schema $name $.Name}}{{if call $pc}},{{end}}
         {{end}}
-    }
+    },
+    {{else}}
+    "required": {{if .Resource.Required}}["Type", "Properties"]{{else}}["Type"]{{end}},
+    "properties": {
+        "Properties": {
+            "type": "object",
+            "properties": {
+                {{$length := len .Resource.Properties}}{{$pc := counter $length}}{{range $name, $property := .Resource.Properties}}
+                {{$property.Schema $name $.Name}}{{if call $pc}},{{end}}
+                {{end}}
+             },
+             {{if .Resource.Required}}"required": [{{.Resource.Required}}],{{end}}
+            "additionalProperties": false
+        },
+        "Type": {
+            "type": "string",
+            "enum": [
+                "{{.Name}}"
+            ]
+        }
+    },
+    {{end}}
+    "additionalProperties": false
 }

--- a/generate/templates/schema.template
+++ b/generate/templates/schema.template
@@ -16,6 +16,21 @@
             "maxLength": 1024
         },
 
+        "Metadata": {
+            "type": "object"
+        },
+
+        "Transform": {
+        {{if .ResourceSpecificationTransform}}
+            "type": "string",
+            "enum": [
+                "{{.ResourceSpecificationTransform}}"
+            ]
+        {{else}}
+            "type": ["object","string"]
+        {{end}}
+        },
+
         "Parameters": {
             "type": "object",
             "patternProperties": {
@@ -26,11 +41,11 @@
             "maxProperties": 50,
             "additionalProperties": false
         },
-        
+
         "Mappings": {
             "type": "object",
             "patternProperties": {
-                ".*": {
+                "^[a-zA-Z0-9]+$": {
                     "type": "object"
                 }
             },
@@ -40,12 +55,25 @@
         "Conditions": {
             "type": "object",
             "patternProperties": {
-                ".*": {
+                "^[a-zA-Z0-9]+$": {
                     "type": "object"
                 }
             },
             "additionalProperties": false
         },
+
+        "Outputs": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
+                    "type": "object"
+                }
+            },
+            "minProperties": 1,
+            "maxProperties": 60,
+            "additionalProperties": false
+        },
+
         "Resources": {
             "type": "object",
             "patternProperties": {
@@ -55,10 +83,18 @@
                         {{end}}
                     ]
                 }
-            }
+            },
+            "additionalProperties": false
         }
     },
+    "required": [
+        {{if .ResourceSpecificationTransform}}
+            "Transform",
+        {{end}}
 
+        "Resources"
+    ],
+    "additionalProperties": false,
     "definitions": {
         "Parameter": {
             "type": "object",
@@ -131,14 +167,14 @@
                 "Type"
             ]
         },
-    
+
         {{range $name, $resource := .Resources}}
-            {{$resource.Schema $name}},
+            {{$resource.Schema $name false}},
         {{end}}
 
         {{$length := len .Properties}}{{$rc := counter $length}}{{range $name, $resource := .Properties}}
-            {{$resource.Schema $name}}{{if call $rc}},{{end}}
+            {{$resource.Schema $name true}}{{if call $rc}},{{end}}
         {{end}}
-        
+
     }
 }

--- a/goformation_schema_test.go
+++ b/goformation_schema_test.go
@@ -1,0 +1,175 @@
+package goformation_test
+
+import (
+	// Note that this is a fork of the main repo: github.com/xeipuuv/gojsonschema
+	// CloudFormation uses nested schema def references, which is currently broken
+	// in the main repo: https://github.com/xeipuuv/gojsonschema/pull/146
+	. "github.com/johandorland/gojsonschema"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"os"
+)
+
+var _ = Describe("Goformation-generated JSON schemas", func() {
+
+	Context("with a valid CloudFormation template", func() {
+
+		pwd, _ := os.Getwd()
+		schemaLoader := NewReferenceLoader("file://" + pwd + "/schema/cloudformation.schema.json")
+		documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/valid-template.json")
+
+		result, err := Validate(schemaLoader, documentLoader)
+		It("should successfully validate the CloudFormation template", func() {
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Errors()).Should(BeEmpty())
+			Expect(result.Valid()).Should(BeTrue())
+		})
+	})
+
+	Context("with a valid SAM template", func() {
+
+		pwd, _ := os.Getwd()
+		schemaLoader := NewReferenceLoader("file://" + pwd + "/schema/sam.schema.json")
+		documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/valid-sam-template.json")
+
+		result, err := Validate(schemaLoader, documentLoader)
+		It("should successfully validate the SAM template", func() {
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Errors()).Should(BeEmpty())
+			Expect(result.Valid()).Should(BeTrue())
+		})
+	})
+
+	Context("with a valid template, but which contains attributes not yet supported by the generated schema", func() {
+
+		pwd, _ := os.Getwd()
+		schemaLoader := NewReferenceLoader("file://" + pwd + "/schema/cloudformation.schema.json")
+
+		It("should report that a template with intrinsic functions is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/valid-template-with-fns.json")
+			result, err := Validate(schemaLoader, documentLoader)
+
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+	})
+
+	Context("with an invalid CloudFormation template", func() {
+
+		pwd, _ := os.Getwd()
+		schemaLoader := NewReferenceLoader("file://" + pwd + "/schema/cloudformation.schema.json")
+
+		It("should report that a template missing required root properties is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-missing-resources.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template missing required resource properties is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-missing-resource-properties.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with missing single required resource property is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-empty-resource-properties.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with a non-alphanumeric resource key is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-invalid-resource-name.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with unknown root properties is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-additional-property.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with unknown resource type is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-unknown-resource-type.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with unknown resource type is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-missing-resource-type.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with unknown resource properties is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-additional-resource-property.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with an unknown subproperty property is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-unknown-subproperty-property.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with a wrong subproperty type is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-invalid-resource-subproperty.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with a subproperty that is missing a required property is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-template-subproperty-missing-property.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+	})
+
+	Context("with an invalid SAM template", func() {
+
+		pwd, _ := os.Getwd()
+		schemaLoader := NewReferenceLoader("file://" + pwd + "/schema/sam.schema.json")
+
+		It("should report that a template missing the Transform property is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-sam-template-no-transform.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+
+		It("should report that a template with a non-SAM Transform value is invalid", func() {
+			documentLoader := NewReferenceLoader("file://" + pwd + "/test/json/invalid-sam-template-wrong-transform.json")
+			result, err := Validate(schemaLoader, documentLoader)
+			Expect(err).To(BeNil())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.Valid()).Should(BeFalse())
+		})
+	})
+})

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -2470,6 +2470,9 @@
                 "Name": {
                     "type": "string"
                 },
+                "Type": {
+                    "type": "string"
+                },
                 "Value": {
                     "type": "string"
                 }
@@ -3283,7 +3286,17 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPoolRoleAttachment.RulesConfigurationType": {
-            "properties": {},
+            "properties": {
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Cognito::IdentityPoolRoleAttachment.MappingRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Rules"
+            ],
             "type": "object"
         },
         "AWS::Cognito::UserPool": {
@@ -5075,6 +5088,12 @@
                 },
                 "SubnetId": {
                     "type": "string"
+                },
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -5908,6 +5927,9 @@
             "properties": {
                 "AmazonProvidedIpv6CidrBlock": {
                     "type": "boolean"
+                },
+                "CidrBlock": {
+                    "type": "string"
                 },
                 "VpcId": {
                     "type": "string"
@@ -7927,6 +7949,59 @@
                 },
                 "Description": {
                     "type": "string"
+                },
+                "ResourceLifecycleConfig": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig": {
+            "properties": {
+                "ServiceRole": {
+                    "type": "string"
+                },
+                "VersionLifecycleConfig": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.ApplicationVersionLifecycleConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.ApplicationVersionLifecycleConfig": {
+            "properties": {
+                "MaxAgeRule": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.MaxAgeRule"
+                },
+                "MaxCountRule": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.MaxCountRule"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.MaxAgeRule": {
+            "properties": {
+                "DeleteSourceFromS3": {
+                    "type": "boolean"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "MaxAgeInDays": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.MaxCountRule": {
+            "properties": {
+                "DeleteSourceFromS3": {
+                    "type": "boolean"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "MaxCount": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -7981,6 +8056,9 @@
                     },
                     "type": "array"
                 },
+                "PlatformArn": {
+                    "type": "string"
+                },
                 "SolutionStackName": {
                     "type": "string"
                 },
@@ -8007,8 +8085,7 @@
             },
             "required": [
                 "Namespace",
-                "OptionName",
-                "Value"
+                "OptionName"
             ],
             "type": "object"
         },
@@ -8043,9 +8120,12 @@
                 },
                 "OptionSettings": {
                     "items": {
-                        "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.OptionSettings"
+                        "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.OptionSetting"
                     },
                     "type": "array"
+                },
+                "PlatformArn": {
+                    "type": "string"
                 },
                 "SolutionStackName": {
                     "type": "string"
@@ -8071,7 +8151,7 @@
             ],
             "type": "object"
         },
-        "AWS::ElasticBeanstalk::Environment.OptionSettings": {
+        "AWS::ElasticBeanstalk::Environment.OptionSetting": {
             "properties": {
                 "Namespace": {
                     "type": "string"
@@ -8085,8 +8165,7 @@
             },
             "required": [
                 "Namespace",
-                "OptionName",
-                "Value"
+                "OptionName"
             ],
             "type": "object"
         },
@@ -8409,6 +8488,32 @@
             },
             "type": "object"
         },
+        "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
+            "properties": {
+                "Certificates": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate"
+                    },
+                    "type": "array"
+                },
+                "ListenerArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Certificates",
+                "ListenerArn"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate": {
+            "properties": {
+                "CertificateArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::ElasticLoadBalancingV2::ListenerRule": {
             "properties": {
                 "Actions": {
@@ -8490,6 +8595,12 @@
                     },
                     "type": "array"
                 },
+                "SubnetMappings": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping"
+                    },
+                    "type": "array"
+                },
                 "Subnets": {
                     "items": {
                         "type": "string"
@@ -8501,6 +8612,9 @@
                         "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
+                },
+                "Type": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -8514,6 +8628,21 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping": {
+            "properties": {
+                "AllocationId": {
+                    "type": "string"
+                },
+                "SubnetId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AllocationId",
+                "SubnetId"
+            ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::TargetGroup": {
@@ -8560,6 +8689,9 @@
                     },
                     "type": "array"
                 },
+                "TargetType": {
+                    "type": "string"
+                },
                 "Targets": {
                     "items": {
                         "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription"
@@ -8593,6 +8725,9 @@
         },
         "AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription": {
             "properties": {
+                "AvailabilityZone": {
+                    "type": "string"
+                },
                 "Id": {
                     "type": "string"
                 },
@@ -8730,10 +8865,89 @@
             },
             "type": "object"
         },
+        "AWS::Events::Rule.EcsParameters": {
+            "properties": {
+                "TaskCount": {
+                    "type": "number"
+                },
+                "TaskDefinitionArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TaskDefinitionArn"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.InputTransformer": {
+            "properties": {
+                "InputPathsMap": {
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "InputTemplate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InputTemplate"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.KinesisParameters": {
+            "properties": {
+                "PartitionKeyPath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PartitionKeyPath"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.RunCommandParameters": {
+            "properties": {
+                "RunCommandTargets": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Events::Rule.RunCommandTarget"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "RunCommandTargets"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.RunCommandTarget": {
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key",
+                "Values"
+            ],
+            "type": "object"
+        },
         "AWS::Events::Rule.Target": {
             "properties": {
                 "Arn": {
                     "type": "string"
+                },
+                "EcsParameters": {
+                    "$ref": "#/definitions/AWS::Events::Rule.EcsParameters"
                 },
                 "Id": {
                     "type": "string"
@@ -8744,8 +8958,17 @@
                 "InputPath": {
                     "type": "string"
                 },
+                "InputTransformer": {
+                    "$ref": "#/definitions/AWS::Events::Rule.InputTransformer"
+                },
+                "KinesisParameters": {
+                    "$ref": "#/definitions/AWS::Events::Rule.KinesisParameters"
+                },
                 "RoleArn": {
                     "type": "string"
+                },
+                "RunCommandParameters": {
+                    "$ref": "#/definitions/AWS::Events::Rule.RunCommandParameters"
                 }
             },
             "required": [
@@ -9476,9 +9699,6 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "FunctionArn"
-            ],
             "type": "object"
         },
         "AWS::IoT::TopicRule.PutItemInput": {
@@ -9621,6 +9841,12 @@
                 },
                 "KeyUsage": {
                     "type": "string"
+                },
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -10045,11 +10271,17 @@
                 "DeliveryStreamName": {
                     "type": "string"
                 },
+                "DeliveryStreamType": {
+                    "type": "string"
+                },
                 "ElasticsearchDestinationConfiguration": {
                     "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration"
                 },
                 "ExtendedS3DestinationConfiguration": {
                     "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration"
+                },
+                "KinesisStreamSourceConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration"
                 },
                 "RedshiftDestinationConfiguration": {
                     "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.RedshiftDestinationConfiguration"
@@ -10242,6 +10474,21 @@
             },
             "required": [
                 "AWSKMSKeyARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration": {
+            "properties": {
+                "KinesisStreamARN": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KinesisStreamARN",
+                "RoleARN"
             ],
             "type": "object"
         },
@@ -12467,11 +12714,23 @@
                 "AccessControl": {
                     "type": "string"
                 },
+                "AnalyticsConfigurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.AnalyticsConfiguration"
+                    },
+                    "type": "array"
+                },
                 "BucketName": {
                     "type": "string"
                 },
                 "CorsConfiguration": {
                     "$ref": "#/definitions/AWS::S3::Bucket.CorsConfiguration"
+                },
+                "InventoryConfigurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.InventoryConfiguration"
+                    },
+                    "type": "array"
                 },
                 "LifecycleConfiguration": {
                     "$ref": "#/definitions/AWS::S3::Bucket.LifecycleConfiguration"
@@ -12528,6 +12787,30 @@
             ],
             "type": "object"
         },
+        "AWS::S3::Bucket.AnalyticsConfiguration": {
+            "properties": {
+                "Id": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "StorageClassAnalysis": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.StorageClassAnalysis"
+                },
+                "TagFilters": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.TagFilter"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Id",
+                "StorageClassAnalysis"
+            ],
+            "type": "object"
+        },
         "AWS::S3::Bucket.CorsConfiguration": {
             "properties": {
                 "CorsRules": {
@@ -12581,6 +12864,42 @@
             ],
             "type": "object"
         },
+        "AWS::S3::Bucket.DataExport": {
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.Destination"
+                },
+                "OutputSchemaVersion": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destination",
+                "OutputSchemaVersion"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.Destination": {
+            "properties": {
+                "BucketAccountId": {
+                    "type": "string"
+                },
+                "BucketArn": {
+                    "type": "string"
+                },
+                "Format": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketArn",
+                "Format"
+            ],
+            "type": "object"
+        },
         "AWS::S3::Bucket.FilterRule": {
             "properties": {
                 "Name": {
@@ -12593,6 +12912,42 @@
             "required": [
                 "Name",
                 "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.InventoryConfiguration": {
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.Destination"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "IncludedObjectVersions": {
+                    "type": "string"
+                },
+                "OptionalFields": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "ScheduleFrequency": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destination",
+                "Enabled",
+                "Id",
+                "IncludedObjectVersions",
+                "ScheduleFrequency"
             ],
             "type": "object"
         },
@@ -12904,6 +13259,14 @@
             "required": [
                 "Rules"
             ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.StorageClassAnalysis": {
+            "properties": {
+                "DataExport": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.DataExport"
+                }
+            },
             "type": "object"
         },
         "AWS::S3::Bucket.TagFilter": {
@@ -14480,6 +14843,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerCertificate"
                         },
                         {
                             "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule"

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -1,35 +1,69 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
     "definitions": {
         "AWS::ApiGateway::Account": {
+            "additionalProperties": false,
             "properties": {
-                "CloudWatchRoleArn": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CloudWatchRoleArn": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Account"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ApiGateway::ApiKey": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "Enabled": {
-                    "type": "boolean"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "StageKeys": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ApiGateway::ApiKey.StageKey"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StageKeys": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::ApiKey.StageKey"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::ApiKey"
+                    ],
+                    "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ApiGateway::ApiKey.StageKey": {
+            "additionalProperties": false,
             "properties": {
                 "RestApiId": {
                     "type": "string"
@@ -41,92 +75,160 @@
             "type": "object"
         },
         "AWS::ApiGateway::Authorizer": {
+            "additionalProperties": false,
             "properties": {
-                "AuthorizerCredentials": {
-                    "type": "string"
-                },
-                "AuthorizerResultTtlInSeconds": {
-                    "type": "number"
-                },
-                "AuthorizerUri": {
-                    "type": "string"
-                },
-                "IdentitySource": {
-                    "type": "string"
-                },
-                "IdentityValidationExpression": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "ProviderARNs": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AuthorizerCredentials": {
+                            "type": "string"
+                        },
+                        "AuthorizerResultTtlInSeconds": {
+                            "type": "number"
+                        },
+                        "AuthorizerUri": {
+                            "type": "string"
+                        },
+                        "IdentitySource": {
+                            "type": "string"
+                        },
+                        "IdentityValidationExpression": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ProviderARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
-                },
-                "RestApiId": {
-                    "type": "string"
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Authorizer"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::BasePathMapping": {
+            "additionalProperties": false,
             "properties": {
-                "BasePath": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BasePath": {
+                            "type": "string"
+                        },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "Stage": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DomainName"
+                    ],
+                    "type": "object"
                 },
-                "DomainName": {
-                    "type": "string"
-                },
-                "RestApiId": {
-                    "type": "string"
-                },
-                "Stage": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::BasePathMapping"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DomainName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::ClientCertificate": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::ApiGateway::Deployment": {
-            "properties": {
-                "Description": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
-                "RestApiId": {
-                    "type": "string"
-                },
-                "StageDescription": {
-                    "$ref": "#/definitions/AWS::ApiGateway::Deployment.StageDescription"
-                },
-                "StageName": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::ClientCertificate"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "RestApiId"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Deployment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "StageDescription": {
+                            "$ref": "#/definitions/AWS::ApiGateway::Deployment.StageDescription"
+                        },
+                        "StageName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Deployment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::Deployment.MethodSetting": {
+            "additionalProperties": false,
             "properties": {
                 "CacheDataEncrypted": {
                     "type": "boolean"
@@ -162,6 +264,7 @@
             "type": "object"
         },
         "AWS::ApiGateway::Deployment.StageDescription": {
+            "additionalProperties": false,
             "properties": {
                 "CacheClusterEnabled": {
                     "type": "boolean"
@@ -212,6 +315,7 @@
                     "type": "number"
                 },
                 "Variables": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -223,25 +327,43 @@
             "type": "object"
         },
         "AWS::ApiGateway::DocumentationPart": {
+            "additionalProperties": false,
             "properties": {
-                "Location": {
-                    "$ref": "#/definitions/AWS::ApiGateway::DocumentationPart.Location"
-                },
                 "Properties": {
-                    "type": "string"
+                    "additionalProperties": false,
+                    "properties": {
+                        "Location": {
+                            "$ref": "#/definitions/AWS::ApiGateway::DocumentationPart.Location"
+                        },
+                        "Properties": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Location",
+                        "Properties",
+                        "RestApiId"
+                    ],
+                    "type": "object"
                 },
-                "RestApiId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::DocumentationPart"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Location",
-                "Properties",
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::DocumentationPart.Location": {
+            "additionalProperties": false,
             "properties": {
                 "Method": {
                     "type": "string"
@@ -262,126 +384,199 @@
             "type": "object"
         },
         "AWS::ApiGateway::DocumentationVersion": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DocumentationVersion": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DocumentationVersion",
+                        "RestApiId"
+                    ],
+                    "type": "object"
                 },
-                "DocumentationVersion": {
-                    "type": "string"
-                },
-                "RestApiId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::DocumentationVersion"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DocumentationVersion",
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::DomainName": {
+            "additionalProperties": false,
             "properties": {
-                "CertificateArn": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateArn": {
+                            "type": "string"
+                        },
+                        "DomainName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CertificateArn",
+                        "DomainName"
+                    ],
+                    "type": "object"
                 },
-                "DomainName": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::DomainName"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "CertificateArn",
-                "DomainName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::GatewayResponse": {
+            "additionalProperties": false,
             "properties": {
-                "ResponseParameters": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResponseParameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ResponseTemplates": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ResponseType": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "StatusCode": {
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "ResponseType",
+                        "RestApiId"
+                    ],
                     "type": "object"
                 },
-                "ResponseTemplates": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "ResponseType": {
-                    "type": "string"
-                },
-                "RestApiId": {
-                    "type": "string"
-                },
-                "StatusCode": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::GatewayResponse"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ResponseType",
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::Method": {
+            "additionalProperties": false,
             "properties": {
-                "ApiKeyRequired": {
-                    "type": "boolean"
-                },
-                "AuthorizationType": {
-                    "type": "string"
-                },
-                "AuthorizerId": {
-                    "type": "string"
-                },
-                "HttpMethod": {
-                    "type": "string"
-                },
-                "Integration": {
-                    "$ref": "#/definitions/AWS::ApiGateway::Method.Integration"
-                },
-                "MethodResponses": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ApiGateway::Method.MethodResponse"
-                    },
-                    "type": "array"
-                },
-                "RequestModels": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApiKeyRequired": {
+                            "type": "boolean"
+                        },
+                        "AuthorizationType": {
+                            "type": "string"
+                        },
+                        "AuthorizerId": {
+                            "type": "string"
+                        },
+                        "HttpMethod": {
+                            "type": "string"
+                        },
+                        "Integration": {
+                            "$ref": "#/definitions/AWS::ApiGateway::Method.Integration"
+                        },
+                        "MethodResponses": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::Method.MethodResponse"
+                            },
+                            "type": "array"
+                        },
+                        "RequestModels": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "RequestParameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "HttpMethod",
+                        "ResourceId",
+                        "RestApiId"
+                    ],
                     "type": "object"
                 },
-                "RequestParameters": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "ResourceId": {
-                    "type": "string"
-                },
-                "RestApiId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Method"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "HttpMethod",
-                "ResourceId",
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::Method.Integration": {
+            "additionalProperties": false,
             "properties": {
                 "CacheKeyParameters": {
                     "items": {
@@ -408,6 +603,7 @@
                     "type": "string"
                 },
                 "RequestParameters": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -416,6 +612,7 @@
                     "type": "object"
                 },
                 "RequestTemplates": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -433,8 +630,10 @@
             "type": "object"
         },
         "AWS::ApiGateway::Method.IntegrationResponse": {
+            "additionalProperties": false,
             "properties": {
                 "ResponseParameters": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -443,6 +642,7 @@
                     "type": "object"
                 },
                 "ResponseTemplates": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -463,8 +663,10 @@
             "type": "object"
         },
         "AWS::ApiGateway::Method.MethodResponse": {
+            "additionalProperties": false,
             "properties": {
                 "ResponseModels": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -473,6 +675,7 @@
                     "type": "object"
                 },
                 "ResponseParameters": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "boolean"
@@ -490,108 +693,177 @@
             "type": "object"
         },
         "AWS::ApiGateway::Model": {
+            "additionalProperties": false,
             "properties": {
-                "ContentType": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "RestApiId": {
-                    "type": "string"
-                },
-                "Schema": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContentType": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "Schema": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Model"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::RequestValidator": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "ValidateRequestBody": {
+                            "type": "boolean"
+                        },
+                        "ValidateRequestParameters": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::RequestValidator"
+                    ],
                     "type": "string"
-                },
-                "RestApiId": {
-                    "type": "string"
-                },
-                "ValidateRequestBody": {
-                    "type": "boolean"
-                },
-                "ValidateRequestParameters": {
-                    "type": "boolean"
                 }
             },
             "required": [
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::Resource": {
+            "additionalProperties": false,
             "properties": {
-                "ParentId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ParentId": {
+                            "type": "string"
+                        },
+                        "PathPart": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ParentId",
+                        "PathPart",
+                        "RestApiId"
+                    ],
+                    "type": "object"
                 },
-                "PathPart": {
-                    "type": "string"
-                },
-                "RestApiId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Resource"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ParentId",
-                "PathPart",
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::RestApi": {
+            "additionalProperties": false,
             "properties": {
-                "BinaryMediaTypes": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Body": {
-                    "type": "object"
-                },
-                "BodyS3Location": {
-                    "$ref": "#/definitions/AWS::ApiGateway::RestApi.S3Location"
-                },
-                "CloneFrom": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "FailOnWarnings": {
-                    "type": "boolean"
-                },
-                "Mode": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Parameters": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BinaryMediaTypes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Body": {
+                            "type": "object"
+                        },
+                        "BodyS3Location": {
+                            "$ref": "#/definitions/AWS::ApiGateway::RestApi.S3Location"
+                        },
+                        "CloneFrom": {
                             "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "FailOnWarnings": {
+                            "type": "boolean"
+                        },
+                        "Mode": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
                         }
                     },
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::RestApi"
+                    ],
+                    "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ApiGateway::RestApi.S3Location": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -609,52 +881,71 @@
             "type": "object"
         },
         "AWS::ApiGateway::Stage": {
+            "additionalProperties": false,
             "properties": {
-                "CacheClusterEnabled": {
-                    "type": "boolean"
-                },
-                "CacheClusterSize": {
-                    "type": "string"
-                },
-                "ClientCertificateId": {
-                    "type": "string"
-                },
-                "DeploymentId": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "DocumentationVersion": {
-                    "type": "string"
-                },
-                "MethodSettings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ApiGateway::Stage.MethodSetting"
-                    },
-                    "type": "array"
-                },
-                "RestApiId": {
-                    "type": "string"
-                },
-                "StageName": {
-                    "type": "string"
-                },
-                "Variables": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheClusterEnabled": {
+                            "type": "boolean"
+                        },
+                        "CacheClusterSize": {
                             "type": "string"
+                        },
+                        "ClientCertificateId": {
+                            "type": "string"
+                        },
+                        "DeploymentId": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DocumentationVersion": {
+                            "type": "string"
+                        },
+                        "MethodSettings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::Stage.MethodSetting"
+                            },
+                            "type": "array"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "StageName": {
+                            "type": "string"
+                        },
+                        "Variables": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
                         }
                     },
+                    "required": [
+                        "RestApiId"
+                    ],
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Stage"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "RestApiId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApiGateway::Stage.MethodSetting": {
+            "additionalProperties": false,
             "properties": {
                 "CacheDataEncrypted": {
                     "type": "boolean"
@@ -690,29 +981,46 @@
             "type": "object"
         },
         "AWS::ApiGateway::UsagePlan": {
+            "additionalProperties": false,
             "properties": {
-                "ApiStages": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.ApiStage"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApiStages": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.ApiStage"
+                            },
+                            "type": "array"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Quota": {
+                            "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.QuotaSettings"
+                        },
+                        "Throttle": {
+                            "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.ThrottleSettings"
+                        },
+                        "UsagePlanName": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "Description": {
-                    "type": "string"
-                },
-                "Quota": {
-                    "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.QuotaSettings"
-                },
-                "Throttle": {
-                    "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.ThrottleSettings"
-                },
-                "UsagePlanName": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::UsagePlan"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ApiGateway::UsagePlan.ApiStage": {
+            "additionalProperties": false,
             "properties": {
                 "ApiId": {
                     "type": "string"
@@ -724,6 +1032,7 @@
             "type": "object"
         },
         "AWS::ApiGateway::UsagePlan.QuotaSettings": {
+            "additionalProperties": false,
             "properties": {
                 "Limit": {
                     "type": "number"
@@ -738,6 +1047,7 @@
             "type": "object"
         },
         "AWS::ApiGateway::UsagePlan.ThrottleSettings": {
+            "additionalProperties": false,
             "properties": {
                 "BurstLimit": {
                     "type": "number"
@@ -749,89 +1059,141 @@
             "type": "object"
         },
         "AWS::ApiGateway::UsagePlanKey": {
+            "additionalProperties": false,
             "properties": {
-                "KeyId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "KeyId": {
+                            "type": "string"
+                        },
+                        "KeyType": {
+                            "type": "string"
+                        },
+                        "UsagePlanId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "KeyId",
+                        "KeyType",
+                        "UsagePlanId"
+                    ],
+                    "type": "object"
                 },
-                "KeyType": {
-                    "type": "string"
-                },
-                "UsagePlanId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::UsagePlanKey"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "KeyId",
-                "KeyType",
-                "UsagePlanId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalableTarget": {
+            "additionalProperties": false,
             "properties": {
-                "MaxCapacity": {
-                    "type": "number"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "MaxCapacity": {
+                            "type": "number"
+                        },
+                        "MinCapacity": {
+                            "type": "number"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "RoleARN": {
+                            "type": "string"
+                        },
+                        "ScalableDimension": {
+                            "type": "string"
+                        },
+                        "ServiceNamespace": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "MaxCapacity",
+                        "MinCapacity",
+                        "ResourceId",
+                        "RoleARN",
+                        "ScalableDimension",
+                        "ServiceNamespace"
+                    ],
+                    "type": "object"
                 },
-                "MinCapacity": {
-                    "type": "number"
-                },
-                "ResourceId": {
-                    "type": "string"
-                },
-                "RoleARN": {
-                    "type": "string"
-                },
-                "ScalableDimension": {
-                    "type": "string"
-                },
-                "ServiceNamespace": {
+                "Type": {
+                    "enum": [
+                        "AWS::ApplicationAutoScaling::ScalableTarget"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "MaxCapacity",
-                "MinCapacity",
-                "ResourceId",
-                "RoleARN",
-                "ScalableDimension",
-                "ServiceNamespace"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy": {
+            "additionalProperties": false,
             "properties": {
-                "PolicyName": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "PolicyType": {
+                            "type": "string"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "ScalableDimension": {
+                            "type": "string"
+                        },
+                        "ScalingTargetId": {
+                            "type": "string"
+                        },
+                        "ServiceNamespace": {
+                            "type": "string"
+                        },
+                        "StepScalingPolicyConfiguration": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.StepScalingPolicyConfiguration"
+                        },
+                        "TargetTrackingScalingPolicyConfiguration": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.TargetTrackingScalingPolicyConfiguration"
+                        }
+                    },
+                    "required": [
+                        "PolicyName",
+                        "PolicyType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApplicationAutoScaling::ScalingPolicy"
+                    ],
                     "type": "string"
-                },
-                "PolicyType": {
-                    "type": "string"
-                },
-                "ResourceId": {
-                    "type": "string"
-                },
-                "ScalableDimension": {
-                    "type": "string"
-                },
-                "ScalingTargetId": {
-                    "type": "string"
-                },
-                "ServiceNamespace": {
-                    "type": "string"
-                },
-                "StepScalingPolicyConfiguration": {
-                    "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.StepScalingPolicyConfiguration"
-                },
-                "TargetTrackingScalingPolicyConfiguration": {
-                    "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.TargetTrackingScalingPolicyConfiguration"
                 }
             },
             "required": [
-                "PolicyName",
-                "PolicyType"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy.CustomizedMetricSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Dimensions": {
                     "items": {
@@ -860,6 +1222,7 @@
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy.MetricDimension": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -875,6 +1238,7 @@
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "PredefinedMetricType": {
                     "type": "string"
@@ -889,6 +1253,7 @@
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy.StepAdjustment": {
+            "additionalProperties": false,
             "properties": {
                 "MetricIntervalLowerBound": {
                     "type": "number"
@@ -906,6 +1271,7 @@
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy.StepScalingPolicyConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "AdjustmentType": {
                     "type": "string"
@@ -929,6 +1295,7 @@
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy.TargetTrackingScalingPolicyConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "CustomizedMetricSpecification": {
                     "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.CustomizedMetricSpecification"
@@ -952,90 +1319,108 @@
             "type": "object"
         },
         "AWS::AutoScaling::AutoScalingGroup": {
+            "additionalProperties": false,
             "properties": {
-                "AvailabilityZones": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Cooldown": {
+                            "type": "string"
+                        },
+                        "DesiredCapacity": {
+                            "type": "string"
+                        },
+                        "HealthCheckGracePeriod": {
+                            "type": "number"
+                        },
+                        "HealthCheckType": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "LaunchConfigurationName": {
+                            "type": "string"
+                        },
+                        "LoadBalancerNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "MaxSize": {
+                            "type": "string"
+                        },
+                        "MetricsCollection": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.MetricsCollection"
+                            },
+                            "type": "array"
+                        },
+                        "MinSize": {
+                            "type": "string"
+                        },
+                        "NotificationConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.NotificationConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementGroup": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.TagProperty"
+                            },
+                            "type": "array"
+                        },
+                        "TargetGroupARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "TerminationPolicies": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "VPCZoneIdentifier": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "MaxSize",
+                        "MinSize"
+                    ],
+                    "type": "object"
                 },
-                "Cooldown": {
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::AutoScalingGroup"
+                    ],
                     "type": "string"
-                },
-                "DesiredCapacity": {
-                    "type": "string"
-                },
-                "HealthCheckGracePeriod": {
-                    "type": "number"
-                },
-                "HealthCheckType": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "LaunchConfigurationName": {
-                    "type": "string"
-                },
-                "LoadBalancerNames": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "MaxSize": {
-                    "type": "string"
-                },
-                "MetricsCollection": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.MetricsCollection"
-                    },
-                    "type": "array"
-                },
-                "MinSize": {
-                    "type": "string"
-                },
-                "NotificationConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.NotificationConfiguration"
-                    },
-                    "type": "array"
-                },
-                "PlacementGroup": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.TagProperty"
-                    },
-                    "type": "array"
-                },
-                "TargetGroupARNs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "TerminationPolicies": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "VPCZoneIdentifier": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "MaxSize",
-                "MinSize"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::AutoScaling::AutoScalingGroup.MetricsCollection": {
+            "additionalProperties": false,
             "properties": {
                 "Granularity": {
                     "type": "string"
@@ -1053,6 +1438,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::AutoScalingGroup.NotificationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "NotificationTypes": {
                     "items": {
@@ -1070,6 +1456,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::AutoScalingGroup.TagProperty": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -1089,75 +1476,93 @@
             "type": "object"
         },
         "AWS::AutoScaling::LaunchConfiguration": {
+            "additionalProperties": false,
             "properties": {
-                "AssociatePublicIpAddress": {
-                    "type": "boolean"
-                },
-                "BlockDeviceMappings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.BlockDeviceMapping"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AssociatePublicIpAddress": {
+                            "type": "boolean"
+                        },
+                        "BlockDeviceMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.BlockDeviceMapping"
+                            },
+                            "type": "array"
+                        },
+                        "ClassicLinkVPCId": {
+                            "type": "string"
+                        },
+                        "ClassicLinkVPCSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "EbsOptimized": {
+                            "type": "boolean"
+                        },
+                        "IamInstanceProfile": {
+                            "type": "string"
+                        },
+                        "ImageId": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "InstanceMonitoring": {
+                            "type": "boolean"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "KernelId": {
+                            "type": "string"
+                        },
+                        "KeyName": {
+                            "type": "string"
+                        },
+                        "PlacementTenancy": {
+                            "type": "string"
+                        },
+                        "RamDiskId": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SpotPrice": {
+                            "type": "string"
+                        },
+                        "UserData": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ImageId",
+                        "InstanceType"
+                    ],
+                    "type": "object"
                 },
-                "ClassicLinkVPCId": {
-                    "type": "string"
-                },
-                "ClassicLinkVPCSecurityGroups": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "EbsOptimized": {
-                    "type": "boolean"
-                },
-                "IamInstanceProfile": {
-                    "type": "string"
-                },
-                "ImageId": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "InstanceMonitoring": {
-                    "type": "boolean"
-                },
-                "InstanceType": {
-                    "type": "string"
-                },
-                "KernelId": {
-                    "type": "string"
-                },
-                "KeyName": {
-                    "type": "string"
-                },
-                "PlacementTenancy": {
-                    "type": "string"
-                },
-                "RamDiskId": {
-                    "type": "string"
-                },
-                "SecurityGroups": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SpotPrice": {
-                    "type": "string"
-                },
-                "UserData": {
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::LaunchConfiguration"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ImageId",
-                "InstanceType"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::AutoScaling::LaunchConfiguration.BlockDevice": {
+            "additionalProperties": false,
             "properties": {
                 "DeleteOnTermination": {
                     "type": "boolean"
@@ -1181,6 +1586,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::LaunchConfiguration.BlockDeviceMapping": {
+            "additionalProperties": false,
             "properties": {
                 "DeviceName": {
                     "type": "string"
@@ -1201,77 +1607,112 @@
             "type": "object"
         },
         "AWS::AutoScaling::LifecycleHook": {
+            "additionalProperties": false,
             "properties": {
-                "AutoScalingGroupName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoScalingGroupName": {
+                            "type": "string"
+                        },
+                        "DefaultResult": {
+                            "type": "string"
+                        },
+                        "HeartbeatTimeout": {
+                            "type": "number"
+                        },
+                        "LifecycleTransition": {
+                            "type": "string"
+                        },
+                        "NotificationMetadata": {
+                            "type": "string"
+                        },
+                        "NotificationTargetARN": {
+                            "type": "string"
+                        },
+                        "RoleARN": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AutoScalingGroupName",
+                        "LifecycleTransition"
+                    ],
+                    "type": "object"
                 },
-                "DefaultResult": {
-                    "type": "string"
-                },
-                "HeartbeatTimeout": {
-                    "type": "number"
-                },
-                "LifecycleTransition": {
-                    "type": "string"
-                },
-                "NotificationMetadata": {
-                    "type": "string"
-                },
-                "NotificationTargetARN": {
-                    "type": "string"
-                },
-                "RoleARN": {
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::LifecycleHook"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "AutoScalingGroupName",
-                "LifecycleTransition"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::AutoScaling::ScalingPolicy": {
+            "additionalProperties": false,
             "properties": {
-                "AdjustmentType": {
-                    "type": "string"
-                },
-                "AutoScalingGroupName": {
-                    "type": "string"
-                },
-                "Cooldown": {
-                    "type": "string"
-                },
-                "EstimatedInstanceWarmup": {
-                    "type": "number"
-                },
-                "MetricAggregationType": {
-                    "type": "string"
-                },
-                "MinAdjustmentMagnitude": {
-                    "type": "number"
-                },
-                "PolicyType": {
-                    "type": "string"
-                },
-                "ScalingAdjustment": {
-                    "type": "number"
-                },
-                "StepAdjustments": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.StepAdjustment"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdjustmentType": {
+                            "type": "string"
+                        },
+                        "AutoScalingGroupName": {
+                            "type": "string"
+                        },
+                        "Cooldown": {
+                            "type": "string"
+                        },
+                        "EstimatedInstanceWarmup": {
+                            "type": "number"
+                        },
+                        "MetricAggregationType": {
+                            "type": "string"
+                        },
+                        "MinAdjustmentMagnitude": {
+                            "type": "number"
+                        },
+                        "PolicyType": {
+                            "type": "string"
+                        },
+                        "ScalingAdjustment": {
+                            "type": "number"
+                        },
+                        "StepAdjustments": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.StepAdjustment"
+                            },
+                            "type": "array"
+                        },
+                        "TargetTrackingConfiguration": {
+                            "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.TargetTrackingConfiguration"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "AutoScalingGroupName"
+                    ],
+                    "type": "object"
                 },
-                "TargetTrackingConfiguration": {
-                    "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.TargetTrackingConfiguration"
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::ScalingPolicy"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "AutoScalingGroupName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Dimensions": {
                     "items": {
@@ -1300,6 +1741,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::ScalingPolicy.MetricDimension": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -1315,6 +1757,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::ScalingPolicy.PredefinedMetricSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "PredefinedMetricType": {
                     "type": "string"
@@ -1329,6 +1772,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::ScalingPolicy.StepAdjustment": {
+            "additionalProperties": false,
             "properties": {
                 "MetricIntervalLowerBound": {
                     "type": "number"
@@ -1346,6 +1790,7 @@
             "type": "object"
         },
         "AWS::AutoScaling::ScalingPolicy.TargetTrackingConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "CustomizedMetricSpecification": {
                     "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification"
@@ -1366,60 +1811,95 @@
             "type": "object"
         },
         "AWS::AutoScaling::ScheduledAction": {
+            "additionalProperties": false,
             "properties": {
-                "AutoScalingGroupName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoScalingGroupName": {
+                            "type": "string"
+                        },
+                        "DesiredCapacity": {
+                            "type": "number"
+                        },
+                        "EndTime": {
+                            "type": "string"
+                        },
+                        "MaxSize": {
+                            "type": "number"
+                        },
+                        "MinSize": {
+                            "type": "number"
+                        },
+                        "Recurrence": {
+                            "type": "string"
+                        },
+                        "StartTime": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AutoScalingGroupName"
+                    ],
+                    "type": "object"
                 },
-                "DesiredCapacity": {
-                    "type": "number"
-                },
-                "EndTime": {
-                    "type": "string"
-                },
-                "MaxSize": {
-                    "type": "number"
-                },
-                "MinSize": {
-                    "type": "number"
-                },
-                "Recurrence": {
-                    "type": "string"
-                },
-                "StartTime": {
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::ScheduledAction"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "AutoScalingGroupName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Batch::ComputeEnvironment": {
+            "additionalProperties": false,
             "properties": {
-                "ComputeEnvironmentName": {
-                    "type": "string"
-                },
-                "ComputeResources": {
-                    "$ref": "#/definitions/AWS::Batch::ComputeEnvironment.ComputeResources"
-                },
-                "ServiceRole": {
-                    "type": "string"
-                },
-                "State": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ComputeEnvironmentName": {
+                            "type": "string"
+                        },
+                        "ComputeResources": {
+                            "$ref": "#/definitions/AWS::Batch::ComputeEnvironment.ComputeResources"
+                        },
+                        "ServiceRole": {
+                            "type": "string"
+                        },
+                        "State": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ComputeResources",
+                        "ServiceRole",
+                        "Type"
+                    ],
+                    "type": "object"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::Batch::ComputeEnvironment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ComputeResources",
-                "ServiceRole",
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Batch::ComputeEnvironment.ComputeResources": {
+            "additionalProperties": false,
             "properties": {
                 "BidPercentage": {
                     "type": "number"
@@ -1482,30 +1962,48 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition": {
+            "additionalProperties": false,
             "properties": {
-                "ContainerProperties": {
-                    "$ref": "#/definitions/AWS::Batch::JobDefinition.ContainerProperties"
-                },
-                "JobDefinitionName": {
-                    "type": "string"
-                },
-                "Parameters": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContainerProperties": {
+                            "$ref": "#/definitions/AWS::Batch::JobDefinition.ContainerProperties"
+                        },
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "type": "object"
+                        },
+                        "RetryStrategy": {
+                            "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ContainerProperties",
+                        "Type"
+                    ],
                     "type": "object"
                 },
-                "RetryStrategy": {
-                    "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
-                },
                 "Type": {
+                    "enum": [
+                        "AWS::Batch::JobDefinition"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ContainerProperties",
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Batch::JobDefinition.ContainerProperties": {
+            "additionalProperties": false,
             "properties": {
                 "Command": {
                     "items": {
@@ -1567,6 +2065,7 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition.Environment": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -1578,6 +2077,7 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition.MountPoints": {
+            "additionalProperties": false,
             "properties": {
                 "ContainerPath": {
                     "type": "string"
@@ -1592,6 +2092,7 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition.RetryStrategy": {
+            "additionalProperties": false,
             "properties": {
                 "Attempts": {
                     "type": "number"
@@ -1600,6 +2101,7 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition.Ulimit": {
+            "additionalProperties": false,
             "properties": {
                 "HardLimit": {
                     "type": "number"
@@ -1619,6 +2121,7 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition.Volumes": {
+            "additionalProperties": false,
             "properties": {
                 "Host": {
                     "$ref": "#/definitions/AWS::Batch::JobDefinition.VolumesHost"
@@ -1630,6 +2133,7 @@
             "type": "object"
         },
         "AWS::Batch::JobDefinition.VolumesHost": {
+            "additionalProperties": false,
             "properties": {
                 "SourcePath": {
                     "type": "string"
@@ -1638,30 +2142,48 @@
             "type": "object"
         },
         "AWS::Batch::JobQueue": {
+            "additionalProperties": false,
             "properties": {
-                "ComputeEnvironmentOrder": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Batch::JobQueue.ComputeEnvironmentOrder"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ComputeEnvironmentOrder": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Batch::JobQueue.ComputeEnvironmentOrder"
+                            },
+                            "type": "array"
+                        },
+                        "JobQueueName": {
+                            "type": "string"
+                        },
+                        "Priority": {
+                            "type": "number"
+                        },
+                        "State": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ComputeEnvironmentOrder",
+                        "Priority"
+                    ],
+                    "type": "object"
                 },
-                "JobQueueName": {
-                    "type": "string"
-                },
-                "Priority": {
-                    "type": "number"
-                },
-                "State": {
+                "Type": {
+                    "enum": [
+                        "AWS::Batch::JobQueue"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ComputeEnvironmentOrder",
-                "Priority"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Batch::JobQueue.ComputeEnvironmentOrder": {
+            "additionalProperties": false,
             "properties": {
                 "ComputeEnvironment": {
                     "type": "string"
@@ -1677,35 +2199,53 @@
             "type": "object"
         },
         "AWS::CertificateManager::Certificate": {
+            "additionalProperties": false,
             "properties": {
-                "DomainName": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainValidationOptions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CertificateManager::Certificate.DomainValidationOption"
+                            },
+                            "type": "array"
+                        },
+                        "SubjectAlternativeNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DomainName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CertificateManager::Certificate"
+                    ],
                     "type": "string"
-                },
-                "DomainValidationOptions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CertificateManager::Certificate.DomainValidationOption"
-                    },
-                    "type": "array"
-                },
-                "SubjectAlternativeNames": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "DomainName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CertificateManager::Certificate.DomainValidationOption": {
+            "additionalProperties": false,
             "properties": {
                 "DomainName": {
                     "type": "string"
@@ -1721,84 +2261,170 @@
             "type": "object"
         },
         "AWS::CloudFormation::CustomResource": {
+            "additionalProperties": false,
             "properties": {
-                "ServiceToken": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ServiceToken": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ServiceToken"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::CustomResource"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ServiceToken"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CloudFormation::Stack": {
+            "additionalProperties": false,
             "properties": {
-                "NotificationARNs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Parameters": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "NotificationARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TemplateURL": {
                             "type": "string"
+                        },
+                        "TimeoutInMinutes": {
+                            "type": "number"
                         }
                     },
+                    "required": [
+                        "TemplateURL"
+                    ],
                     "type": "object"
                 },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "TemplateURL": {
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::Stack"
+                    ],
                     "type": "string"
-                },
-                "TimeoutInMinutes": {
-                    "type": "number"
                 }
             },
             "required": [
-                "TemplateURL"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CloudFormation::WaitCondition": {
+            "additionalProperties": false,
             "properties": {
-                "Count": {
-                    "type": "number"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Count": {
+                            "type": "number"
+                        },
+                        "Handle": {
+                            "type": "string"
+                        },
+                        "Timeout": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Handle",
+                        "Timeout"
+                    ],
+                    "type": "object"
                 },
-                "Handle": {
-                    "type": "string"
-                },
-                "Timeout": {
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::WaitCondition"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Handle",
-                "Timeout"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CloudFormation::WaitConditionHandle": {
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::CloudFront::Distribution": {
+            "additionalProperties": false,
             "properties": {
-                "DistributionConfig": {
-                    "$ref": "#/definitions/AWS::CloudFront::Distribution.DistributionConfig"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {},
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::WaitConditionHandle"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "DistributionConfig"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DistributionConfig": {
+                            "$ref": "#/definitions/AWS::CloudFront::Distribution.DistributionConfig"
+                        }
+                    },
+                    "required": [
+                        "DistributionConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFront::Distribution"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CloudFront::Distribution.CacheBehavior": {
+            "additionalProperties": false,
             "properties": {
                 "AllowedMethods": {
                     "items": {
@@ -1855,6 +2481,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.Cookies": {
+            "additionalProperties": false,
             "properties": {
                 "Forward": {
                     "type": "string"
@@ -1872,6 +2499,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.CustomErrorResponse": {
+            "additionalProperties": false,
             "properties": {
                 "ErrorCachingMinTTL": {
                     "type": "number"
@@ -1892,6 +2520,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.CustomOriginConfig": {
+            "additionalProperties": false,
             "properties": {
                 "HTTPPort": {
                     "type": "number"
@@ -1915,6 +2544,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.DefaultCacheBehavior": {
+            "additionalProperties": false,
             "properties": {
                 "AllowedMethods": {
                     "items": {
@@ -1967,6 +2597,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.DistributionConfig": {
+            "additionalProperties": false,
             "properties": {
                 "Aliases": {
                     "items": {
@@ -2031,6 +2662,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.ForwardedValues": {
+            "additionalProperties": false,
             "properties": {
                 "Cookies": {
                     "$ref": "#/definitions/AWS::CloudFront::Distribution.Cookies"
@@ -2057,6 +2689,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.GeoRestriction": {
+            "additionalProperties": false,
             "properties": {
                 "Locations": {
                     "items": {
@@ -2074,6 +2707,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.Logging": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -2091,6 +2725,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.Origin": {
+            "additionalProperties": false,
             "properties": {
                 "CustomOriginConfig": {
                     "$ref": "#/definitions/AWS::CloudFront::Distribution.CustomOriginConfig"
@@ -2121,6 +2756,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.OriginCustomHeader": {
+            "additionalProperties": false,
             "properties": {
                 "HeaderName": {
                     "type": "string"
@@ -2136,6 +2772,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.Restrictions": {
+            "additionalProperties": false,
             "properties": {
                 "GeoRestriction": {
                     "$ref": "#/definitions/AWS::CloudFront::Distribution.GeoRestriction"
@@ -2147,6 +2784,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.S3OriginConfig": {
+            "additionalProperties": false,
             "properties": {
                 "OriginAccessIdentity": {
                     "type": "string"
@@ -2155,6 +2793,7 @@
             "type": "object"
         },
         "AWS::CloudFront::Distribution.ViewerCertificate": {
+            "additionalProperties": false,
             "properties": {
                 "AcmCertificateArn": {
                     "type": "string"
@@ -2175,60 +2814,78 @@
             "type": "object"
         },
         "AWS::CloudTrail::Trail": {
+            "additionalProperties": false,
             "properties": {
-                "CloudWatchLogsLogGroupArn": {
-                    "type": "string"
-                },
-                "CloudWatchLogsRoleArn": {
-                    "type": "string"
-                },
-                "EnableLogFileValidation": {
-                    "type": "boolean"
-                },
-                "EventSelectors": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CloudTrail::Trail.EventSelector"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CloudWatchLogsLogGroupArn": {
+                            "type": "string"
+                        },
+                        "CloudWatchLogsRoleArn": {
+                            "type": "string"
+                        },
+                        "EnableLogFileValidation": {
+                            "type": "boolean"
+                        },
+                        "EventSelectors": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CloudTrail::Trail.EventSelector"
+                            },
+                            "type": "array"
+                        },
+                        "IncludeGlobalServiceEvents": {
+                            "type": "boolean"
+                        },
+                        "IsLogging": {
+                            "type": "boolean"
+                        },
+                        "IsMultiRegionTrail": {
+                            "type": "boolean"
+                        },
+                        "KMSKeyId": {
+                            "type": "string"
+                        },
+                        "S3BucketName": {
+                            "type": "string"
+                        },
+                        "S3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "SnsTopicName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TrailName": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "IsLogging",
+                        "S3BucketName"
+                    ],
+                    "type": "object"
                 },
-                "IncludeGlobalServiceEvents": {
-                    "type": "boolean"
-                },
-                "IsLogging": {
-                    "type": "boolean"
-                },
-                "IsMultiRegionTrail": {
-                    "type": "boolean"
-                },
-                "KMSKeyId": {
-                    "type": "string"
-                },
-                "S3BucketName": {
-                    "type": "string"
-                },
-                "S3KeyPrefix": {
-                    "type": "string"
-                },
-                "SnsTopicName": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "TrailName": {
+                "Type": {
+                    "enum": [
+                        "AWS::CloudTrail::Trail"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "IsLogging",
-                "S3BucketName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CloudTrail::Trail.DataResource": {
+            "additionalProperties": false,
             "properties": {
                 "Type": {
                     "type": "string"
@@ -2246,6 +2903,7 @@
             "type": "object"
         },
         "AWS::CloudTrail::Trail.EventSelector": {
+            "additionalProperties": false,
             "properties": {
                 "DataResources": {
                     "items": {
@@ -2263,85 +2921,103 @@
             "type": "object"
         },
         "AWS::CloudWatch::Alarm": {
+            "additionalProperties": false,
             "properties": {
-                "ActionsEnabled": {
-                    "type": "boolean"
-                },
-                "AlarmActions": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ActionsEnabled": {
+                            "type": "boolean"
+                        },
+                        "AlarmActions": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "AlarmDescription": {
+                            "type": "string"
+                        },
+                        "AlarmName": {
+                            "type": "string"
+                        },
+                        "ComparisonOperator": {
+                            "type": "string"
+                        },
+                        "Dimensions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CloudWatch::Alarm.Dimension"
+                            },
+                            "type": "array"
+                        },
+                        "EvaluateLowSampleCountPercentile": {
+                            "type": "string"
+                        },
+                        "EvaluationPeriods": {
+                            "type": "number"
+                        },
+                        "ExtendedStatistic": {
+                            "type": "string"
+                        },
+                        "InsufficientDataActions": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Namespace": {
+                            "type": "string"
+                        },
+                        "OKActions": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Period": {
+                            "type": "number"
+                        },
+                        "Statistic": {
+                            "type": "string"
+                        },
+                        "Threshold": {
+                            "type": "number"
+                        },
+                        "TreatMissingData": {
+                            "type": "string"
+                        },
+                        "Unit": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ComparisonOperator",
+                        "EvaluationPeriods",
+                        "MetricName",
+                        "Namespace",
+                        "Period",
+                        "Threshold"
+                    ],
+                    "type": "object"
                 },
-                "AlarmDescription": {
-                    "type": "string"
-                },
-                "AlarmName": {
-                    "type": "string"
-                },
-                "ComparisonOperator": {
-                    "type": "string"
-                },
-                "Dimensions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CloudWatch::Alarm.Dimension"
-                    },
-                    "type": "array"
-                },
-                "EvaluateLowSampleCountPercentile": {
-                    "type": "string"
-                },
-                "EvaluationPeriods": {
-                    "type": "number"
-                },
-                "ExtendedStatistic": {
-                    "type": "string"
-                },
-                "InsufficientDataActions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "MetricName": {
-                    "type": "string"
-                },
-                "Namespace": {
-                    "type": "string"
-                },
-                "OKActions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Period": {
-                    "type": "number"
-                },
-                "Statistic": {
-                    "type": "string"
-                },
-                "Threshold": {
-                    "type": "number"
-                },
-                "TreatMissingData": {
-                    "type": "string"
-                },
-                "Unit": {
+                "Type": {
+                    "enum": [
+                        "AWS::CloudWatch::Alarm"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ComparisonOperator",
-                "EvaluationPeriods",
-                "MetricName",
-                "Namespace",
-                "Period",
-                "Threshold"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CloudWatch::Alarm.Dimension": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -2357,61 +3033,96 @@
             "type": "object"
         },
         "AWS::CloudWatch::Dashboard": {
+            "additionalProperties": false,
             "properties": {
-                "DashboardBody": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DashboardBody": {
+                            "type": "string"
+                        },
+                        "DashboardName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DashboardBody"
+                    ],
+                    "type": "object"
                 },
-                "DashboardName": {
+                "Type": {
+                    "enum": [
+                        "AWS::CloudWatch::Dashboard"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DashboardBody"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CodeBuild::Project": {
+            "additionalProperties": false,
             "properties": {
-                "Artifacts": {
-                    "$ref": "#/definitions/AWS::CodeBuild::Project.Artifacts"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "EncryptionKey": {
-                    "type": "string"
-                },
-                "Environment": {
-                    "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "ServiceRole": {
-                    "type": "string"
-                },
-                "Source": {
-                    "$ref": "#/definitions/AWS::CodeBuild::Project.Source"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Artifacts": {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project.Artifacts"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EncryptionKey": {
+                            "type": "string"
+                        },
+                        "Environment": {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ServiceRole": {
+                            "type": "string"
+                        },
+                        "Source": {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project.Source"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TimeoutInMinutes": {
+                            "type": "number"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Artifacts",
+                        "Environment",
+                        "ServiceRole",
+                        "Source"
+                    ],
+                    "type": "object"
                 },
-                "TimeoutInMinutes": {
-                    "type": "number"
+                "Type": {
+                    "enum": [
+                        "AWS::CodeBuild::Project"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Artifacts",
-                "Environment",
-                "ServiceRole",
-                "Source"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CodeBuild::Project.Artifacts": {
+            "additionalProperties": false,
             "properties": {
                 "Location": {
                     "type": "string"
@@ -2438,6 +3149,7 @@
             "type": "object"
         },
         "AWS::CodeBuild::Project.Environment": {
+            "additionalProperties": false,
             "properties": {
                 "ComputeType": {
                     "type": "string"
@@ -2466,6 +3178,7 @@
             "type": "object"
         },
         "AWS::CodeBuild::Project.EnvironmentVariable": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -2484,6 +3197,7 @@
             "type": "object"
         },
         "AWS::CodeBuild::Project.Source": {
+            "additionalProperties": false,
             "properties": {
                 "Auth": {
                     "$ref": "#/definitions/AWS::CodeBuild::Project.SourceAuth"
@@ -2504,6 +3218,7 @@
             "type": "object"
         },
         "AWS::CodeBuild::Project.SourceAuth": {
+            "additionalProperties": false,
             "properties": {
                 "Resource": {
                     "type": "string"
@@ -2518,26 +3233,44 @@
             "type": "object"
         },
         "AWS::CodeCommit::Repository": {
+            "additionalProperties": false,
             "properties": {
-                "RepositoryDescription": {
-                    "type": "string"
-                },
-                "RepositoryName": {
-                    "type": "string"
-                },
-                "Triggers": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodeCommit::Repository.RepositoryTrigger"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryDescription": {
+                            "type": "string"
+                        },
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "Triggers": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeCommit::Repository.RepositoryTrigger"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "RepositoryName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeCommit::Repository"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "RepositoryName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CodeCommit::Repository.RepositoryTrigger": {
+            "additionalProperties": false,
             "properties": {
                 "Branches": {
                     "items": {
@@ -2564,25 +3297,58 @@
             "type": "object"
         },
         "AWS::CodeDeploy::Application": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeDeploy::Application"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentConfig": {
+            "additionalProperties": false,
             "properties": {
-                "DeploymentConfigName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeploymentConfigName": {
+                            "type": "string"
+                        },
+                        "MinimumHealthyHosts": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts"
+                        }
+                    },
+                    "type": "object"
                 },
-                "MinimumHealthyHosts": {
-                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts"
+                "Type": {
+                    "enum": [
+                        "AWS::CodeDeploy::DeploymentConfig"
+                    ],
+                    "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts": {
+            "additionalProperties": false,
             "properties": {
                 "Type": {
                     "type": "string"
@@ -2598,66 +3364,84 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup": {
+            "additionalProperties": false,
             "properties": {
-                "AlarmConfiguration": {
-                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.AlarmConfiguration"
-                },
-                "ApplicationName": {
-                    "type": "string"
-                },
-                "AutoRollbackConfiguration": {
-                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration"
-                },
-                "AutoScalingGroups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AlarmConfiguration": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.AlarmConfiguration"
+                        },
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "AutoRollbackConfiguration": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration"
+                        },
+                        "AutoScalingGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Deployment": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.Deployment"
+                        },
+                        "DeploymentConfigName": {
+                            "type": "string"
+                        },
+                        "DeploymentGroupName": {
+                            "type": "string"
+                        },
+                        "DeploymentStyle": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle"
+                        },
+                        "Ec2TagFilters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.EC2TagFilter"
+                            },
+                            "type": "array"
+                        },
+                        "LoadBalancerInfo": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.LoadBalancerInfo"
+                        },
+                        "OnPremisesInstanceTagFilters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.TagFilter"
+                            },
+                            "type": "array"
+                        },
+                        "ServiceRoleArn": {
+                            "type": "string"
+                        },
+                        "TriggerConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.TriggerConfig"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ApplicationName",
+                        "ServiceRoleArn"
+                    ],
+                    "type": "object"
                 },
-                "Deployment": {
-                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.Deployment"
-                },
-                "DeploymentConfigName": {
+                "Type": {
+                    "enum": [
+                        "AWS::CodeDeploy::DeploymentGroup"
+                    ],
                     "type": "string"
-                },
-                "DeploymentGroupName": {
-                    "type": "string"
-                },
-                "DeploymentStyle": {
-                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle"
-                },
-                "Ec2TagFilters": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.EC2TagFilter"
-                    },
-                    "type": "array"
-                },
-                "LoadBalancerInfo": {
-                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.LoadBalancerInfo"
-                },
-                "OnPremisesInstanceTagFilters": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.TagFilter"
-                    },
-                    "type": "array"
-                },
-                "ServiceRoleArn": {
-                    "type": "string"
-                },
-                "TriggerConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.TriggerConfig"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "ApplicationName",
-                "ServiceRoleArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.Alarm": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -2666,6 +3450,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.AlarmConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Alarms": {
                     "items": {
@@ -2683,6 +3468,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Enabled": {
                     "type": "boolean"
@@ -2697,6 +3483,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.Deployment": {
+            "additionalProperties": false,
             "properties": {
                 "Description": {
                     "type": "string"
@@ -2714,6 +3501,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle": {
+            "additionalProperties": false,
             "properties": {
                 "DeploymentOption": {
                     "type": "string"
@@ -2722,6 +3510,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.EC2TagFilter": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -2736,6 +3525,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.ELBInfo": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -2744,6 +3534,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.GitHubLocation": {
+            "additionalProperties": false,
             "properties": {
                 "CommitId": {
                     "type": "string"
@@ -2759,6 +3550,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.LoadBalancerInfo": {
+            "additionalProperties": false,
             "properties": {
                 "ElbInfoList": {
                     "items": {
@@ -2770,6 +3562,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.RevisionLocation": {
+            "additionalProperties": false,
             "properties": {
                 "GitHubLocation": {
                     "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.GitHubLocation"
@@ -2784,6 +3577,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.S3Location": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -2808,6 +3602,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.TagFilter": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -2822,6 +3617,7 @@
             "type": "object"
         },
         "AWS::CodeDeploy::DeploymentGroup.TriggerConfig": {
+            "additionalProperties": false,
             "properties": {
                 "TriggerEvents": {
                     "items": {
@@ -2839,41 +3635,59 @@
             "type": "object"
         },
         "AWS::CodePipeline::CustomActionType": {
+            "additionalProperties": false,
             "properties": {
-                "Category": {
-                    "type": "string"
-                },
-                "ConfigurationProperties": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ConfigurationProperties"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Category": {
+                            "type": "string"
+                        },
+                        "ConfigurationProperties": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ConfigurationProperties"
+                            },
+                            "type": "array"
+                        },
+                        "InputArtifactDetails": {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ArtifactDetails"
+                        },
+                        "OutputArtifactDetails": {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ArtifactDetails"
+                        },
+                        "Provider": {
+                            "type": "string"
+                        },
+                        "Settings": {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.Settings"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Category",
+                        "InputArtifactDetails",
+                        "OutputArtifactDetails",
+                        "Provider"
+                    ],
+                    "type": "object"
                 },
-                "InputArtifactDetails": {
-                    "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ArtifactDetails"
-                },
-                "OutputArtifactDetails": {
-                    "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ArtifactDetails"
-                },
-                "Provider": {
-                    "type": "string"
-                },
-                "Settings": {
-                    "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.Settings"
-                },
-                "Version": {
+                "Type": {
+                    "enum": [
+                        "AWS::CodePipeline::CustomActionType"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Category",
-                "InputArtifactDetails",
-                "OutputArtifactDetails",
-                "Provider"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CodePipeline::CustomActionType.ArtifactDetails": {
+            "additionalProperties": false,
             "properties": {
                 "MaximumCount": {
                     "type": "number"
@@ -2889,6 +3703,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::CustomActionType.ConfigurationProperties": {
+            "additionalProperties": false,
             "properties": {
                 "Description": {
                     "type": "string"
@@ -2921,6 +3736,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::CustomActionType.Settings": {
+            "additionalProperties": false,
             "properties": {
                 "EntityUrlTemplate": {
                     "type": "string"
@@ -2938,40 +3754,58 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline": {
+            "additionalProperties": false,
             "properties": {
-                "ArtifactStore": {
-                    "$ref": "#/definitions/AWS::CodePipeline::Pipeline.ArtifactStore"
-                },
-                "DisableInboundStageTransitions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodePipeline::Pipeline.StageTransition"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ArtifactStore": {
+                            "$ref": "#/definitions/AWS::CodePipeline::Pipeline.ArtifactStore"
+                        },
+                        "DisableInboundStageTransitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodePipeline::Pipeline.StageTransition"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RestartExecutionOnUpdate": {
+                            "type": "boolean"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Stages": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodePipeline::Pipeline.StageDeclaration"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ArtifactStore",
+                        "RoleArn",
+                        "Stages"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::CodePipeline::Pipeline"
+                    ],
                     "type": "string"
-                },
-                "RestartExecutionOnUpdate": {
-                    "type": "boolean"
-                },
-                "RoleArn": {
-                    "type": "string"
-                },
-                "Stages": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::CodePipeline::Pipeline.StageDeclaration"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "ArtifactStore",
-                "RoleArn",
-                "Stages"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.ActionDeclaration": {
+            "additionalProperties": false,
             "properties": {
                 "ActionTypeId": {
                     "$ref": "#/definitions/AWS::CodePipeline::Pipeline.ActionTypeId"
@@ -3008,6 +3842,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.ActionTypeId": {
+            "additionalProperties": false,
             "properties": {
                 "Category": {
                     "type": "string"
@@ -3031,6 +3866,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.ArtifactStore": {
+            "additionalProperties": false,
             "properties": {
                 "EncryptionKey": {
                     "$ref": "#/definitions/AWS::CodePipeline::Pipeline.EncryptionKey"
@@ -3049,6 +3885,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.BlockerDeclaration": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -3064,6 +3901,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.EncryptionKey": {
+            "additionalProperties": false,
             "properties": {
                 "Id": {
                     "type": "string"
@@ -3079,6 +3917,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.InputArtifact": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -3090,6 +3929,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.OutputArtifact": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -3101,6 +3941,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.StageDeclaration": {
+            "additionalProperties": false,
             "properties": {
                 "Actions": {
                     "items": {
@@ -3125,6 +3966,7 @@
             "type": "object"
         },
         "AWS::CodePipeline::Pipeline.StageTransition": {
+            "additionalProperties": false,
             "properties": {
                 "Reason": {
                     "type": "string"
@@ -3140,53 +3982,71 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPool": {
+            "additionalProperties": false,
             "properties": {
-                "AllowUnauthenticatedIdentities": {
-                    "type": "boolean"
-                },
-                "CognitoEvents": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowUnauthenticatedIdentities": {
+                            "type": "boolean"
+                        },
+                        "CognitoEvents": {
+                            "type": "object"
+                        },
+                        "CognitoIdentityProviders": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::IdentityPool.CognitoIdentityProvider"
+                            },
+                            "type": "array"
+                        },
+                        "CognitoStreams": {
+                            "$ref": "#/definitions/AWS::Cognito::IdentityPool.CognitoStreams"
+                        },
+                        "DeveloperProviderName": {
+                            "type": "string"
+                        },
+                        "IdentityPoolName": {
+                            "type": "string"
+                        },
+                        "OpenIdConnectProviderARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PushSync": {
+                            "$ref": "#/definitions/AWS::Cognito::IdentityPool.PushSync"
+                        },
+                        "SamlProviderARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SupportedLoginProviders": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "AllowUnauthenticatedIdentities"
+                    ],
                     "type": "object"
                 },
-                "CognitoIdentityProviders": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Cognito::IdentityPool.CognitoIdentityProvider"
-                    },
-                    "type": "array"
-                },
-                "CognitoStreams": {
-                    "$ref": "#/definitions/AWS::Cognito::IdentityPool.CognitoStreams"
-                },
-                "DeveloperProviderName": {
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::IdentityPool"
+                    ],
                     "type": "string"
-                },
-                "IdentityPoolName": {
-                    "type": "string"
-                },
-                "OpenIdConnectProviderARNs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "PushSync": {
-                    "$ref": "#/definitions/AWS::Cognito::IdentityPool.PushSync"
-                },
-                "SamlProviderARNs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SupportedLoginProviders": {
-                    "type": "object"
                 }
             },
             "required": [
-                "AllowUnauthenticatedIdentities"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Cognito::IdentityPool.CognitoIdentityProvider": {
+            "additionalProperties": false,
             "properties": {
                 "ClientId": {
                     "type": "string"
@@ -3201,6 +4061,7 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPool.CognitoStreams": {
+            "additionalProperties": false,
             "properties": {
                 "RoleArn": {
                     "type": "string"
@@ -3215,6 +4076,7 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPool.PushSync": {
+            "additionalProperties": false,
             "properties": {
                 "ApplicationArns": {
                     "items": {
@@ -3229,23 +4091,41 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPoolRoleAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "IdentityPoolId": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IdentityPoolId": {
+                            "type": "string"
+                        },
+                        "RoleMappings": {
+                            "type": "object"
+                        },
+                        "Roles": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "IdentityPoolId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::IdentityPoolRoleAttachment"
+                    ],
                     "type": "string"
-                },
-                "RoleMappings": {
-                    "type": "object"
-                },
-                "Roles": {
-                    "type": "object"
                 }
             },
             "required": [
-                "IdentityPoolId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Cognito::IdentityPoolRoleAttachment.MappingRule": {
+            "additionalProperties": false,
             "properties": {
                 "Claim": {
                     "type": "string"
@@ -3269,6 +4149,7 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPoolRoleAttachment.RoleMapping": {
+            "additionalProperties": false,
             "properties": {
                 "AmbiguousRoleResolution": {
                     "type": "string"
@@ -3286,6 +4167,7 @@
             "type": "object"
         },
         "AWS::Cognito::IdentityPoolRoleAttachment.RulesConfigurationType": {
+            "additionalProperties": false,
             "properties": {
                 "Rules": {
                     "items": {
@@ -3300,68 +4182,85 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool": {
+            "additionalProperties": false,
             "properties": {
-                "AdminCreateUserConfig": {
-                    "$ref": "#/definitions/AWS::Cognito::UserPool.AdminCreateUserConfig"
-                },
-                "AliasAttributes": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdminCreateUserConfig": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.AdminCreateUserConfig"
+                        },
+                        "AliasAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "AutoVerifiedAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "DeviceConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.DeviceConfiguration"
+                        },
+                        "EmailConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.EmailConfiguration"
+                        },
+                        "EmailVerificationMessage": {
+                            "type": "string"
+                        },
+                        "EmailVerificationSubject": {
+                            "type": "string"
+                        },
+                        "LambdaConfig": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.LambdaConfig"
+                        },
+                        "MfaConfiguration": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.Policies"
+                        },
+                        "Schema": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::UserPool.SchemaAttribute"
+                            },
+                            "type": "array"
+                        },
+                        "SmsAuthenticationMessage": {
+                            "type": "string"
+                        },
+                        "SmsConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.SmsConfiguration"
+                        },
+                        "SmsVerificationMessage": {
+                            "type": "string"
+                        },
+                        "UserPoolName": {
+                            "type": "string"
+                        },
+                        "UserPoolTags": {
+                            "type": "object"
+                        }
                     },
-                    "type": "array"
-                },
-                "AutoVerifiedAttributes": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "DeviceConfiguration": {
-                    "$ref": "#/definitions/AWS::Cognito::UserPool.DeviceConfiguration"
-                },
-                "EmailConfiguration": {
-                    "$ref": "#/definitions/AWS::Cognito::UserPool.EmailConfiguration"
-                },
-                "EmailVerificationMessage": {
-                    "type": "string"
-                },
-                "EmailVerificationSubject": {
-                    "type": "string"
-                },
-                "LambdaConfig": {
-                    "$ref": "#/definitions/AWS::Cognito::UserPool.LambdaConfig"
-                },
-                "MfaConfiguration": {
-                    "type": "string"
-                },
-                "Policies": {
-                    "$ref": "#/definitions/AWS::Cognito::UserPool.Policies"
-                },
-                "Schema": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Cognito::UserPool.SchemaAttribute"
-                    },
-                    "type": "array"
-                },
-                "SmsAuthenticationMessage": {
-                    "type": "string"
-                },
-                "SmsConfiguration": {
-                    "$ref": "#/definitions/AWS::Cognito::UserPool.SmsConfiguration"
-                },
-                "SmsVerificationMessage": {
-                    "type": "string"
-                },
-                "UserPoolName": {
-                    "type": "string"
-                },
-                "UserPoolTags": {
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPool"
+                    ],
+                    "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Cognito::UserPool.AdminCreateUserConfig": {
+            "additionalProperties": false,
             "properties": {
                 "AllowAdminCreateUserOnly": {
                     "type": "boolean"
@@ -3376,6 +4275,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.DeviceConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "ChallengeRequiredOnNewDevice": {
                     "type": "boolean"
@@ -3387,6 +4287,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.EmailConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "ReplyToEmailAddress": {
                     "type": "string"
@@ -3398,6 +4299,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.InviteMessageTemplate": {
+            "additionalProperties": false,
             "properties": {
                 "EmailMessage": {
                     "type": "string"
@@ -3412,6 +4314,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.LambdaConfig": {
+            "additionalProperties": false,
             "properties": {
                 "CreateAuthChallenge": {
                     "type": "string"
@@ -3441,6 +4344,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.NumberAttributeConstraints": {
+            "additionalProperties": false,
             "properties": {
                 "MaxValue": {
                     "type": "string"
@@ -3452,6 +4356,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.PasswordPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "MinimumLength": {
                     "type": "number"
@@ -3472,6 +4377,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.Policies": {
+            "additionalProperties": false,
             "properties": {
                 "PasswordPolicy": {
                     "$ref": "#/definitions/AWS::Cognito::UserPool.PasswordPolicy"
@@ -3480,6 +4386,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.SchemaAttribute": {
+            "additionalProperties": false,
             "properties": {
                 "AttributeDataType": {
                     "type": "string"
@@ -3506,6 +4413,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.SmsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "ExternalId": {
                     "type": "string"
@@ -3517,6 +4425,7 @@
             "type": "object"
         },
         "AWS::Cognito::UserPool.StringAttributeConstraints": {
+            "additionalProperties": false,
             "properties": {
                 "MaxLength": {
                     "type": "string"
@@ -3528,105 +4437,157 @@
             "type": "object"
         },
         "AWS::Cognito::UserPoolClient": {
+            "additionalProperties": false,
             "properties": {
-                "ClientName": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ClientName": {
+                            "type": "string"
+                        },
+                        "ExplicitAuthFlows": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "GenerateSecret": {
+                            "type": "boolean"
+                        },
+                        "ReadAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "RefreshTokenValidity": {
+                            "type": "number"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        },
+                        "WriteAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "UserPoolId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolClient"
+                    ],
                     "type": "string"
-                },
-                "ExplicitAuthFlows": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "GenerateSecret": {
-                    "type": "boolean"
-                },
-                "ReadAttributes": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "RefreshTokenValidity": {
-                    "type": "number"
-                },
-                "UserPoolId": {
-                    "type": "string"
-                },
-                "WriteAttributes": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "UserPoolId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Cognito::UserPoolGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "Precedence": {
+                            "type": "number"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "UserPoolId"
+                    ],
+                    "type": "object"
                 },
-                "GroupName": {
-                    "type": "string"
-                },
-                "Precedence": {
-                    "type": "number"
-                },
-                "RoleArn": {
-                    "type": "string"
-                },
-                "UserPoolId": {
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolGroup"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "UserPoolId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Cognito::UserPoolUser": {
+            "additionalProperties": false,
             "properties": {
-                "DesiredDeliveryMediums": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DesiredDeliveryMediums": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ForceAliasCreation": {
+                            "type": "boolean"
+                        },
+                        "MessageAction": {
+                            "type": "string"
+                        },
+                        "UserAttributes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::UserPoolUser.AttributeType"
+                            },
+                            "type": "array"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        },
+                        "Username": {
+                            "type": "string"
+                        },
+                        "ValidationData": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::UserPoolUser.AttributeType"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "UserPoolId"
+                    ],
+                    "type": "object"
                 },
-                "ForceAliasCreation": {
-                    "type": "boolean"
-                },
-                "MessageAction": {
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolUser"
+                    ],
                     "type": "string"
-                },
-                "UserAttributes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Cognito::UserPoolUser.AttributeType"
-                    },
-                    "type": "array"
-                },
-                "UserPoolId": {
-                    "type": "string"
-                },
-                "Username": {
-                    "type": "string"
-                },
-                "ValidationData": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Cognito::UserPoolUser.AttributeType"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "UserPoolId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Cognito::UserPoolUser.AttributeType": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -3638,51 +4599,86 @@
             "type": "object"
         },
         "AWS::Cognito::UserPoolUserToGroupAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "GroupName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        },
+                        "Username": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "GroupName",
+                        "UserPoolId",
+                        "Username"
+                    ],
+                    "type": "object"
                 },
-                "UserPoolId": {
-                    "type": "string"
-                },
-                "Username": {
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolUserToGroupAttachment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "GroupName",
-                "UserPoolId",
-                "Username"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Config::ConfigRule": {
+            "additionalProperties": false,
             "properties": {
-                "ConfigRuleName": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "InputParameters": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConfigRuleName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "InputParameters": {
+                            "type": "object"
+                        },
+                        "MaximumExecutionFrequency": {
+                            "type": "string"
+                        },
+                        "Scope": {
+                            "$ref": "#/definitions/AWS::Config::ConfigRule.Scope"
+                        },
+                        "Source": {
+                            "$ref": "#/definitions/AWS::Config::ConfigRule.Source"
+                        }
+                    },
+                    "required": [
+                        "Source"
+                    ],
                     "type": "object"
                 },
-                "MaximumExecutionFrequency": {
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConfigRule"
+                    ],
                     "type": "string"
-                },
-                "Scope": {
-                    "$ref": "#/definitions/AWS::Config::ConfigRule.Scope"
-                },
-                "Source": {
-                    "$ref": "#/definitions/AWS::Config::ConfigRule.Source"
                 }
             },
             "required": [
-                "Source"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Config::ConfigRule.Scope": {
+            "additionalProperties": false,
             "properties": {
                 "ComplianceResourceId": {
                     "type": "string"
@@ -3703,6 +4699,7 @@
             "type": "object"
         },
         "AWS::Config::ConfigRule.Source": {
+            "additionalProperties": false,
             "properties": {
                 "Owner": {
                     "type": "string"
@@ -3724,6 +4721,7 @@
             "type": "object"
         },
         "AWS::Config::ConfigRule.SourceDetail": {
+            "additionalProperties": false,
             "properties": {
                 "EventSource": {
                     "type": "string"
@@ -3742,23 +4740,41 @@
             "type": "object"
         },
         "AWS::Config::ConfigurationRecorder": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RecordingGroup": {
+                            "$ref": "#/definitions/AWS::Config::ConfigurationRecorder.RecordingGroup"
+                        },
+                        "RoleARN": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RoleARN"
+                    ],
+                    "type": "object"
                 },
-                "RecordingGroup": {
-                    "$ref": "#/definitions/AWS::Config::ConfigurationRecorder.RecordingGroup"
-                },
-                "RoleARN": {
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConfigurationRecorder"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "RoleARN"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Config::ConfigurationRecorder.RecordingGroup": {
+            "additionalProperties": false,
             "properties": {
                 "AllSupported": {
                     "type": "boolean"
@@ -3776,29 +4792,47 @@
             "type": "object"
         },
         "AWS::Config::DeliveryChannel": {
+            "additionalProperties": false,
             "properties": {
-                "ConfigSnapshotDeliveryProperties": {
-                    "$ref": "#/definitions/AWS::Config::DeliveryChannel.ConfigSnapshotDeliveryProperties"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConfigSnapshotDeliveryProperties": {
+                            "$ref": "#/definitions/AWS::Config::DeliveryChannel.ConfigSnapshotDeliveryProperties"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "S3BucketName": {
+                            "type": "string"
+                        },
+                        "S3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "SnsTopicARN": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "S3BucketName"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
-                    "type": "string"
-                },
-                "S3BucketName": {
-                    "type": "string"
-                },
-                "S3KeyPrefix": {
-                    "type": "string"
-                },
-                "SnsTopicARN": {
+                "Type": {
+                    "enum": [
+                        "AWS::Config::DeliveryChannel"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "S3BucketName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Config::DeliveryChannel.ConfigSnapshotDeliveryProperties": {
+            "additionalProperties": false,
             "properties": {
                 "DeliveryFrequency": {
                     "type": "string"
@@ -3807,166 +4841,250 @@
             "type": "object"
         },
         "AWS::DAX::Cluster": {
+            "additionalProperties": false,
             "properties": {
-                "AvailabilityZones": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ClusterName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "IAMRoleARN": {
+                            "type": "string"
+                        },
+                        "NodeType": {
+                            "type": "string"
+                        },
+                        "NotificationTopicARN": {
+                            "type": "string"
+                        },
+                        "ParameterGroupName": {
+                            "type": "string"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "ReplicationFactor": {
+                            "type": "number"
+                        },
+                        "SecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "type": "object"
+                        }
                     },
-                    "type": "array"
-                },
-                "ClusterName": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "IAMRoleARN": {
-                    "type": "string"
-                },
-                "NodeType": {
-                    "type": "string"
-                },
-                "NotificationTopicARN": {
-                    "type": "string"
-                },
-                "ParameterGroupName": {
-                    "type": "string"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "ReplicationFactor": {
-                    "type": "number"
-                },
-                "SecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SubnetGroupName": {
-                    "type": "string"
-                },
-                "Tags": {
+                    "required": [
+                        "IAMRoleARN",
+                        "NodeType",
+                        "ReplicationFactor"
+                    ],
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DAX::Cluster"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "IAMRoleARN",
-                "NodeType",
-                "ReplicationFactor"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DAX::ParameterGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "ParameterGroupName": {
-                    "type": "string"
-                },
-                "ParameterNameValues": {
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::DAX::SubnetGroup": {
-            "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "SubnetGroupName": {
-                    "type": "string"
-                },
-                "SubnetIds": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "ParameterGroupName": {
+                            "type": "string"
+                        },
+                        "ParameterNameValues": {
+                            "type": "object"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DAX::ParameterGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "SubnetIds"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::DAX::SubnetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SubnetGroupName": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DAX::SubnetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DMS::Certificate": {
+            "additionalProperties": false,
             "properties": {
-                "CertificateIdentifier": {
-                    "type": "string"
-                },
-                "CertificatePem": {
-                    "type": "string"
-                },
-                "CertificateWallet": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::DMS::Endpoint": {
-            "properties": {
-                "CertificateArn": {
-                    "type": "string"
-                },
-                "DatabaseName": {
-                    "type": "string"
-                },
-                "DynamoDbSettings": {
-                    "$ref": "#/definitions/AWS::DMS::Endpoint.DynamoDbSettings"
-                },
-                "EndpointIdentifier": {
-                    "type": "string"
-                },
-                "EndpointType": {
-                    "type": "string"
-                },
-                "EngineName": {
-                    "type": "string"
-                },
-                "ExtraConnectionAttributes": {
-                    "type": "string"
-                },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "MongoDbSettings": {
-                    "$ref": "#/definitions/AWS::DMS::Endpoint.MongoDbSettings"
-                },
-                "Password": {
-                    "type": "string"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "S3Settings": {
-                    "$ref": "#/definitions/AWS::DMS::Endpoint.S3Settings"
-                },
-                "ServerName": {
-                    "type": "string"
-                },
-                "SslMode": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateIdentifier": {
+                            "type": "string"
+                        },
+                        "CertificatePem": {
+                            "type": "string"
+                        },
+                        "CertificateWallet": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "Username": {
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::Certificate"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "EndpointType",
-                "EngineName"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::Endpoint": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateArn": {
+                            "type": "string"
+                        },
+                        "DatabaseName": {
+                            "type": "string"
+                        },
+                        "DynamoDbSettings": {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint.DynamoDbSettings"
+                        },
+                        "EndpointIdentifier": {
+                            "type": "string"
+                        },
+                        "EndpointType": {
+                            "type": "string"
+                        },
+                        "EngineName": {
+                            "type": "string"
+                        },
+                        "ExtraConnectionAttributes": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "MongoDbSettings": {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint.MongoDbSettings"
+                        },
+                        "Password": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "S3Settings": {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint.S3Settings"
+                        },
+                        "ServerName": {
+                            "type": "string"
+                        },
+                        "SslMode": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Username": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "EndpointType",
+                        "EngineName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::Endpoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DMS::Endpoint.DynamoDbSettings": {
+            "additionalProperties": false,
             "properties": {
                 "ServiceAccessRoleArn": {
                     "type": "string"
@@ -3975,6 +5093,7 @@
             "type": "object"
         },
         "AWS::DMS::Endpoint.MongoDbSettings": {
+            "additionalProperties": false,
             "properties": {
                 "AuthMechanism": {
                     "type": "string"
@@ -4013,6 +5132,7 @@
             "type": "object"
         },
         "AWS::DMS::Endpoint.S3Settings": {
+            "additionalProperties": false,
             "properties": {
                 "BucketFolder": {
                     "type": "string"
@@ -4039,211 +5159,297 @@
             "type": "object"
         },
         "AWS::DMS::EventSubscription": {
+            "additionalProperties": false,
             "properties": {
-                "Enabled": {
-                    "type": "boolean"
-                },
-                "EventCategories": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "EventCategories": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        },
+                        "SourceIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SourceType": {
+                            "type": "string"
+                        },
+                        "SubscriptionName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
                 },
-                "SnsTopicArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::EventSubscription"
+                    ],
                     "type": "string"
-                },
-                "SourceIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SourceType": {
-                    "type": "string"
-                },
-                "SubscriptionName": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "SnsTopicArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DMS::ReplicationInstance": {
+            "additionalProperties": false,
             "properties": {
-                "AllocatedStorage": {
-                    "type": "number"
-                },
-                "AllowMajorVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "AutoMinorVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "EngineVersion": {
-                    "type": "string"
-                },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "MultiAZ": {
-                    "type": "boolean"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "PubliclyAccessible": {
-                    "type": "boolean"
-                },
-                "ReplicationInstanceClass": {
-                    "type": "string"
-                },
-                "ReplicationInstanceIdentifier": {
-                    "type": "string"
-                },
-                "ReplicationSubnetGroupIdentifier": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocatedStorage": {
+                            "type": "number"
+                        },
+                        "AllowMajorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "MultiAZ": {
+                            "type": "boolean"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PubliclyAccessible": {
+                            "type": "boolean"
+                        },
+                        "ReplicationInstanceClass": {
+                            "type": "string"
+                        },
+                        "ReplicationInstanceIdentifier": {
+                            "type": "string"
+                        },
+                        "ReplicationSubnetGroupIdentifier": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ReplicationInstanceClass"
+                    ],
+                    "type": "object"
                 },
-                "VpcSecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::ReplicationInstance"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "ReplicationInstanceClass"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DMS::ReplicationSubnetGroup": {
+            "additionalProperties": false,
             "properties": {
-                "ReplicationSubnetGroupDescription": {
-                    "type": "string"
-                },
-                "ReplicationSubnetGroupIdentifier": {
-                    "type": "string"
-                },
-                "SubnetIds": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ReplicationSubnetGroupDescription": {
+                            "type": "string"
+                        },
+                        "ReplicationSubnetGroupIdentifier": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ReplicationSubnetGroupDescription",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
                 },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::ReplicationSubnetGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "ReplicationSubnetGroupDescription",
-                "SubnetIds"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DMS::ReplicationTask": {
+            "additionalProperties": false,
             "properties": {
-                "CdcStartTime": {
-                    "type": "number"
-                },
-                "MigrationType": {
-                    "type": "string"
-                },
-                "ReplicationInstanceArn": {
-                    "type": "string"
-                },
-                "ReplicationTaskIdentifier": {
-                    "type": "string"
-                },
-                "ReplicationTaskSettings": {
-                    "type": "string"
-                },
-                "SourceEndpointArn": {
-                    "type": "string"
-                },
-                "TableMappings": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CdcStartTime": {
+                            "type": "number"
+                        },
+                        "MigrationType": {
+                            "type": "string"
+                        },
+                        "ReplicationInstanceArn": {
+                            "type": "string"
+                        },
+                        "ReplicationTaskIdentifier": {
+                            "type": "string"
+                        },
+                        "ReplicationTaskSettings": {
+                            "type": "string"
+                        },
+                        "SourceEndpointArn": {
+                            "type": "string"
+                        },
+                        "TableMappings": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TargetEndpointArn": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "MigrationType",
+                        "ReplicationInstanceArn",
+                        "SourceEndpointArn",
+                        "TableMappings",
+                        "TargetEndpointArn"
+                    ],
+                    "type": "object"
                 },
-                "TargetEndpointArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::ReplicationTask"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "MigrationType",
-                "ReplicationInstanceArn",
-                "SourceEndpointArn",
-                "TableMappings",
-                "TargetEndpointArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline": {
+            "additionalProperties": false,
             "properties": {
-                "Activate": {
-                    "type": "boolean"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Activate": {
+                            "type": "boolean"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ParameterObjects": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterObject"
+                            },
+                            "type": "array"
+                        },
+                        "ParameterValues": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterValue"
+                            },
+                            "type": "array"
+                        },
+                        "PipelineObjects": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.PipelineObject"
+                            },
+                            "type": "array"
+                        },
+                        "PipelineTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.PipelineTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "ParameterObjects"
+                    ],
+                    "type": "object"
                 },
-                "Description": {
+                "Type": {
+                    "enum": [
+                        "AWS::DataPipeline::Pipeline"
+                    ],
                     "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "ParameterObjects": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterObject"
-                    },
-                    "type": "array"
-                },
-                "ParameterValues": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterValue"
-                    },
-                    "type": "array"
-                },
-                "PipelineObjects": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DataPipeline::Pipeline.PipelineObject"
-                    },
-                    "type": "array"
-                },
-                "PipelineTags": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DataPipeline::Pipeline.PipelineTag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "Name",
-                "ParameterObjects"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline.Field": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -4261,6 +5467,7 @@
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline.ParameterAttribute": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -4276,6 +5483,7 @@
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline.ParameterObject": {
+            "additionalProperties": false,
             "properties": {
                 "Attributes": {
                     "items": {
@@ -4294,6 +5502,7 @@
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline.ParameterValue": {
+            "additionalProperties": false,
             "properties": {
                 "Id": {
                     "type": "string"
@@ -4309,6 +5518,7 @@
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline.PipelineObject": {
+            "additionalProperties": false,
             "properties": {
                 "Fields": {
                     "items": {
@@ -4331,6 +5541,7 @@
             "type": "object"
         },
         "AWS::DataPipeline::Pipeline.PipelineTag": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -4346,34 +5557,52 @@
             "type": "object"
         },
         "AWS::DirectoryService::MicrosoftAD": {
+            "additionalProperties": false,
             "properties": {
-                "CreateAlias": {
-                    "type": "boolean"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CreateAlias": {
+                            "type": "boolean"
+                        },
+                        "EnableSso": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Password": {
+                            "type": "string"
+                        },
+                        "ShortName": {
+                            "type": "string"
+                        },
+                        "VpcSettings": {
+                            "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD.VpcSettings"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "Password",
+                        "VpcSettings"
+                    ],
+                    "type": "object"
                 },
-                "EnableSso": {
-                    "type": "boolean"
-                },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::DirectoryService::MicrosoftAD"
+                    ],
                     "type": "string"
-                },
-                "Password": {
-                    "type": "string"
-                },
-                "ShortName": {
-                    "type": "string"
-                },
-                "VpcSettings": {
-                    "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD.VpcSettings"
                 }
             },
             "required": [
-                "Name",
-                "Password",
-                "VpcSettings"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DirectoryService::MicrosoftAD.VpcSettings": {
+            "additionalProperties": false,
             "properties": {
                 "SubnetIds": {
                     "items": {
@@ -4392,41 +5621,59 @@
             "type": "object"
         },
         "AWS::DirectoryService::SimpleAD": {
+            "additionalProperties": false,
             "properties": {
-                "CreateAlias": {
-                    "type": "boolean"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CreateAlias": {
+                            "type": "boolean"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnableSso": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Password": {
+                            "type": "string"
+                        },
+                        "ShortName": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "string"
+                        },
+                        "VpcSettings": {
+                            "$ref": "#/definitions/AWS::DirectoryService::SimpleAD.VpcSettings"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "Password",
+                        "Size",
+                        "VpcSettings"
+                    ],
+                    "type": "object"
                 },
-                "Description": {
+                "Type": {
+                    "enum": [
+                        "AWS::DirectoryService::SimpleAD"
+                    ],
                     "type": "string"
-                },
-                "EnableSso": {
-                    "type": "boolean"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Password": {
-                    "type": "string"
-                },
-                "ShortName": {
-                    "type": "string"
-                },
-                "Size": {
-                    "type": "string"
-                },
-                "VpcSettings": {
-                    "$ref": "#/definitions/AWS::DirectoryService::SimpleAD.VpcSettings"
                 }
             },
             "required": [
-                "Name",
-                "Password",
-                "Size",
-                "VpcSettings"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DirectoryService::SimpleAD.VpcSettings": {
+            "additionalProperties": false,
             "properties": {
                 "SubnetIds": {
                     "items": {
@@ -4445,57 +5692,75 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table": {
+            "additionalProperties": false,
             "properties": {
-                "AttributeDefinitions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DynamoDB::Table.AttributeDefinition"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AttributeDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.AttributeDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "GlobalSecondaryIndexes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.GlobalSecondaryIndex"
+                            },
+                            "type": "array"
+                        },
+                        "KeySchema": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.KeySchema"
+                            },
+                            "type": "array"
+                        },
+                        "LocalSecondaryIndexes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.LocalSecondaryIndex"
+                            },
+                            "type": "array"
+                        },
+                        "ProvisionedThroughput": {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table.ProvisionedThroughput"
+                        },
+                        "StreamSpecification": {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table.StreamSpecification"
+                        },
+                        "TableName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TimeToLiveSpecification": {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table.TimeToLiveSpecification"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "KeySchema",
+                        "ProvisionedThroughput"
+                    ],
+                    "type": "object"
                 },
-                "GlobalSecondaryIndexes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DynamoDB::Table.GlobalSecondaryIndex"
-                    },
-                    "type": "array"
-                },
-                "KeySchema": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DynamoDB::Table.KeySchema"
-                    },
-                    "type": "array"
-                },
-                "LocalSecondaryIndexes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::DynamoDB::Table.LocalSecondaryIndex"
-                    },
-                    "type": "array"
-                },
-                "ProvisionedThroughput": {
-                    "$ref": "#/definitions/AWS::DynamoDB::Table.ProvisionedThroughput"
-                },
-                "StreamSpecification": {
-                    "$ref": "#/definitions/AWS::DynamoDB::Table.StreamSpecification"
-                },
-                "TableName": {
+                "Type": {
+                    "enum": [
+                        "AWS::DynamoDB::Table"
+                    ],
                     "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "TimeToLiveSpecification": {
-                    "$ref": "#/definitions/AWS::DynamoDB::Table.TimeToLiveSpecification"
                 }
             },
             "required": [
-                "KeySchema",
-                "ProvisionedThroughput"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::DynamoDB::Table.AttributeDefinition": {
+            "additionalProperties": false,
             "properties": {
                 "AttributeName": {
                     "type": "string"
@@ -4511,6 +5776,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.GlobalSecondaryIndex": {
+            "additionalProperties": false,
             "properties": {
                 "IndexName": {
                     "type": "string"
@@ -4537,6 +5803,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.KeySchema": {
+            "additionalProperties": false,
             "properties": {
                 "AttributeName": {
                     "type": "string"
@@ -4552,6 +5819,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.LocalSecondaryIndex": {
+            "additionalProperties": false,
             "properties": {
                 "IndexName": {
                     "type": "string"
@@ -4574,6 +5842,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.Projection": {
+            "additionalProperties": false,
             "properties": {
                 "NonKeyAttributes": {
                     "items": {
@@ -4588,6 +5857,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.ProvisionedThroughput": {
+            "additionalProperties": false,
             "properties": {
                 "ReadCapacityUnits": {
                     "type": "number"
@@ -4603,6 +5873,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.StreamSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "StreamViewType": {
                     "type": "string"
@@ -4614,6 +5885,7 @@
             "type": "object"
         },
         "AWS::DynamoDB::Table.TimeToLiveSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "AttributeName": {
                     "type": "string"
@@ -4629,272 +5901,406 @@
             "type": "object"
         },
         "AWS::EC2::CustomerGateway": {
+            "additionalProperties": false,
             "properties": {
-                "BgpAsn": {
-                    "type": "number"
-                },
-                "IpAddress": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BgpAsn": {
+                            "type": "number"
+                        },
+                        "IpAddress": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "BgpAsn",
+                        "IpAddress",
+                        "Type"
+                    ],
+                    "type": "object"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::EC2::CustomerGateway"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "BgpAsn",
-                "IpAddress",
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::DHCPOptions": {
+            "additionalProperties": false,
             "properties": {
-                "DomainName": {
-                    "type": "string"
-                },
-                "DomainNameServers": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainNameServers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetbiosNameServers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetbiosNodeType": {
+                            "type": "number"
+                        },
+                        "NtpServers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "NetbiosNameServers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "NetbiosNodeType": {
-                    "type": "number"
-                },
-                "NtpServers": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::EC2::EIP": {
-            "properties": {
-                "Domain": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::EC2::EIPAssociation": {
-            "properties": {
-                "AllocationId": {
-                    "type": "string"
-                },
-                "EIP": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "NetworkInterfaceId": {
-                    "type": "string"
-                },
-                "PrivateIpAddress": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::EC2::EgressOnlyInternetGateway": {
-            "properties": {
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::DHCPOptions"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "VpcId"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::EIP": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Domain": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::EIP"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::EIPAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocationId": {
+                            "type": "string"
+                        },
+                        "EIP": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        },
+                        "PrivateIpAddress": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::EIPAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::EgressOnlyInternetGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::EgressOnlyInternetGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::FlowLog": {
+            "additionalProperties": false,
             "properties": {
-                "DeliverLogsPermissionArn": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeliverLogsPermissionArn": {
+                            "type": "string"
+                        },
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "TrafficType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeliverLogsPermissionArn",
+                        "LogGroupName",
+                        "ResourceId",
+                        "ResourceType",
+                        "TrafficType"
+                    ],
+                    "type": "object"
                 },
-                "LogGroupName": {
-                    "type": "string"
-                },
-                "ResourceId": {
-                    "type": "string"
-                },
-                "ResourceType": {
-                    "type": "string"
-                },
-                "TrafficType": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::FlowLog"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DeliverLogsPermissionArn",
-                "LogGroupName",
-                "ResourceId",
-                "ResourceType",
-                "TrafficType"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::Host": {
+            "additionalProperties": false,
             "properties": {
-                "AutoPlacement": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoPlacement": {
+                            "type": "string"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AvailabilityZone",
+                        "InstanceType"
+                    ],
+                    "type": "object"
                 },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "InstanceType": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Host"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "AvailabilityZone",
-                "InstanceType"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::Instance": {
+            "additionalProperties": false,
             "properties": {
-                "AdditionalInfo": {
-                    "type": "string"
-                },
-                "Affinity": {
-                    "type": "string"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "BlockDeviceMappings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::Instance.BlockDeviceMapping"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdditionalInfo": {
+                            "type": "string"
+                        },
+                        "Affinity": {
+                            "type": "string"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "BlockDeviceMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.BlockDeviceMapping"
+                            },
+                            "type": "array"
+                        },
+                        "DisableApiTermination": {
+                            "type": "boolean"
+                        },
+                        "EbsOptimized": {
+                            "type": "boolean"
+                        },
+                        "HostId": {
+                            "type": "string"
+                        },
+                        "IamInstanceProfile": {
+                            "type": "string"
+                        },
+                        "ImageId": {
+                            "type": "string"
+                        },
+                        "InstanceInitiatedShutdownBehavior": {
+                            "type": "string"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "Ipv6AddressCount": {
+                            "type": "number"
+                        },
+                        "Ipv6Addresses": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.InstanceIpv6Address"
+                            },
+                            "type": "array"
+                        },
+                        "KernelId": {
+                            "type": "string"
+                        },
+                        "KeyName": {
+                            "type": "string"
+                        },
+                        "Monitoring": {
+                            "type": "boolean"
+                        },
+                        "NetworkInterfaces": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.NetworkInterface"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementGroupName": {
+                            "type": "string"
+                        },
+                        "PrivateIpAddress": {
+                            "type": "string"
+                        },
+                        "RamdiskId": {
+                            "type": "string"
+                        },
+                        "SecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SourceDestCheck": {
+                            "type": "boolean"
+                        },
+                        "SsmAssociations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.SsmAssociation"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Tenancy": {
+                            "type": "string"
+                        },
+                        "UserData": {
+                            "type": "string"
+                        },
+                        "Volumes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.Volume"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ImageId"
+                    ],
+                    "type": "object"
                 },
-                "DisableApiTermination": {
-                    "type": "boolean"
-                },
-                "EbsOptimized": {
-                    "type": "boolean"
-                },
-                "HostId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Instance"
+                    ],
                     "type": "string"
-                },
-                "IamInstanceProfile": {
-                    "type": "string"
-                },
-                "ImageId": {
-                    "type": "string"
-                },
-                "InstanceInitiatedShutdownBehavior": {
-                    "type": "string"
-                },
-                "InstanceType": {
-                    "type": "string"
-                },
-                "Ipv6AddressCount": {
-                    "type": "number"
-                },
-                "Ipv6Addresses": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::Instance.InstanceIpv6Address"
-                    },
-                    "type": "array"
-                },
-                "KernelId": {
-                    "type": "string"
-                },
-                "KeyName": {
-                    "type": "string"
-                },
-                "Monitoring": {
-                    "type": "boolean"
-                },
-                "NetworkInterfaces": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::Instance.NetworkInterface"
-                    },
-                    "type": "array"
-                },
-                "PlacementGroupName": {
-                    "type": "string"
-                },
-                "PrivateIpAddress": {
-                    "type": "string"
-                },
-                "RamdiskId": {
-                    "type": "string"
-                },
-                "SecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SecurityGroups": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SourceDestCheck": {
-                    "type": "boolean"
-                },
-                "SsmAssociations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::Instance.SsmAssociation"
-                    },
-                    "type": "array"
-                },
-                "SubnetId": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "Tenancy": {
-                    "type": "string"
-                },
-                "UserData": {
-                    "type": "string"
-                },
-                "Volumes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::Instance.Volume"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "ImageId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::Instance.AssociationParameter": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -4913,6 +6319,7 @@
             "type": "object"
         },
         "AWS::EC2::Instance.BlockDeviceMapping": {
+            "additionalProperties": false,
             "properties": {
                 "DeviceName": {
                     "type": "string"
@@ -4933,6 +6340,7 @@
             "type": "object"
         },
         "AWS::EC2::Instance.Ebs": {
+            "additionalProperties": false,
             "properties": {
                 "DeleteOnTermination": {
                     "type": "boolean"
@@ -4956,6 +6364,7 @@
             "type": "object"
         },
         "AWS::EC2::Instance.InstanceIpv6Address": {
+            "additionalProperties": false,
             "properties": {
                 "Ipv6Address": {
                     "type": "string"
@@ -4967,6 +6376,7 @@
             "type": "object"
         },
         "AWS::EC2::Instance.NetworkInterface": {
+            "additionalProperties": false,
             "properties": {
                 "AssociatePublicIpAddress": {
                     "type": "boolean"
@@ -5020,10 +6430,12 @@
             "type": "object"
         },
         "AWS::EC2::Instance.NoDevice": {
+            "additionalProperties": false,
             "properties": {},
             "type": "object"
         },
         "AWS::EC2::Instance.PrivateIpAddressSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Primary": {
                     "type": "boolean"
@@ -5039,6 +6451,7 @@
             "type": "object"
         },
         "AWS::EC2::Instance.SsmAssociation": {
+            "additionalProperties": false,
             "properties": {
                 "AssociationParameters": {
                     "items": {
@@ -5056,6 +6469,7 @@
             "type": "object"
         },
         "AWS::EC2::Instance.Volume": {
+            "additionalProperties": false,
             "properties": {
                 "Device": {
                     "type": "string"
@@ -5071,94 +6485,162 @@
             "type": "object"
         },
         "AWS::EC2::InternetGateway": {
+            "additionalProperties": false,
             "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::EC2::NatGateway": {
-            "properties": {
-                "AllocationId": {
-                    "type": "string"
+                    "type": "object"
                 },
-                "SubnetId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::InternetGateway"
+                    ],
                     "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "AllocationId",
-                "SubnetId"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NatGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocationId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "AllocationId",
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NatGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::NetworkAcl": {
+            "additionalProperties": false,
             "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkAcl"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::NetworkAclEntry": {
+            "additionalProperties": false,
             "properties": {
-                "CidrBlock": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "Egress": {
+                            "type": "boolean"
+                        },
+                        "Icmp": {
+                            "$ref": "#/definitions/AWS::EC2::NetworkAclEntry.Icmp"
+                        },
+                        "Ipv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "NetworkAclId": {
+                            "type": "string"
+                        },
+                        "PortRange": {
+                            "$ref": "#/definitions/AWS::EC2::NetworkAclEntry.PortRange"
+                        },
+                        "Protocol": {
+                            "type": "number"
+                        },
+                        "RuleAction": {
+                            "type": "string"
+                        },
+                        "RuleNumber": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "CidrBlock",
+                        "NetworkAclId",
+                        "Protocol",
+                        "RuleAction",
+                        "RuleNumber"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkAclEntry"
+                    ],
                     "type": "string"
-                },
-                "Egress": {
-                    "type": "boolean"
-                },
-                "Icmp": {
-                    "$ref": "#/definitions/AWS::EC2::NetworkAclEntry.Icmp"
-                },
-                "Ipv6CidrBlock": {
-                    "type": "string"
-                },
-                "NetworkAclId": {
-                    "type": "string"
-                },
-                "PortRange": {
-                    "$ref": "#/definitions/AWS::EC2::NetworkAclEntry.PortRange"
-                },
-                "Protocol": {
-                    "type": "number"
-                },
-                "RuleAction": {
-                    "type": "string"
-                },
-                "RuleNumber": {
-                    "type": "number"
                 }
             },
             "required": [
-                "CidrBlock",
-                "NetworkAclId",
-                "Protocol",
-                "RuleAction",
-                "RuleNumber"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::NetworkAclEntry.Icmp": {
+            "additionalProperties": false,
             "properties": {
                 "Code": {
                     "type": "number"
@@ -5170,6 +6652,7 @@
             "type": "object"
         },
         "AWS::EC2::NetworkAclEntry.PortRange": {
+            "additionalProperties": false,
             "properties": {
                 "From": {
                     "type": "number"
@@ -5181,56 +6664,74 @@
             "type": "object"
         },
         "AWS::EC2::NetworkInterface": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "GroupSet": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "GroupSet": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "InterfaceType": {
+                            "type": "string"
+                        },
+                        "Ipv6AddressCount": {
+                            "type": "number"
+                        },
+                        "Ipv6Addresses": {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInterface.InstanceIpv6Address"
+                        },
+                        "PrivateIpAddress": {
+                            "type": "string"
+                        },
+                        "PrivateIpAddresses": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::NetworkInterface.PrivateIpAddressSpecification"
+                            },
+                            "type": "array"
+                        },
+                        "SecondaryPrivateIpAddressCount": {
+                            "type": "number"
+                        },
+                        "SourceDestCheck": {
+                            "type": "boolean"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "SubnetId"
+                    ],
+                    "type": "object"
                 },
-                "InterfaceType": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInterface"
+                    ],
                     "type": "string"
-                },
-                "Ipv6AddressCount": {
-                    "type": "number"
-                },
-                "Ipv6Addresses": {
-                    "$ref": "#/definitions/AWS::EC2::NetworkInterface.InstanceIpv6Address"
-                },
-                "PrivateIpAddress": {
-                    "type": "string"
-                },
-                "PrivateIpAddresses": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::NetworkInterface.PrivateIpAddressSpecification"
-                    },
-                    "type": "array"
-                },
-                "SecondaryPrivateIpAddressCount": {
-                    "type": "number"
-                },
-                "SourceDestCheck": {
-                    "type": "boolean"
-                },
-                "SubnetId": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "SubnetId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::NetworkInterface.InstanceIpv6Address": {
+            "additionalProperties": false,
             "properties": {
                 "Ipv6Address": {
                     "type": "string"
@@ -5242,6 +6743,7 @@
             "type": "object"
         },
         "AWS::EC2::NetworkInterface.PrivateIpAddressSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Primary": {
                     "type": "boolean"
@@ -5257,139 +6759,241 @@
             "type": "object"
         },
         "AWS::EC2::NetworkInterfaceAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "DeleteOnTermination": {
-                    "type": "boolean"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeleteOnTermination": {
+                            "type": "boolean"
+                        },
+                        "DeviceIndex": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeviceIndex",
+                        "InstanceId",
+                        "NetworkInterfaceId"
+                    ],
+                    "type": "object"
                 },
-                "DeviceIndex": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "NetworkInterfaceId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInterfaceAttachment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DeviceIndex",
-                "InstanceId",
-                "NetworkInterfaceId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::NetworkInterfacePermission": {
+            "additionalProperties": false,
             "properties": {
-                "AwsAccountId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AwsAccountId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        },
+                        "Permission": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AwsAccountId",
+                        "NetworkInterfaceId",
+                        "Permission"
+                    ],
+                    "type": "object"
                 },
-                "NetworkInterfaceId": {
-                    "type": "string"
-                },
-                "Permission": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInterfacePermission"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "AwsAccountId",
-                "NetworkInterfaceId",
-                "Permission"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::PlacementGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Strategy": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::EC2::Route": {
-            "properties": {
-                "DestinationCidrBlock": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Strategy": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
-                "DestinationIpv6CidrBlock": {
-                    "type": "string"
-                },
-                "GatewayId": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "NatGatewayId": {
-                    "type": "string"
-                },
-                "NetworkInterfaceId": {
-                    "type": "string"
-                },
-                "RouteTableId": {
-                    "type": "string"
-                },
-                "VpcPeeringConnectionId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::PlacementGroup"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "RouteTableId"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Route": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "DestinationIpv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "GatewayId": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "NatGatewayId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        },
+                        "RouteTableId": {
+                            "type": "string"
+                        },
+                        "VpcPeeringConnectionId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RouteTableId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Route"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::RouteTable": {
+            "additionalProperties": false,
             "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::RouteTable"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SecurityGroup": {
+            "additionalProperties": false,
             "properties": {
-                "GroupDescription": {
-                    "type": "string"
-                },
-                "GroupName": {
-                    "type": "string"
-                },
-                "SecurityGroupEgress": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::SecurityGroup.Egress"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupDescription": {
+                            "type": "string"
+                        },
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "SecurityGroupEgress": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::SecurityGroup.Egress"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityGroupIngress": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::SecurityGroup.Ingress"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "GroupDescription"
+                    ],
+                    "type": "object"
                 },
-                "SecurityGroupIngress": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EC2::SecurityGroup.Ingress"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SecurityGroup"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "GroupDescription"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SecurityGroup.Egress": {
+            "additionalProperties": false,
             "properties": {
                 "CidrIp": {
                     "type": "string"
@@ -5419,6 +7023,7 @@
             "type": "object"
         },
         "AWS::EC2::SecurityGroup.Ingress": {
+            "additionalProperties": false,
             "properties": {
                 "CidrIp": {
                     "type": "string"
@@ -5451,88 +7056,140 @@
             "type": "object"
         },
         "AWS::EC2::SecurityGroupEgress": {
+            "additionalProperties": false,
             "properties": {
-                "CidrIp": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrIp": {
+                            "type": "string"
+                        },
+                        "CidrIpv6": {
+                            "type": "string"
+                        },
+                        "DestinationPrefixListId": {
+                            "type": "string"
+                        },
+                        "DestinationSecurityGroupId": {
+                            "type": "string"
+                        },
+                        "FromPort": {
+                            "type": "number"
+                        },
+                        "GroupId": {
+                            "type": "string"
+                        },
+                        "IpProtocol": {
+                            "type": "string"
+                        },
+                        "ToPort": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "GroupId",
+                        "IpProtocol"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SecurityGroupEgress"
+                    ],
                     "type": "string"
-                },
-                "CidrIpv6": {
-                    "type": "string"
-                },
-                "DestinationPrefixListId": {
-                    "type": "string"
-                },
-                "DestinationSecurityGroupId": {
-                    "type": "string"
-                },
-                "FromPort": {
-                    "type": "number"
-                },
-                "GroupId": {
-                    "type": "string"
-                },
-                "IpProtocol": {
-                    "type": "string"
-                },
-                "ToPort": {
-                    "type": "number"
                 }
             },
             "required": [
-                "GroupId",
-                "IpProtocol"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SecurityGroupIngress": {
+            "additionalProperties": false,
             "properties": {
-                "CidrIp": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrIp": {
+                            "type": "string"
+                        },
+                        "CidrIpv6": {
+                            "type": "string"
+                        },
+                        "FromPort": {
+                            "type": "number"
+                        },
+                        "GroupId": {
+                            "type": "string"
+                        },
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "IpProtocol": {
+                            "type": "string"
+                        },
+                        "SourceSecurityGroupId": {
+                            "type": "string"
+                        },
+                        "SourceSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "SourceSecurityGroupOwnerId": {
+                            "type": "string"
+                        },
+                        "ToPort": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "IpProtocol"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SecurityGroupIngress"
+                    ],
                     "type": "string"
-                },
-                "CidrIpv6": {
-                    "type": "string"
-                },
-                "FromPort": {
-                    "type": "number"
-                },
-                "GroupId": {
-                    "type": "string"
-                },
-                "GroupName": {
-                    "type": "string"
-                },
-                "IpProtocol": {
-                    "type": "string"
-                },
-                "SourceSecurityGroupId": {
-                    "type": "string"
-                },
-                "SourceSecurityGroupName": {
-                    "type": "string"
-                },
-                "SourceSecurityGroupOwnerId": {
-                    "type": "string"
-                },
-                "ToPort": {
-                    "type": "number"
                 }
             },
             "required": [
-                "IpProtocol"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SpotFleet": {
+            "additionalProperties": false,
             "properties": {
-                "SpotFleetRequestConfigData": {
-                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetRequestConfigData"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "SpotFleetRequestConfigData": {
+                            "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetRequestConfigData"
+                        }
+                    },
+                    "required": [
+                        "SpotFleetRequestConfigData"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SpotFleet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "SpotFleetRequestConfigData"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SpotFleet.BlockDeviceMapping": {
+            "additionalProperties": false,
             "properties": {
                 "DeviceName": {
                     "type": "string"
@@ -5553,6 +7210,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.EbsBlockDevice": {
+            "additionalProperties": false,
             "properties": {
                 "DeleteOnTermination": {
                     "type": "boolean"
@@ -5576,6 +7234,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.GroupIdentifier": {
+            "additionalProperties": false,
             "properties": {
                 "GroupId": {
                     "type": "string"
@@ -5587,6 +7246,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.IamInstanceProfileSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Arn": {
                     "type": "string"
@@ -5595,6 +7255,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.InstanceIpv6Address": {
+            "additionalProperties": false,
             "properties": {
                 "Ipv6Address": {
                     "type": "string"
@@ -5606,6 +7267,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.InstanceNetworkInterfaceSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "AssociatePublicIpAddress": {
                     "type": "boolean"
@@ -5653,6 +7315,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.PrivateIpAddressSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Primary": {
                     "type": "boolean"
@@ -5667,6 +7330,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetLaunchSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "BlockDeviceMappings": {
                     "items": {
@@ -5733,6 +7397,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetMonitoring": {
+            "additionalProperties": false,
             "properties": {
                 "Enabled": {
                     "type": "boolean"
@@ -5741,6 +7406,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetRequestConfigData": {
+            "additionalProperties": false,
             "properties": {
                 "AllocationStrategy": {
                     "type": "string"
@@ -5788,6 +7454,7 @@
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotPlacement": {
+            "additionalProperties": false,
             "properties": {
                 "AvailabilityZone": {
                     "type": "string"
@@ -5799,282 +7466,673 @@
             "type": "object"
         },
         "AWS::EC2::Subnet": {
+            "additionalProperties": false,
             "properties": {
-                "AssignIpv6AddressOnCreation": {
-                    "type": "boolean"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "CidrBlock": {
-                    "type": "string"
-                },
-                "Ipv6CidrBlock": {
-                    "type": "string"
-                },
-                "MapPublicIpOnLaunch": {
-                    "type": "boolean"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AssignIpv6AddressOnCreation": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "Ipv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "MapPublicIpOnLaunch": {
+                            "type": "boolean"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "CidrBlock",
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Subnet"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "CidrBlock",
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SubnetCidrBlock": {
+            "additionalProperties": false,
             "properties": {
-                "Ipv6CidrBlock": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Ipv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Ipv6CidrBlock",
+                        "SubnetId"
+                    ],
+                    "type": "object"
                 },
-                "SubnetId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SubnetCidrBlock"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Ipv6CidrBlock",
-                "SubnetId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SubnetNetworkAclAssociation": {
+            "additionalProperties": false,
             "properties": {
-                "NetworkAclId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "NetworkAclId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "NetworkAclId",
+                        "SubnetId"
+                    ],
+                    "type": "object"
                 },
-                "SubnetId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SubnetNetworkAclAssociation"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "NetworkAclId",
-                "SubnetId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::SubnetRouteTableAssociation": {
+            "additionalProperties": false,
             "properties": {
-                "RouteTableId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RouteTableId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RouteTableId",
+                        "SubnetId"
+                    ],
+                    "type": "object"
                 },
-                "SubnetId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SubnetRouteTableAssociation"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "RouteTableId",
-                "SubnetId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::TrunkInterfaceAssociation": {
+            "additionalProperties": false,
             "properties": {
-                "BranchInterfaceId": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BranchInterfaceId": {
+                            "type": "string"
+                        },
+                        "GREKey": {
+                            "type": "number"
+                        },
+                        "TrunkInterfaceId": {
+                            "type": "string"
+                        },
+                        "VLANId": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "BranchInterfaceId",
+                        "TrunkInterfaceId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::TrunkInterfaceAssociation"
+                    ],
                     "type": "string"
-                },
-                "GREKey": {
-                    "type": "number"
-                },
-                "TrunkInterfaceId": {
-                    "type": "string"
-                },
-                "VLANId": {
-                    "type": "number"
                 }
             },
             "required": [
-                "BranchInterfaceId",
-                "TrunkInterfaceId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPC": {
+            "additionalProperties": false,
             "properties": {
-                "CidrBlock": {
-                    "type": "string"
-                },
-                "EnableDnsHostnames": {
-                    "type": "boolean"
-                },
-                "EnableDnsSupport": {
-                    "type": "boolean"
-                },
-                "InstanceTenancy": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "EnableDnsHostnames": {
+                            "type": "boolean"
+                        },
+                        "EnableDnsSupport": {
+                            "type": "boolean"
+                        },
+                        "InstanceTenancy": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "CidrBlock"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPC"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "CidrBlock"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPCCidrBlock": {
+            "additionalProperties": false,
             "properties": {
-                "AmazonProvidedIpv6CidrBlock": {
-                    "type": "boolean"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AmazonProvidedIpv6CidrBlock": {
+                            "type": "boolean"
+                        },
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "CidrBlock": {
-                    "type": "string"
-                },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCCidrBlock"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPCDHCPOptionsAssociation": {
+            "additionalProperties": false,
             "properties": {
-                "DhcpOptionsId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DhcpOptionsId": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DhcpOptionsId",
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCDHCPOptionsAssociation"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DhcpOptionsId",
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPCEndpoint": {
+            "additionalProperties": false,
             "properties": {
-                "PolicyDocument": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "RouteTableIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ServiceName": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ServiceName",
+                        "VpcId"
+                    ],
                     "type": "object"
                 },
-                "RouteTableIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "ServiceName": {
-                    "type": "string"
-                },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCEndpoint"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ServiceName",
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPCGatewayAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "InternetGatewayId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InternetGatewayId": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        },
+                        "VpnGatewayId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "VpcId": {
-                    "type": "string"
-                },
-                "VpnGatewayId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCGatewayAttachment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPCPeeringConnection": {
+            "additionalProperties": false,
             "properties": {
-                "PeerOwnerId": {
-                    "type": "string"
-                },
-                "PeerRoleArn": {
-                    "type": "string"
-                },
-                "PeerVpcId": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PeerOwnerId": {
+                            "type": "string"
+                        },
+                        "PeerRoleArn": {
+                            "type": "string"
+                        },
+                        "PeerVpcId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "PeerVpcId",
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCPeeringConnection"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "PeerVpcId",
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPNConnection": {
+            "additionalProperties": false,
             "properties": {
-                "CustomerGatewayId": {
-                    "type": "string"
-                },
-                "StaticRoutesOnly": {
-                    "type": "boolean"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CustomerGatewayId": {
+                            "type": "string"
+                        },
+                        "StaticRoutesOnly": {
+                            "type": "boolean"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "VpnGatewayId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "CustomerGatewayId",
+                        "Type",
+                        "VpnGatewayId"
+                    ],
+                    "type": "object"
                 },
                 "Type": {
-                    "type": "string"
-                },
-                "VpnGatewayId": {
+                    "enum": [
+                        "AWS::EC2::VPNConnection"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "CustomerGatewayId",
                 "Type",
-                "VpnGatewayId"
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPNConnectionRoute": {
+            "additionalProperties": false,
             "properties": {
-                "DestinationCidrBlock": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "VpnConnectionId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationCidrBlock",
+                        "VpnConnectionId"
+                    ],
+                    "type": "object"
                 },
-                "VpnConnectionId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNConnectionRoute"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DestinationCidrBlock",
-                "VpnConnectionId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EC2::VPNGateway": {
+            "additionalProperties": false,
             "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Type"
+                    ],
+                    "type": "object"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPNGatewayRoutePropagation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RouteTableIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "VpnGatewayId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RouteTableIds",
+                        "VpnGatewayId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNGatewayRoutePropagation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Volume": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoEnableIO": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "Encrypted": {
+                            "type": "boolean"
+                        },
+                        "Iops": {
+                            "type": "number"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "number"
+                        },
+                        "SnapshotId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VolumeType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AvailabilityZone"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Volume"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VolumeAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Device": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "VolumeId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Device",
+                        "InstanceId",
+                        "VolumeId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VolumeAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECR::Repository": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "RepositoryPolicyText": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECR::Repository"
+                    ],
                     "type": "string"
                 }
             },
@@ -6083,145 +8141,93 @@
             ],
             "type": "object"
         },
-        "AWS::EC2::VPNGatewayRoutePropagation": {
-            "properties": {
-                "RouteTableIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "VpnGatewayId": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "RouteTableIds",
-                "VpnGatewayId"
-            ],
-            "type": "object"
-        },
-        "AWS::EC2::Volume": {
-            "properties": {
-                "AutoEnableIO": {
-                    "type": "boolean"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "Encrypted": {
-                    "type": "boolean"
-                },
-                "Iops": {
-                    "type": "number"
-                },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "Size": {
-                    "type": "number"
-                },
-                "SnapshotId": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "VolumeType": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "AvailabilityZone"
-            ],
-            "type": "object"
-        },
-        "AWS::EC2::VolumeAttachment": {
-            "properties": {
-                "Device": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "VolumeId": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "Device",
-                "InstanceId",
-                "VolumeId"
-            ],
-            "type": "object"
-        },
-        "AWS::ECR::Repository": {
-            "properties": {
-                "RepositoryName": {
-                    "type": "string"
-                },
-                "RepositoryPolicyText": {
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
         "AWS::ECS::Cluster": {
+            "additionalProperties": false,
             "properties": {
-                "ClusterName": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ClusterName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECS::Cluster"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ECS::Service": {
+            "additionalProperties": false,
             "properties": {
-                "Cluster": {
-                    "type": "string"
-                },
-                "DeploymentConfiguration": {
-                    "$ref": "#/definitions/AWS::ECS::Service.DeploymentConfiguration"
-                },
-                "DesiredCount": {
-                    "type": "number"
-                },
-                "LoadBalancers": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ECS::Service.LoadBalancer"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Cluster": {
+                            "type": "string"
+                        },
+                        "DeploymentConfiguration": {
+                            "$ref": "#/definitions/AWS::ECS::Service.DeploymentConfiguration"
+                        },
+                        "DesiredCount": {
+                            "type": "number"
+                        },
+                        "LoadBalancers": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::Service.LoadBalancer"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::Service.PlacementConstraint"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementStrategies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::Service.PlacementStrategy"
+                            },
+                            "type": "array"
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "ServiceName": {
+                            "type": "string"
+                        },
+                        "TaskDefinition": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "TaskDefinition"
+                    ],
+                    "type": "object"
                 },
-                "PlacementConstraints": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ECS::Service.PlacementConstraint"
-                    },
-                    "type": "array"
-                },
-                "PlacementStrategies": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ECS::Service.PlacementStrategy"
-                    },
-                    "type": "array"
-                },
-                "Role": {
-                    "type": "string"
-                },
-                "ServiceName": {
-                    "type": "string"
-                },
-                "TaskDefinition": {
+                "Type": {
+                    "enum": [
+                        "AWS::ECS::Service"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "TaskDefinition"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ECS::Service.DeploymentConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "MaximumPercent": {
                     "type": "number"
@@ -6233,6 +8239,7 @@
             "type": "object"
         },
         "AWS::ECS::Service.LoadBalancer": {
+            "additionalProperties": false,
             "properties": {
                 "ContainerName": {
                     "type": "string"
@@ -6253,6 +8260,7 @@
             "type": "object"
         },
         "AWS::ECS::Service.PlacementConstraint": {
+            "additionalProperties": false,
             "properties": {
                 "Expression": {
                     "type": "string"
@@ -6267,6 +8275,7 @@
             "type": "object"
         },
         "AWS::ECS::Service.PlacementStrategy": {
+            "additionalProperties": false,
             "properties": {
                 "Field": {
                     "type": "string"
@@ -6281,38 +8290,55 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition": {
+            "additionalProperties": false,
             "properties": {
-                "ContainerDefinitions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.ContainerDefinition"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContainerDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::TaskDefinition.ContainerDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "Family": {
+                            "type": "string"
+                        },
+                        "NetworkMode": {
+                            "type": "string"
+                        },
+                        "PlacementConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint"
+                            },
+                            "type": "array"
+                        },
+                        "TaskRoleArn": {
+                            "type": "string"
+                        },
+                        "Volumes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::TaskDefinition.Volume"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "Family": {
+                "Type": {
+                    "enum": [
+                        "AWS::ECS::TaskDefinition"
+                    ],
                     "type": "string"
-                },
-                "NetworkMode": {
-                    "type": "string"
-                },
-                "PlacementConstraints": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint"
-                    },
-                    "type": "array"
-                },
-                "TaskRoleArn": {
-                    "type": "string"
-                },
-                "Volumes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.Volume"
-                    },
-                    "type": "array"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.ContainerDefinition": {
+            "additionalProperties": false,
             "properties": {
                 "Command": {
                     "items": {
@@ -6339,6 +8365,7 @@
                     "type": "array"
                 },
                 "DockerLabels": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -6437,6 +8464,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.HostEntry": {
+            "additionalProperties": false,
             "properties": {
                 "Hostname": {
                     "type": "string"
@@ -6452,6 +8480,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.HostVolumeProperties": {
+            "additionalProperties": false,
             "properties": {
                 "SourcePath": {
                     "type": "string"
@@ -6460,6 +8489,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.KeyValuePair": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -6471,11 +8501,13 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.LogConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "LogDriver": {
                     "type": "string"
                 },
                 "Options": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -6490,6 +8522,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.MountPoint": {
+            "additionalProperties": false,
             "properties": {
                 "ContainerPath": {
                     "type": "string"
@@ -6504,6 +8537,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.PortMapping": {
+            "additionalProperties": false,
             "properties": {
                 "ContainerPort": {
                     "type": "number"
@@ -6518,6 +8552,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint": {
+            "additionalProperties": false,
             "properties": {
                 "Expression": {
                     "type": "string"
@@ -6532,6 +8567,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.Ulimit": {
+            "additionalProperties": false,
             "properties": {
                 "HardLimit": {
                     "type": "number"
@@ -6551,6 +8587,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.Volume": {
+            "additionalProperties": false,
             "properties": {
                 "Host": {
                     "$ref": "#/definitions/AWS::ECS::TaskDefinition.HostVolumeProperties"
@@ -6562,6 +8599,7 @@
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.VolumeFrom": {
+            "additionalProperties": false,
             "properties": {
                 "ReadOnly": {
                     "type": "boolean"
@@ -6573,26 +8611,43 @@
             "type": "object"
         },
         "AWS::EFS::FileSystem": {
+            "additionalProperties": false,
             "properties": {
-                "Encrypted": {
-                    "type": "boolean"
-                },
-                "FileSystemTags": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EFS::FileSystem.ElasticFileSystemTag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Encrypted": {
+                            "type": "boolean"
+                        },
+                        "FileSystemTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EFS::FileSystem.ElasticFileSystemTag"
+                            },
+                            "type": "array"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "PerformanceMode": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "PerformanceMode": {
+                "Type": {
+                    "enum": [
+                        "AWS::EFS::FileSystem"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::EFS::FileSystem.ElasticFileSystemTag": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -6608,101 +8663,137 @@
             "type": "object"
         },
         "AWS::EFS::MountTarget": {
+            "additionalProperties": false,
             "properties": {
-                "FileSystemId": {
-                    "type": "string"
-                },
-                "IpAddress": {
-                    "type": "string"
-                },
-                "SecurityGroups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FileSystemId": {
+                            "type": "string"
+                        },
+                        "IpAddress": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "FileSystemId",
+                        "SecurityGroups",
+                        "SubnetId"
+                    ],
+                    "type": "object"
                 },
-                "SubnetId": {
+                "Type": {
+                    "enum": [
+                        "AWS::EFS::MountTarget"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "FileSystemId",
-                "SecurityGroups",
-                "SubnetId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EMR::Cluster": {
+            "additionalProperties": false,
             "properties": {
-                "AdditionalInfo": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdditionalInfo": {
+                            "type": "object"
+                        },
+                        "Applications": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::Cluster.Application"
+                            },
+                            "type": "array"
+                        },
+                        "AutoScalingRole": {
+                            "type": "string"
+                        },
+                        "BootstrapActions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::Cluster.BootstrapActionConfig"
+                            },
+                            "type": "array"
+                        },
+                        "Configurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::Cluster.Configuration"
+                            },
+                            "type": "array"
+                        },
+                        "Instances": {
+                            "$ref": "#/definitions/AWS::EMR::Cluster.JobFlowInstancesConfig"
+                        },
+                        "JobFlowRole": {
+                            "type": "string"
+                        },
+                        "LogUri": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ReleaseLabel": {
+                            "type": "string"
+                        },
+                        "ScaleDownBehavior": {
+                            "type": "string"
+                        },
+                        "SecurityConfiguration": {
+                            "type": "string"
+                        },
+                        "ServiceRole": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VisibleToAllUsers": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "Instances",
+                        "JobFlowRole",
+                        "Name",
+                        "ServiceRole"
+                    ],
                     "type": "object"
                 },
-                "Applications": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EMR::Cluster.Application"
-                    },
-                    "type": "array"
-                },
-                "AutoScalingRole": {
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::Cluster"
+                    ],
                     "type": "string"
-                },
-                "BootstrapActions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EMR::Cluster.BootstrapActionConfig"
-                    },
-                    "type": "array"
-                },
-                "Configurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EMR::Cluster.Configuration"
-                    },
-                    "type": "array"
-                },
-                "Instances": {
-                    "$ref": "#/definitions/AWS::EMR::Cluster.JobFlowInstancesConfig"
-                },
-                "JobFlowRole": {
-                    "type": "string"
-                },
-                "LogUri": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "ReleaseLabel": {
-                    "type": "string"
-                },
-                "ScaleDownBehavior": {
-                    "type": "string"
-                },
-                "SecurityConfiguration": {
-                    "type": "string"
-                },
-                "ServiceRole": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "VisibleToAllUsers": {
-                    "type": "boolean"
                 }
             },
             "required": [
-                "Instances",
-                "JobFlowRole",
-                "Name",
-                "ServiceRole"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EMR::Cluster.Application": {
+            "additionalProperties": false,
             "properties": {
                 "AdditionalInfo": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -6726,6 +8817,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.AutoScalingPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "Constraints": {
                     "$ref": "#/definitions/AWS::EMR::Cluster.ScalingConstraints"
@@ -6744,6 +8836,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.BootstrapActionConfig": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -6759,6 +8852,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.CloudWatchAlarmDefinition": {
+            "additionalProperties": false,
             "properties": {
                 "ComparisonOperator": {
                     "type": "string"
@@ -6800,11 +8894,13 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.Configuration": {
+            "additionalProperties": false,
             "properties": {
                 "Classification": {
                     "type": "string"
                 },
                 "ConfigurationProperties": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -6822,6 +8918,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.EbsBlockDeviceConfig": {
+            "additionalProperties": false,
             "properties": {
                 "VolumeSpecification": {
                     "$ref": "#/definitions/AWS::EMR::Cluster.VolumeSpecification"
@@ -6836,6 +8933,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.EbsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "EbsBlockDeviceConfigs": {
                     "items": {
@@ -6850,6 +8948,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.InstanceFleetConfig": {
+            "additionalProperties": false,
             "properties": {
                 "InstanceTypeConfigs": {
                     "items": {
@@ -6873,6 +8972,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.InstanceFleetProvisioningSpecifications": {
+            "additionalProperties": false,
             "properties": {
                 "SpotSpecification": {
                     "$ref": "#/definitions/AWS::EMR::Cluster.SpotProvisioningSpecification"
@@ -6884,6 +8984,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.InstanceGroupConfig": {
+            "additionalProperties": false,
             "properties": {
                 "AutoScalingPolicy": {
                     "$ref": "#/definitions/AWS::EMR::Cluster.AutoScalingPolicy"
@@ -6920,6 +9021,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.InstanceTypeConfig": {
+            "additionalProperties": false,
             "properties": {
                 "BidPrice": {
                     "type": "string"
@@ -6949,6 +9051,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.JobFlowInstancesConfig": {
+            "additionalProperties": false,
             "properties": {
                 "AdditionalMasterSecurityGroups": {
                     "items": {
@@ -7002,6 +9105,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.MetricDimension": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -7017,6 +9121,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.PlacementType": {
+            "additionalProperties": false,
             "properties": {
                 "AvailabilityZone": {
                     "type": "string"
@@ -7028,6 +9133,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.ScalingAction": {
+            "additionalProperties": false,
             "properties": {
                 "Market": {
                     "type": "string"
@@ -7042,6 +9148,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.ScalingConstraints": {
+            "additionalProperties": false,
             "properties": {
                 "MaxCapacity": {
                     "type": "number"
@@ -7057,6 +9164,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.ScalingRule": {
+            "additionalProperties": false,
             "properties": {
                 "Action": {
                     "$ref": "#/definitions/AWS::EMR::Cluster.ScalingAction"
@@ -7079,6 +9187,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.ScalingTrigger": {
+            "additionalProperties": false,
             "properties": {
                 "CloudWatchAlarmDefinition": {
                     "$ref": "#/definitions/AWS::EMR::Cluster.CloudWatchAlarmDefinition"
@@ -7090,6 +9199,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.ScriptBootstrapActionConfig": {
+            "additionalProperties": false,
             "properties": {
                 "Args": {
                     "items": {
@@ -7107,6 +9217,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.SimpleScalingPolicyConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "AdjustmentType": {
                     "type": "string"
@@ -7124,6 +9235,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.SpotProvisioningSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "BlockDurationMinutes": {
                     "type": "number"
@@ -7142,6 +9254,7 @@
             "type": "object"
         },
         "AWS::EMR::Cluster.VolumeSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Iops": {
                     "type": "number"
@@ -7160,44 +9273,63 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig": {
+            "additionalProperties": false,
             "properties": {
-                "ClusterId": {
-                    "type": "string"
-                },
-                "InstanceFleetType": {
-                    "type": "string"
-                },
-                "InstanceTypeConfigs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.InstanceTypeConfig"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ClusterId": {
+                            "type": "string"
+                        },
+                        "InstanceFleetType": {
+                            "type": "string"
+                        },
+                        "InstanceTypeConfigs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.InstanceTypeConfig"
+                            },
+                            "type": "array"
+                        },
+                        "LaunchSpecifications": {
+                            "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.InstanceFleetProvisioningSpecifications"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "TargetOnDemandCapacity": {
+                            "type": "number"
+                        },
+                        "TargetSpotCapacity": {
+                            "type": "number"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ClusterId",
+                        "InstanceFleetType"
+                    ],
+                    "type": "object"
                 },
-                "LaunchSpecifications": {
-                    "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.InstanceFleetProvisioningSpecifications"
-                },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::InstanceFleetConfig"
+                    ],
                     "type": "string"
-                },
-                "TargetOnDemandCapacity": {
-                    "type": "number"
-                },
-                "TargetSpotCapacity": {
-                    "type": "number"
                 }
             },
             "required": [
-                "ClusterId",
-                "InstanceFleetType"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.Configuration": {
+            "additionalProperties": false,
             "properties": {
                 "Classification": {
                     "type": "string"
                 },
                 "ConfigurationProperties": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -7215,6 +9347,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.EbsBlockDeviceConfig": {
+            "additionalProperties": false,
             "properties": {
                 "VolumeSpecification": {
                     "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.VolumeSpecification"
@@ -7229,6 +9362,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.EbsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "EbsBlockDeviceConfigs": {
                     "items": {
@@ -7243,6 +9377,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.InstanceFleetProvisioningSpecifications": {
+            "additionalProperties": false,
             "properties": {
                 "SpotSpecification": {
                     "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.SpotProvisioningSpecification"
@@ -7254,6 +9389,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.InstanceTypeConfig": {
+            "additionalProperties": false,
             "properties": {
                 "BidPrice": {
                     "type": "string"
@@ -7283,6 +9419,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.SpotProvisioningSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "BlockDurationMinutes": {
                     "type": "number"
@@ -7301,6 +9438,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceFleetConfig.VolumeSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Iops": {
                     "type": "number"
@@ -7319,50 +9457,68 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig": {
+            "additionalProperties": false,
             "properties": {
-                "AutoScalingPolicy": {
-                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.AutoScalingPolicy"
-                },
-                "BidPrice": {
-                    "type": "string"
-                },
-                "Configurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.Configuration"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoScalingPolicy": {
+                            "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.AutoScalingPolicy"
+                        },
+                        "BidPrice": {
+                            "type": "string"
+                        },
+                        "Configurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.Configuration"
+                            },
+                            "type": "array"
+                        },
+                        "EbsConfiguration": {
+                            "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.EbsConfiguration"
+                        },
+                        "InstanceCount": {
+                            "type": "number"
+                        },
+                        "InstanceRole": {
+                            "type": "string"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "JobFlowId": {
+                            "type": "string"
+                        },
+                        "Market": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "InstanceCount",
+                        "InstanceRole",
+                        "InstanceType",
+                        "JobFlowId"
+                    ],
+                    "type": "object"
                 },
-                "EbsConfiguration": {
-                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.EbsConfiguration"
-                },
-                "InstanceCount": {
-                    "type": "number"
-                },
-                "InstanceRole": {
-                    "type": "string"
-                },
-                "InstanceType": {
-                    "type": "string"
-                },
-                "JobFlowId": {
-                    "type": "string"
-                },
-                "Market": {
-                    "type": "string"
-                },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::InstanceGroupConfig"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "InstanceCount",
-                "InstanceRole",
-                "InstanceType",
-                "JobFlowId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.AutoScalingPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "Constraints": {
                     "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.ScalingConstraints"
@@ -7381,6 +9537,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.CloudWatchAlarmDefinition": {
+            "additionalProperties": false,
             "properties": {
                 "ComparisonOperator": {
                     "type": "string"
@@ -7422,11 +9579,13 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.Configuration": {
+            "additionalProperties": false,
             "properties": {
                 "Classification": {
                     "type": "string"
                 },
                 "ConfigurationProperties": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -7444,6 +9603,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.EbsBlockDeviceConfig": {
+            "additionalProperties": false,
             "properties": {
                 "VolumeSpecification": {
                     "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.VolumeSpecification"
@@ -7458,6 +9618,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.EbsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "EbsBlockDeviceConfigs": {
                     "items": {
@@ -7472,6 +9633,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.MetricDimension": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -7487,6 +9649,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.ScalingAction": {
+            "additionalProperties": false,
             "properties": {
                 "Market": {
                     "type": "string"
@@ -7501,6 +9664,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.ScalingConstraints": {
+            "additionalProperties": false,
             "properties": {
                 "MaxCapacity": {
                     "type": "number"
@@ -7516,6 +9680,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.ScalingRule": {
+            "additionalProperties": false,
             "properties": {
                 "Action": {
                     "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.ScalingAction"
@@ -7538,6 +9703,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.ScalingTrigger": {
+            "additionalProperties": false,
             "properties": {
                 "CloudWatchAlarmDefinition": {
                     "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.CloudWatchAlarmDefinition"
@@ -7549,6 +9715,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.SimpleScalingPolicyConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "AdjustmentType": {
                     "type": "string"
@@ -7566,6 +9733,7 @@
             "type": "object"
         },
         "AWS::EMR::InstanceGroupConfig.VolumeSpecification": {
+            "additionalProperties": false,
             "properties": {
                 "Iops": {
                     "type": "number"
@@ -7584,43 +9752,78 @@
             "type": "object"
         },
         "AWS::EMR::SecurityConfiguration": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "SecurityConfiguration": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SecurityConfiguration": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "SecurityConfiguration"
+                    ],
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::SecurityConfiguration"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "SecurityConfiguration"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EMR::Step": {
+            "additionalProperties": false,
             "properties": {
-                "ActionOnFailure": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ActionOnFailure": {
+                            "type": "string"
+                        },
+                        "HadoopJarStep": {
+                            "$ref": "#/definitions/AWS::EMR::Step.HadoopJarStepConfig"
+                        },
+                        "JobFlowId": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ActionOnFailure",
+                        "HadoopJarStep",
+                        "JobFlowId",
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "HadoopJarStep": {
-                    "$ref": "#/definitions/AWS::EMR::Step.HadoopJarStepConfig"
-                },
-                "JobFlowId": {
-                    "type": "string"
-                },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::Step"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ActionOnFailure",
-                "HadoopJarStep",
-                "JobFlowId",
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::EMR::Step.HadoopJarStepConfig": {
+            "additionalProperties": false,
             "properties": {
                 "Args": {
                     "items": {
@@ -7647,6 +9850,7 @@
             "type": "object"
         },
         "AWS::EMR::Step.KeyValue": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -7658,221 +9862,274 @@
             "type": "object"
         },
         "AWS::ElastiCache::CacheCluster": {
+            "additionalProperties": false,
             "properties": {
-                "AZMode": {
-                    "type": "string"
-                },
-                "AutoMinorVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "CacheNodeType": {
-                    "type": "string"
-                },
-                "CacheParameterGroupName": {
-                    "type": "string"
-                },
-                "CacheSecurityGroupNames": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AZMode": {
+                            "type": "string"
+                        },
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "CacheNodeType": {
+                            "type": "string"
+                        },
+                        "CacheParameterGroupName": {
+                            "type": "string"
+                        },
+                        "CacheSecurityGroupNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "CacheSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "ClusterName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "NotificationTopicArn": {
+                            "type": "string"
+                        },
+                        "NumCacheNodes": {
+                            "type": "number"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredAvailabilityZone": {
+                            "type": "string"
+                        },
+                        "PreferredAvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "SnapshotArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnapshotName": {
+                            "type": "string"
+                        },
+                        "SnapshotRetentionLimit": {
+                            "type": "number"
+                        },
+                        "SnapshotWindow": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "CacheNodeType",
+                        "Engine",
+                        "NumCacheNodes"
+                    ],
+                    "type": "object"
                 },
-                "CacheSubnetGroupName": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::CacheCluster"
+                    ],
                     "type": "string"
-                },
-                "ClusterName": {
-                    "type": "string"
-                },
-                "Engine": {
-                    "type": "string"
-                },
-                "EngineVersion": {
-                    "type": "string"
-                },
-                "NotificationTopicArn": {
-                    "type": "string"
-                },
-                "NumCacheNodes": {
-                    "type": "number"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "PreferredAvailabilityZone": {
-                    "type": "string"
-                },
-                "PreferredAvailabilityZones": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "SnapshotArns": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SnapshotName": {
-                    "type": "string"
-                },
-                "SnapshotRetentionLimit": {
-                    "type": "number"
-                },
-                "SnapshotWindow": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "VpcSecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "CacheNodeType",
-                "Engine",
-                "NumCacheNodes"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElastiCache::ParameterGroup": {
+            "additionalProperties": false,
             "properties": {
-                "CacheParameterGroupFamily": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
                 "Properties": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheParameterGroupFamily": {
                             "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Properties": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
                         }
                     },
+                    "required": [
+                        "CacheParameterGroupFamily",
+                        "Description"
+                    ],
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::ParameterGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "CacheParameterGroupFamily",
-                "Description"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElastiCache::ReplicationGroup": {
+            "additionalProperties": false,
             "properties": {
-                "AutoMinorVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "AutomaticFailoverEnabled": {
-                    "type": "boolean"
-                },
-                "CacheNodeType": {
-                    "type": "string"
-                },
-                "CacheParameterGroupName": {
-                    "type": "string"
-                },
-                "CacheSecurityGroupNames": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutomaticFailoverEnabled": {
+                            "type": "boolean"
+                        },
+                        "CacheNodeType": {
+                            "type": "string"
+                        },
+                        "CacheParameterGroupName": {
+                            "type": "string"
+                        },
+                        "CacheSecurityGroupNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "CacheSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "NodeGroupConfiguration": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElastiCache::ReplicationGroup.NodeGroupConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationTopicArn": {
+                            "type": "string"
+                        },
+                        "NumCacheClusters": {
+                            "type": "number"
+                        },
+                        "NumNodeGroups": {
+                            "type": "number"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredCacheClusterAZs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PrimaryClusterId": {
+                            "type": "string"
+                        },
+                        "ReplicasPerNodeGroup": {
+                            "type": "number"
+                        },
+                        "ReplicationGroupDescription": {
+                            "type": "string"
+                        },
+                        "ReplicationGroupId": {
+                            "type": "string"
+                        },
+                        "SecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnapshotArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnapshotName": {
+                            "type": "string"
+                        },
+                        "SnapshotRetentionLimit": {
+                            "type": "number"
+                        },
+                        "SnapshotWindow": {
+                            "type": "string"
+                        },
+                        "SnapshottingClusterId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ReplicationGroupDescription"
+                    ],
+                    "type": "object"
                 },
-                "CacheSubnetGroupName": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::ReplicationGroup"
+                    ],
                     "type": "string"
-                },
-                "Engine": {
-                    "type": "string"
-                },
-                "EngineVersion": {
-                    "type": "string"
-                },
-                "NodeGroupConfiguration": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElastiCache::ReplicationGroup.NodeGroupConfiguration"
-                    },
-                    "type": "array"
-                },
-                "NotificationTopicArn": {
-                    "type": "string"
-                },
-                "NumCacheClusters": {
-                    "type": "number"
-                },
-                "NumNodeGroups": {
-                    "type": "number"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "PreferredCacheClusterAZs": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "PrimaryClusterId": {
-                    "type": "string"
-                },
-                "ReplicasPerNodeGroup": {
-                    "type": "number"
-                },
-                "ReplicationGroupDescription": {
-                    "type": "string"
-                },
-                "ReplicationGroupId": {
-                    "type": "string"
-                },
-                "SecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SnapshotArns": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SnapshotName": {
-                    "type": "string"
-                },
-                "SnapshotRetentionLimit": {
-                    "type": "number"
-                },
-                "SnapshotWindow": {
-                    "type": "string"
-                },
-                "SnapshottingClusterId": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "ReplicationGroupDescription"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElastiCache::ReplicationGroup.NodeGroupConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "PrimaryAvailabilityZone": {
                     "type": "string"
@@ -7893,70 +10150,138 @@
             "type": "object"
         },
         "AWS::ElastiCache::SecurityGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Description"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::SecurityGroup"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Description"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElastiCache::SecurityGroupIngress": {
+            "additionalProperties": false,
             "properties": {
-                "CacheSecurityGroupName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupOwnerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CacheSecurityGroupName",
+                        "EC2SecurityGroupName"
+                    ],
+                    "type": "object"
                 },
-                "EC2SecurityGroupName": {
-                    "type": "string"
-                },
-                "EC2SecurityGroupOwnerId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::SecurityGroupIngress"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "CacheSecurityGroupName",
-                "EC2SecurityGroupName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElastiCache::SubnetGroup": {
+            "additionalProperties": false,
             "properties": {
-                "CacheSubnetGroupName": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "SubnetIds": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Description",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::SubnetGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Description",
-                "SubnetIds"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "ResourceLifecycleConfig": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig"
+                        }
+                    },
+                    "type": "object"
                 },
-                "Description": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::Application"
+                    ],
                     "type": "string"
-                },
-                "ResourceLifecycleConfig": {
-                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig": {
+            "additionalProperties": false,
             "properties": {
                 "ServiceRole": {
                     "type": "string"
@@ -7968,6 +10293,7 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application.ApplicationVersionLifecycleConfig": {
+            "additionalProperties": false,
             "properties": {
                 "MaxAgeRule": {
                     "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.MaxAgeRule"
@@ -7979,6 +10305,7 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application.MaxAgeRule": {
+            "additionalProperties": false,
             "properties": {
                 "DeleteSourceFromS3": {
                     "type": "boolean"
@@ -7993,6 +10320,7 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application.MaxCountRule": {
+            "additionalProperties": false,
             "properties": {
                 "DeleteSourceFromS3": {
                     "type": "boolean"
@@ -8007,24 +10335,42 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::ApplicationVersion": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SourceBundle": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::ApplicationVersion.SourceBundle"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "SourceBundle"
+                    ],
+                    "type": "object"
                 },
-                "Description": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::ApplicationVersion"
+                    ],
                     "type": "string"
-                },
-                "SourceBundle": {
-                    "$ref": "#/definitions/AWS::ElasticBeanstalk::ApplicationVersion.SourceBundle"
                 }
             },
             "required": [
-                "ApplicationName",
-                "SourceBundle"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticBeanstalk::ApplicationVersion.SourceBundle": {
+            "additionalProperties": false,
             "properties": {
                 "S3Bucket": {
                     "type": "string"
@@ -8040,38 +10386,56 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::ConfigurationTemplate": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "EnvironmentId": {
-                    "type": "string"
-                },
-                "OptionSettings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate.ConfigurationOptionSetting"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnvironmentId": {
+                            "type": "string"
+                        },
+                        "OptionSettings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate.ConfigurationOptionSetting"
+                            },
+                            "type": "array"
+                        },
+                        "PlatformArn": {
+                            "type": "string"
+                        },
+                        "SolutionStackName": {
+                            "type": "string"
+                        },
+                        "SourceConfiguration": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate.SourceConfiguration"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ApplicationName"
+                    ],
+                    "type": "object"
                 },
-                "PlatformArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::ConfigurationTemplate"
+                    ],
                     "type": "string"
-                },
-                "SolutionStackName": {
-                    "type": "string"
-                },
-                "SourceConfiguration": {
-                    "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate.SourceConfiguration"
                 }
             },
             "required": [
-                "ApplicationName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticBeanstalk::ConfigurationTemplate.ConfigurationOptionSetting": {
+            "additionalProperties": false,
             "properties": {
                 "Namespace": {
                     "type": "string"
@@ -8090,6 +10454,7 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::ConfigurationTemplate.SourceConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "ApplicationName": {
                     "type": "string"
@@ -8105,53 +10470,71 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Environment": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
-                    "type": "string"
-                },
-                "CNAMEPrefix": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "EnvironmentName": {
-                    "type": "string"
-                },
-                "OptionSettings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.OptionSetting"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "CNAMEPrefix": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnvironmentName": {
+                            "type": "string"
+                        },
+                        "OptionSettings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.OptionSetting"
+                            },
+                            "type": "array"
+                        },
+                        "PlatformArn": {
+                            "type": "string"
+                        },
+                        "SolutionStackName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TemplateName": {
+                            "type": "string"
+                        },
+                        "Tier": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.Tier"
+                        },
+                        "VersionLabel": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ApplicationName"
+                    ],
+                    "type": "object"
                 },
-                "PlatformArn": {
-                    "type": "string"
-                },
-                "SolutionStackName": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "TemplateName": {
-                    "type": "string"
-                },
-                "Tier": {
-                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.Tier"
-                },
-                "VersionLabel": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::Environment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ApplicationName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Environment.OptionSetting": {
+            "additionalProperties": false,
             "properties": {
                 "Namespace": {
                     "type": "string"
@@ -8170,6 +10553,7 @@
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Environment.Tier": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -8184,89 +10568,107 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer": {
+            "additionalProperties": false,
             "properties": {
-                "AccessLoggingPolicy": {
-                    "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.AccessLoggingPolicy"
-                },
-                "AppCookieStickinessPolicy": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.AppCookieStickinessPolicy"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessLoggingPolicy": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.AccessLoggingPolicy"
+                        },
+                        "AppCookieStickinessPolicy": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.AppCookieStickinessPolicy"
+                            },
+                            "type": "array"
+                        },
+                        "AvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ConnectionDrainingPolicy": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.ConnectionDrainingPolicy"
+                        },
+                        "ConnectionSettings": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.ConnectionSettings"
+                        },
+                        "CrossZone": {
+                            "type": "boolean"
+                        },
+                        "HealthCheck": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.HealthCheck"
+                        },
+                        "Instances": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "LBCookieStickinessPolicy": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.LBCookieStickinessPolicy"
+                            },
+                            "type": "array"
+                        },
+                        "Listeners": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.Listeners"
+                            },
+                            "type": "array"
+                        },
+                        "LoadBalancerName": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.Policies"
+                            },
+                            "type": "array"
+                        },
+                        "Scheme": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Subnets": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Listeners"
+                    ],
+                    "type": "object"
                 },
-                "AvailabilityZones": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "ConnectionDrainingPolicy": {
-                    "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.ConnectionDrainingPolicy"
-                },
-                "ConnectionSettings": {
-                    "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.ConnectionSettings"
-                },
-                "CrossZone": {
-                    "type": "boolean"
-                },
-                "HealthCheck": {
-                    "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.HealthCheck"
-                },
-                "Instances": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "LBCookieStickinessPolicy": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.LBCookieStickinessPolicy"
-                    },
-                    "type": "array"
-                },
-                "Listeners": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.Listeners"
-                    },
-                    "type": "array"
-                },
-                "LoadBalancerName": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancing::LoadBalancer"
+                    ],
                     "type": "string"
-                },
-                "Policies": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.Policies"
-                    },
-                    "type": "array"
-                },
-                "Scheme": {
-                    "type": "string"
-                },
-                "SecurityGroups": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Subnets": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "Listeners"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.AccessLoggingPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "EmitInterval": {
                     "type": "number"
@@ -8288,6 +10690,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.AppCookieStickinessPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "CookieName": {
                     "type": "string"
@@ -8303,6 +10706,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.ConnectionDrainingPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "Enabled": {
                     "type": "boolean"
@@ -8317,6 +10721,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.ConnectionSettings": {
+            "additionalProperties": false,
             "properties": {
                 "IdleTimeout": {
                     "type": "number"
@@ -8328,6 +10733,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.HealthCheck": {
+            "additionalProperties": false,
             "properties": {
                 "HealthyThreshold": {
                     "type": "string"
@@ -8355,6 +10761,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.LBCookieStickinessPolicy": {
+            "additionalProperties": false,
             "properties": {
                 "CookieExpirationPeriod": {
                     "type": "string"
@@ -8366,6 +10773,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.Listeners": {
+            "additionalProperties": false,
             "properties": {
                 "InstancePort": {
                     "type": "string"
@@ -8397,6 +10805,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancing::LoadBalancer.Policies": {
+            "additionalProperties": false,
             "properties": {
                 "Attributes": {
                     "items": {
@@ -8431,41 +10840,59 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::Listener": {
+            "additionalProperties": false,
             "properties": {
-                "Certificates": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.Certificate"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Certificates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.Certificate"
+                            },
+                            "type": "array"
+                        },
+                        "DefaultActions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.Action"
+                            },
+                            "type": "array"
+                        },
+                        "LoadBalancerArn": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "SslPolicy": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "DefaultActions",
+                        "LoadBalancerArn",
+                        "Port",
+                        "Protocol"
+                    ],
+                    "type": "object"
                 },
-                "DefaultActions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.Action"
-                    },
-                    "type": "array"
-                },
-                "LoadBalancerArn": {
-                    "type": "string"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "Protocol": {
-                    "type": "string"
-                },
-                "SslPolicy": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::Listener"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DefaultActions",
-                "LoadBalancerArn",
-                "Port",
-                "Protocol"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::Listener.Action": {
+            "additionalProperties": false,
             "properties": {
                 "TargetGroupArn": {
                     "type": "string"
@@ -8481,6 +10908,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::Listener.Certificate": {
+            "additionalProperties": false,
             "properties": {
                 "CertificateArn": {
                     "type": "string"
@@ -8489,24 +10917,42 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
+            "additionalProperties": false,
             "properties": {
-                "Certificates": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Certificates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate"
+                            },
+                            "type": "array"
+                        },
+                        "ListenerArn": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Certificates",
+                        "ListenerArn"
+                    ],
+                    "type": "object"
                 },
-                "ListenerArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::ListenerCertificate"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Certificates",
-                "ListenerArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate": {
+            "additionalProperties": false,
             "properties": {
                 "CertificateArn": {
                     "type": "string"
@@ -8515,35 +10961,53 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule": {
+            "additionalProperties": false,
             "properties": {
-                "Actions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.Action"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Actions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.Action"
+                            },
+                            "type": "array"
+                        },
+                        "Conditions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.RuleCondition"
+                            },
+                            "type": "array"
+                        },
+                        "ListenerArn": {
+                            "type": "string"
+                        },
+                        "Priority": {
+                            "type": "number"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Actions",
+                        "Conditions",
+                        "ListenerArn",
+                        "Priority"
+                    ],
+                    "type": "object"
                 },
-                "Conditions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.RuleCondition"
-                    },
-                    "type": "array"
-                },
-                "ListenerArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::ListenerRule"
+                    ],
                     "type": "string"
-                },
-                "Priority": {
-                    "type": "number"
                 }
             },
             "required": [
-                "Actions",
-                "Conditions",
-                "ListenerArn",
-                "Priority"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule.Action": {
+            "additionalProperties": false,
             "properties": {
                 "TargetGroupArn": {
                     "type": "string"
@@ -8559,6 +11023,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule.RuleCondition": {
+            "additionalProperties": false,
             "properties": {
                 "Field": {
                     "type": "string"
@@ -8573,53 +11038,70 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+            "additionalProperties": false,
             "properties": {
-                "IpAddressType": {
-                    "type": "string"
-                },
-                "LoadBalancerAttributes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IpAddressType": {
+                            "type": "string"
+                        },
+                        "LoadBalancerAttributes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Scheme": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping"
+                            },
+                            "type": "array"
+                        },
+                        "Subnets": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Scheme": {
-                    "type": "string"
-                },
-                "SecurityGroups": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SubnetMappings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping"
-                    },
-                    "type": "array"
-                },
-                "Subnets": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
+                    "type": "object"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::LoadBalancer"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -8631,6 +11113,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping": {
+            "additionalProperties": false,
             "properties": {
                 "AllocationId": {
                     "type": "string"
@@ -8646,73 +11129,91 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::TargetGroup": {
+            "additionalProperties": false,
             "properties": {
-                "HealthCheckIntervalSeconds": {
-                    "type": "number"
-                },
-                "HealthCheckPath": {
-                    "type": "string"
-                },
-                "HealthCheckPort": {
-                    "type": "string"
-                },
-                "HealthCheckProtocol": {
-                    "type": "string"
-                },
-                "HealthCheckTimeoutSeconds": {
-                    "type": "number"
-                },
-                "HealthyThresholdCount": {
-                    "type": "number"
-                },
-                "Matcher": {
-                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.Matcher"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "Protocol": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "HealthCheckIntervalSeconds": {
+                            "type": "number"
+                        },
+                        "HealthCheckPath": {
+                            "type": "string"
+                        },
+                        "HealthCheckPort": {
+                            "type": "string"
+                        },
+                        "HealthCheckProtocol": {
+                            "type": "string"
+                        },
+                        "HealthCheckTimeoutSeconds": {
+                            "type": "number"
+                        },
+                        "HealthyThresholdCount": {
+                            "type": "number"
+                        },
+                        "Matcher": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.Matcher"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TargetGroupAttributes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetGroupAttribute"
+                            },
+                            "type": "array"
+                        },
+                        "TargetType": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription"
+                            },
+                            "type": "array"
+                        },
+                        "UnhealthyThresholdCount": {
+                            "type": "number"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Port",
+                        "Protocol",
+                        "VpcId"
+                    ],
+                    "type": "object"
                 },
-                "TargetGroupAttributes": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetGroupAttribute"
-                    },
-                    "type": "array"
-                },
-                "TargetType": {
-                    "type": "string"
-                },
-                "Targets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription"
-                    },
-                    "type": "array"
-                },
-                "UnhealthyThresholdCount": {
-                    "type": "number"
-                },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::TargetGroup"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Port",
-                "Protocol",
-                "VpcId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::TargetGroup.Matcher": {
+            "additionalProperties": false,
             "properties": {
                 "HttpCode": {
                     "type": "string"
@@ -8724,6 +11225,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription": {
+            "additionalProperties": false,
             "properties": {
                 "AvailabilityZone": {
                     "type": "string"
@@ -8741,6 +11243,7 @@
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::TargetGroup.TargetGroupAttribute": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -8752,43 +11255,61 @@
             "type": "object"
         },
         "AWS::Elasticsearch::Domain": {
+            "additionalProperties": false,
             "properties": {
-                "AccessPolicies": {
-                    "type": "object"
-                },
-                "AdvancedOptions": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessPolicies": {
+                            "type": "object"
+                        },
+                        "AdvancedOptions": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "DomainName": {
                             "type": "string"
+                        },
+                        "EBSOptions": {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain.EBSOptions"
+                        },
+                        "ElasticsearchClusterConfig": {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain.ElasticsearchClusterConfig"
+                        },
+                        "ElasticsearchVersion": {
+                            "type": "string"
+                        },
+                        "SnapshotOptions": {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain.SnapshotOptions"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
                 },
-                "DomainName": {
+                "Type": {
+                    "enum": [
+                        "AWS::Elasticsearch::Domain"
+                    ],
                     "type": "string"
-                },
-                "EBSOptions": {
-                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.EBSOptions"
-                },
-                "ElasticsearchClusterConfig": {
-                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.ElasticsearchClusterConfig"
-                },
-                "ElasticsearchVersion": {
-                    "type": "string"
-                },
-                "SnapshotOptions": {
-                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.SnapshotOptions"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Elasticsearch::Domain.EBSOptions": {
+            "additionalProperties": false,
             "properties": {
                 "EBSEnabled": {
                     "type": "boolean"
@@ -8806,6 +11327,7 @@
             "type": "object"
         },
         "AWS::Elasticsearch::Domain.ElasticsearchClusterConfig": {
+            "additionalProperties": false,
             "properties": {
                 "DedicatedMasterCount": {
                     "type": "number"
@@ -8829,6 +11351,7 @@
             "type": "object"
         },
         "AWS::Elasticsearch::Domain.SnapshotOptions": {
+            "additionalProperties": false,
             "properties": {
                 "AutomatedSnapshotStartHour": {
                     "type": "number"
@@ -8837,35 +11360,52 @@
             "type": "object"
         },
         "AWS::Events::Rule": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "EventPattern": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EventPattern": {
+                            "type": "object"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "ScheduleExpression": {
+                            "type": "string"
+                        },
+                        "State": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Events::Rule.Target"
+                            },
+                            "type": "array"
+                        }
+                    },
                     "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::Events::Rule"
+                    ],
                     "type": "string"
-                },
-                "RoleArn": {
-                    "type": "string"
-                },
-                "ScheduleExpression": {
-                    "type": "string"
-                },
-                "State": {
-                    "type": "string"
-                },
-                "Targets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Events::Rule.Target"
-                    },
-                    "type": "array"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Events::Rule.EcsParameters": {
+            "additionalProperties": false,
             "properties": {
                 "TaskCount": {
                     "type": "number"
@@ -8880,8 +11420,10 @@
             "type": "object"
         },
         "AWS::Events::Rule.InputTransformer": {
+            "additionalProperties": false,
             "properties": {
                 "InputPathsMap": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -8899,6 +11441,7 @@
             "type": "object"
         },
         "AWS::Events::Rule.KinesisParameters": {
+            "additionalProperties": false,
             "properties": {
                 "PartitionKeyPath": {
                     "type": "string"
@@ -8910,6 +11453,7 @@
             "type": "object"
         },
         "AWS::Events::Rule.RunCommandParameters": {
+            "additionalProperties": false,
             "properties": {
                 "RunCommandTargets": {
                     "items": {
@@ -8924,6 +11468,7 @@
             "type": "object"
         },
         "AWS::Events::Rule.RunCommandTarget": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -8942,6 +11487,7 @@
             "type": "object"
         },
         "AWS::Events::Rule.Target": {
+            "additionalProperties": false,
             "properties": {
                 "Arn": {
                     "type": "string"
@@ -8978,24 +11524,42 @@
             "type": "object"
         },
         "AWS::GameLift::Alias": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RoutingStrategy": {
+                            "$ref": "#/definitions/AWS::GameLift::Alias.RoutingStrategy"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "RoutingStrategy"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::GameLift::Alias"
+                    ],
                     "type": "string"
-                },
-                "RoutingStrategy": {
-                    "$ref": "#/definitions/AWS::GameLift::Alias.RoutingStrategy"
                 }
             },
             "required": [
-                "Name",
-                "RoutingStrategy"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::GameLift::Alias.RoutingStrategy": {
+            "additionalProperties": false,
             "properties": {
                 "FleetId": {
                     "type": "string"
@@ -9013,20 +11577,37 @@
             "type": "object"
         },
         "AWS::GameLift::Build": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StorageLocation": {
+                            "$ref": "#/definitions/AWS::GameLift::Build.S3Location"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
-                "StorageLocation": {
-                    "$ref": "#/definitions/AWS::GameLift::Build.S3Location"
-                },
-                "Version": {
+                "Type": {
+                    "enum": [
+                        "AWS::GameLift::Build"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::GameLift::Build.S3Location": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -9046,57 +11627,75 @@
             "type": "object"
         },
         "AWS::GameLift::Fleet": {
+            "additionalProperties": false,
             "properties": {
-                "BuildId": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "DesiredEC2Instances": {
-                    "type": "number"
-                },
-                "EC2InboundPermissions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::GameLift::Fleet.IpPermission"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BuildId": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DesiredEC2Instances": {
+                            "type": "number"
+                        },
+                        "EC2InboundPermissions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::GameLift::Fleet.IpPermission"
+                            },
+                            "type": "array"
+                        },
+                        "EC2InstanceType": {
+                            "type": "string"
+                        },
+                        "LogPaths": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "MaxSize": {
+                            "type": "number"
+                        },
+                        "MinSize": {
+                            "type": "number"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ServerLaunchParameters": {
+                            "type": "string"
+                        },
+                        "ServerLaunchPath": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "BuildId",
+                        "DesiredEC2Instances",
+                        "EC2InstanceType",
+                        "Name",
+                        "ServerLaunchPath"
+                    ],
+                    "type": "object"
                 },
-                "EC2InstanceType": {
-                    "type": "string"
-                },
-                "LogPaths": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "MaxSize": {
-                    "type": "number"
-                },
-                "MinSize": {
-                    "type": "number"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "ServerLaunchParameters": {
-                    "type": "string"
-                },
-                "ServerLaunchPath": {
+                "Type": {
+                    "enum": [
+                        "AWS::GameLift::Fleet"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "BuildId",
-                "DesiredEC2Instances",
-                "EC2InstanceType",
-                "Name",
-                "ServerLaunchPath"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::GameLift::Fleet.IpPermission": {
+            "additionalProperties": false,
             "properties": {
                 "FromPort": {
                     "type": "number"
@@ -9120,46 +11719,80 @@
             "type": "object"
         },
         "AWS::IAM::AccessKey": {
+            "additionalProperties": false,
             "properties": {
-                "Serial": {
-                    "type": "number"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Serial": {
+                            "type": "number"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "UserName"
+                    ],
+                    "type": "object"
                 },
-                "Status": {
-                    "type": "string"
-                },
-                "UserName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::AccessKey"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "UserName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IAM::Group": {
+            "additionalProperties": false,
             "properties": {
-                "GroupName": {
-                    "type": "string"
-                },
-                "ManagedPolicyArns": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "ManagedPolicyArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::IAM::Group.Policy"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "Path": {
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::Group"
+                    ],
                     "type": "string"
-                },
-                "Policies": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::IAM::Group.Policy"
-                    },
-                    "type": "array"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::IAM::Group.Policy": {
+            "additionalProperties": false,
             "properties": {
                 "PolicyDocument": {
                     "type": "object"
@@ -9175,126 +11808,195 @@
             "type": "object"
         },
         "AWS::IAM::InstanceProfile": {
+            "additionalProperties": false,
             "properties": {
-                "InstanceProfileName": {
-                    "type": "string"
-                },
-                "Path": {
-                    "type": "string"
-                },
-                "Roles": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InstanceProfileName": {
+                            "type": "string"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Roles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Roles"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::InstanceProfile"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Roles"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IAM::ManagedPolicy": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "Groups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Groups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ManagedPolicyName": {
+                            "type": "string"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "Roles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Users": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
-                },
-                "ManagedPolicyName": {
-                    "type": "string"
-                },
-                "Path": {
-                    "type": "string"
-                },
-                "PolicyDocument": {
+                    "required": [
+                        "PolicyDocument"
+                    ],
                     "type": "object"
                 },
-                "Roles": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Users": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::ManagedPolicy"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "PolicyDocument"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IAM::Policy": {
+            "additionalProperties": false,
             "properties": {
-                "Groups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Groups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "Roles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Users": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
-                },
-                "PolicyDocument": {
+                    "required": [
+                        "PolicyDocument",
+                        "PolicyName"
+                    ],
                     "type": "object"
                 },
-                "PolicyName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::Policy"
+                    ],
                     "type": "string"
-                },
-                "Roles": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Users": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "PolicyDocument",
-                "PolicyName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IAM::Role": {
+            "additionalProperties": false,
             "properties": {
-                "AssumeRolePolicyDocument": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AssumeRolePolicyDocument": {
+                            "type": "object"
+                        },
+                        "ManagedPolicyArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::IAM::Role.Policy"
+                            },
+                            "type": "array"
+                        },
+                        "RoleName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AssumeRolePolicyDocument"
+                    ],
                     "type": "object"
                 },
-                "ManagedPolicyArns": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Path": {
-                    "type": "string"
-                },
-                "Policies": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::IAM::Role.Policy"
-                    },
-                    "type": "array"
-                },
-                "RoleName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::Role"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "AssumeRolePolicyDocument"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IAM::Role.Policy": {
+            "additionalProperties": false,
             "properties": {
                 "PolicyDocument": {
                     "type": "object"
@@ -9310,38 +12012,55 @@
             "type": "object"
         },
         "AWS::IAM::User": {
+            "additionalProperties": false,
             "properties": {
-                "Groups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Groups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "LoginProfile": {
+                            "$ref": "#/definitions/AWS::IAM::User.LoginProfile"
+                        },
+                        "ManagedPolicyArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::IAM::User.Policy"
+                            },
+                            "type": "array"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "LoginProfile": {
-                    "$ref": "#/definitions/AWS::IAM::User.LoginProfile"
-                },
-                "ManagedPolicyArns": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Path": {
-                    "type": "string"
-                },
-                "Policies": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::IAM::User.Policy"
-                    },
-                    "type": "array"
-                },
-                "UserName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::User"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::IAM::User.LoginProfile": {
+            "additionalProperties": false,
             "properties": {
                 "Password": {
                     "type": "string"
@@ -9356,6 +12075,7 @@
             "type": "object"
         },
         "AWS::IAM::User.Policy": {
+            "additionalProperties": false,
             "properties": {
                 "PolicyDocument": {
                     "type": "object"
@@ -9371,81 +12091,167 @@
             "type": "object"
         },
         "AWS::IAM::UserToGroupAddition": {
+            "additionalProperties": false,
             "properties": {
-                "GroupName": {
-                    "type": "string"
-                },
-                "Users": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "Users": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "GroupName",
+                        "Users"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::UserToGroupAddition"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "GroupName",
-                "Users"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IoT::Certificate": {
+            "additionalProperties": false,
             "properties": {
-                "CertificateSigningRequest": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateSigningRequest": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CertificateSigningRequest",
+                        "Status"
+                    ],
+                    "type": "object"
                 },
-                "Status": {
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::Certificate"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "CertificateSigningRequest",
-                "Status"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IoT::Policy": {
+            "additionalProperties": false,
             "properties": {
-                "PolicyDocument": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument"
+                    ],
                     "type": "object"
                 },
-                "PolicyName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::Policy"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "PolicyDocument"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IoT::PolicyPrincipalAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "PolicyName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "Principal": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "PolicyName",
+                        "Principal"
+                    ],
+                    "type": "object"
                 },
-                "Principal": {
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::PolicyPrincipalAttachment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "PolicyName",
-                "Principal"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IoT::Thing": {
+            "additionalProperties": false,
             "properties": {
-                "AttributePayload": {
-                    "$ref": "#/definitions/AWS::IoT::Thing.AttributePayload"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AttributePayload": {
+                            "$ref": "#/definitions/AWS::IoT::Thing.AttributePayload"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
-                "ThingName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::Thing"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::IoT::Thing.AttributePayload": {
+            "additionalProperties": false,
             "properties": {
                 "Attributes": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -9457,35 +12263,70 @@
             "type": "object"
         },
         "AWS::IoT::ThingPrincipalAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "Principal": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Principal": {
+                            "type": "string"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Principal",
+                        "ThingName"
+                    ],
+                    "type": "object"
                 },
-                "ThingName": {
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::ThingPrincipalAttachment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Principal",
-                "ThingName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IoT::TopicRule": {
+            "additionalProperties": false,
             "properties": {
-                "RuleName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RuleName": {
+                            "type": "string"
+                        },
+                        "TopicRulePayload": {
+                            "$ref": "#/definitions/AWS::IoT::TopicRule.TopicRulePayload"
+                        }
+                    },
+                    "required": [
+                        "TopicRulePayload"
+                    ],
+                    "type": "object"
                 },
-                "TopicRulePayload": {
-                    "$ref": "#/definitions/AWS::IoT::TopicRule.TopicRulePayload"
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::TopicRule"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "TopicRulePayload"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::IoT::TopicRule.Action": {
+            "additionalProperties": false,
             "properties": {
                 "CloudwatchAlarm": {
                     "$ref": "#/definitions/AWS::IoT::TopicRule.CloudwatchAlarmAction"
@@ -9527,6 +12368,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.CloudwatchAlarmAction": {
+            "additionalProperties": false,
             "properties": {
                 "AlarmName": {
                     "type": "string"
@@ -9550,6 +12392,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.CloudwatchMetricAction": {
+            "additionalProperties": false,
             "properties": {
                 "MetricName": {
                     "type": "string"
@@ -9580,6 +12423,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.DynamoDBAction": {
+            "additionalProperties": false,
             "properties": {
                 "HashKeyField": {
                     "type": "string"
@@ -9620,6 +12464,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.DynamoDBv2Action": {
+            "additionalProperties": false,
             "properties": {
                 "PutItem": {
                     "$ref": "#/definitions/AWS::IoT::TopicRule.PutItemInput"
@@ -9631,6 +12476,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.ElasticsearchAction": {
+            "additionalProperties": false,
             "properties": {
                 "Endpoint": {
                     "type": "string"
@@ -9658,6 +12504,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.FirehoseAction": {
+            "additionalProperties": false,
             "properties": {
                 "DeliveryStreamName": {
                     "type": "string"
@@ -9676,6 +12523,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.KinesisAction": {
+            "additionalProperties": false,
             "properties": {
                 "PartitionKey": {
                     "type": "string"
@@ -9694,6 +12542,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.LambdaAction": {
+            "additionalProperties": false,
             "properties": {
                 "FunctionArn": {
                     "type": "string"
@@ -9702,6 +12551,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.PutItemInput": {
+            "additionalProperties": false,
             "properties": {
                 "TableName": {
                     "type": "string"
@@ -9713,6 +12563,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.RepublishAction": {
+            "additionalProperties": false,
             "properties": {
                 "RoleArn": {
                     "type": "string"
@@ -9728,6 +12579,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.S3Action": {
+            "additionalProperties": false,
             "properties": {
                 "BucketName": {
                     "type": "string"
@@ -9747,6 +12599,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.SnsAction": {
+            "additionalProperties": false,
             "properties": {
                 "MessageFormat": {
                     "type": "string"
@@ -9765,6 +12618,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.SqsAction": {
+            "additionalProperties": false,
             "properties": {
                 "QueueUrl": {
                     "type": "string"
@@ -9783,6 +12637,7 @@
             "type": "object"
         },
         "AWS::IoT::TopicRule.TopicRulePayload": {
+            "additionalProperties": false,
             "properties": {
                 "Actions": {
                     "items": {
@@ -9811,96 +12666,165 @@
             "type": "object"
         },
         "AWS::KMS::Alias": {
+            "additionalProperties": false,
             "properties": {
-                "AliasName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AliasName": {
+                            "type": "string"
+                        },
+                        "TargetKeyId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AliasName",
+                        "TargetKeyId"
+                    ],
+                    "type": "object"
                 },
-                "TargetKeyId": {
+                "Type": {
+                    "enum": [
+                        "AWS::KMS::Alias"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "AliasName",
-                "TargetKeyId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::KMS::Key": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "EnableKeyRotation": {
-                    "type": "boolean"
-                },
-                "Enabled": {
-                    "type": "boolean"
-                },
-                "KeyPolicy": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnableKeyRotation": {
+                            "type": "boolean"
+                        },
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "KeyPolicy": {
+                            "type": "object"
+                        },
+                        "KeyUsage": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "KeyPolicy"
+                    ],
                     "type": "object"
                 },
-                "KeyUsage": {
+                "Type": {
+                    "enum": [
+                        "AWS::KMS::Key"
+                    ],
                     "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "KeyPolicy"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Kinesis::Stream": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "RetentionPeriodHours": {
-                    "type": "number"
-                },
-                "ShardCount": {
-                    "type": "number"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RetentionPeriodHours": {
+                            "type": "number"
+                        },
+                        "ShardCount": {
+                            "type": "number"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ShardCount"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Kinesis::Stream"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "ShardCount"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationCode": {
-                    "type": "string"
-                },
-                "ApplicationDescription": {
-                    "type": "string"
-                },
-                "ApplicationName": {
-                    "type": "string"
-                },
-                "Inputs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::KinesisAnalytics::Application.Input"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationCode": {
+                            "type": "string"
+                        },
+                        "ApplicationDescription": {
+                            "type": "string"
+                        },
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Inputs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::KinesisAnalytics::Application.Input"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Inputs"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisAnalytics::Application"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Inputs"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.CSVMappingParameters": {
+            "additionalProperties": false,
             "properties": {
                 "RecordColumnDelimiter": {
                     "type": "string"
@@ -9916,6 +12840,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.Input": {
+            "additionalProperties": false,
             "properties": {
                 "InputParallelism": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::Application.InputParallelism"
@@ -9940,6 +12865,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.InputParallelism": {
+            "additionalProperties": false,
             "properties": {
                 "Count": {
                     "type": "number"
@@ -9948,6 +12874,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.InputSchema": {
+            "additionalProperties": false,
             "properties": {
                 "RecordColumns": {
                     "items": {
@@ -9969,6 +12896,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.JSONMappingParameters": {
+            "additionalProperties": false,
             "properties": {
                 "RecordRowPath": {
                     "type": "string"
@@ -9980,6 +12908,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.KinesisFirehoseInput": {
+            "additionalProperties": false,
             "properties": {
                 "ResourceARN": {
                     "type": "string"
@@ -9995,6 +12924,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.KinesisStreamsInput": {
+            "additionalProperties": false,
             "properties": {
                 "ResourceARN": {
                     "type": "string"
@@ -10010,6 +12940,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.MappingParameters": {
+            "additionalProperties": false,
             "properties": {
                 "CSVMappingParameters": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::Application.CSVMappingParameters"
@@ -10021,6 +12952,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.RecordColumn": {
+            "additionalProperties": false,
             "properties": {
                 "Mapping": {
                     "type": "string"
@@ -10039,6 +12971,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::Application.RecordFormat": {
+            "additionalProperties": false,
             "properties": {
                 "MappingParameters": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::Application.MappingParameters"
@@ -10053,21 +12986,39 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationOutput": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Output": {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.Output"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "Output"
+                    ],
+                    "type": "object"
                 },
-                "Output": {
-                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.Output"
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisAnalytics::ApplicationOutput"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "ApplicationName",
-                "Output"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationOutput.DestinationSchema": {
+            "additionalProperties": false,
             "properties": {
                 "RecordFormatType": {
                     "type": "string"
@@ -10076,6 +13027,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationOutput.KinesisFirehoseOutput": {
+            "additionalProperties": false,
             "properties": {
                 "ResourceARN": {
                     "type": "string"
@@ -10091,6 +13043,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationOutput.KinesisStreamsOutput": {
+            "additionalProperties": false,
             "properties": {
                 "ResourceARN": {
                     "type": "string"
@@ -10106,6 +13059,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationOutput.Output": {
+            "additionalProperties": false,
             "properties": {
                 "DestinationSchema": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.DestinationSchema"
@@ -10126,21 +13080,39 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource": {
+            "additionalProperties": false,
             "properties": {
-                "ApplicationName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "ReferenceDataSource": {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceDataSource"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "ReferenceDataSource"
+                    ],
+                    "type": "object"
                 },
-                "ReferenceDataSource": {
-                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceDataSource"
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisAnalytics::ApplicationReferenceDataSource"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "ApplicationName",
-                "ReferenceDataSource"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.CSVMappingParameters": {
+            "additionalProperties": false,
             "properties": {
                 "RecordColumnDelimiter": {
                     "type": "string"
@@ -10156,6 +13128,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.JSONMappingParameters": {
+            "additionalProperties": false,
             "properties": {
                 "RecordRowPath": {
                     "type": "string"
@@ -10167,6 +13140,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.MappingParameters": {
+            "additionalProperties": false,
             "properties": {
                 "CSVMappingParameters": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.CSVMappingParameters"
@@ -10178,6 +13152,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.RecordColumn": {
+            "additionalProperties": false,
             "properties": {
                 "Mapping": {
                     "type": "string"
@@ -10196,6 +13171,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.RecordFormat": {
+            "additionalProperties": false,
             "properties": {
                 "MappingParameters": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.MappingParameters"
@@ -10210,6 +13186,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceDataSource": {
+            "additionalProperties": false,
             "properties": {
                 "ReferenceSchema": {
                     "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceSchema"
@@ -10227,6 +13204,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceSchema": {
+            "additionalProperties": false,
             "properties": {
                 "RecordColumns": {
                     "items": {
@@ -10248,6 +13226,7 @@
             "type": "object"
         },
         "AWS::KinesisAnalytics::ApplicationReferenceDataSource.S3ReferenceDataSource": {
+            "additionalProperties": false,
             "properties": {
                 "BucketARN": {
                     "type": "string"
@@ -10267,32 +13246,49 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream": {
+            "additionalProperties": false,
             "properties": {
-                "DeliveryStreamName": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeliveryStreamName": {
+                            "type": "string"
+                        },
+                        "DeliveryStreamType": {
+                            "type": "string"
+                        },
+                        "ElasticsearchDestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration"
+                        },
+                        "ExtendedS3DestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration"
+                        },
+                        "KinesisStreamSourceConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration"
+                        },
+                        "RedshiftDestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.RedshiftDestinationConfiguration"
+                        },
+                        "S3DestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisFirehose::DeliveryStream"
+                    ],
                     "type": "string"
-                },
-                "DeliveryStreamType": {
-                    "type": "string"
-                },
-                "ElasticsearchDestinationConfiguration": {
-                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration"
-                },
-                "ExtendedS3DestinationConfiguration": {
-                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration"
-                },
-                "KinesisStreamSourceConfiguration": {
-                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration"
-                },
-                "RedshiftDestinationConfiguration": {
-                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.RedshiftDestinationConfiguration"
-                },
-                "S3DestinationConfiguration": {
-                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.BufferingHints": {
+            "additionalProperties": false,
             "properties": {
                 "IntervalInSeconds": {
                     "type": "number"
@@ -10308,6 +13304,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions": {
+            "additionalProperties": false,
             "properties": {
                 "Enabled": {
                     "type": "boolean"
@@ -10322,6 +13319,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.CopyCommand": {
+            "additionalProperties": false,
             "properties": {
                 "CopyOptions": {
                     "type": "string"
@@ -10339,6 +13337,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.ElasticsearchBufferingHints": {
+            "additionalProperties": false,
             "properties": {
                 "IntervalInSeconds": {
                     "type": "number"
@@ -10354,6 +13353,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "BufferingHints": {
                     "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchBufferingHints"
@@ -10403,6 +13403,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.ElasticsearchRetryOptions": {
+            "additionalProperties": false,
             "properties": {
                 "DurationInSeconds": {
                     "type": "number"
@@ -10414,6 +13415,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.EncryptionConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "KMSEncryptionConfig": {
                     "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.KMSEncryptionConfig"
@@ -10425,6 +13427,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "BucketARN": {
                     "type": "string"
@@ -10467,6 +13470,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.KMSEncryptionConfig": {
+            "additionalProperties": false,
             "properties": {
                 "AWSKMSKeyARN": {
                     "type": "string"
@@ -10478,6 +13482,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "KinesisStreamARN": {
                     "type": "string"
@@ -10493,6 +13498,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.ProcessingConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Enabled": {
                     "type": "boolean"
@@ -10511,6 +13517,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.Processor": {
+            "additionalProperties": false,
             "properties": {
                 "Parameters": {
                     "items": {
@@ -10529,6 +13536,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.ProcessorParameter": {
+            "additionalProperties": false,
             "properties": {
                 "ParameterName": {
                     "type": "string"
@@ -10544,6 +13552,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.RedshiftDestinationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "CloudWatchLoggingOptions": {
                     "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions"
@@ -10581,6 +13590,7 @@
             "type": "object"
         },
         "AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "BucketARN": {
                     "type": "string"
@@ -10614,109 +13624,161 @@
             "type": "object"
         },
         "AWS::Lambda::Alias": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "FunctionVersion": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "FunctionName",
+                        "FunctionVersion",
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "FunctionName": {
-                    "type": "string"
-                },
-                "FunctionVersion": {
-                    "type": "string"
-                },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Alias"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "FunctionName",
-                "FunctionVersion",
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Lambda::EventSourceMapping": {
+            "additionalProperties": false,
             "properties": {
-                "BatchSize": {
-                    "type": "number"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BatchSize": {
+                            "type": "number"
+                        },
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "EventSourceArn": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "StartingPosition": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "EventSourceArn",
+                        "FunctionName",
+                        "StartingPosition"
+                    ],
+                    "type": "object"
                 },
-                "Enabled": {
-                    "type": "boolean"
-                },
-                "EventSourceArn": {
-                    "type": "string"
-                },
-                "FunctionName": {
-                    "type": "string"
-                },
-                "StartingPosition": {
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::EventSourceMapping"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "EventSourceArn",
-                "FunctionName",
-                "StartingPosition"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Lambda::Function": {
+            "additionalProperties": false,
             "properties": {
-                "Code": {
-                    "$ref": "#/definitions/AWS::Lambda::Function.Code"
-                },
-                "DeadLetterConfig": {
-                    "$ref": "#/definitions/AWS::Lambda::Function.DeadLetterConfig"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Environment": {
-                    "$ref": "#/definitions/AWS::Lambda::Function.Environment"
-                },
-                "FunctionName": {
-                    "type": "string"
-                },
-                "Handler": {
-                    "type": "string"
-                },
-                "KmsKeyArn": {
-                    "type": "string"
-                },
-                "MemorySize": {
-                    "type": "number"
-                },
-                "Role": {
-                    "type": "string"
-                },
-                "Runtime": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Code": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.Code"
+                        },
+                        "DeadLetterConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.DeadLetterConfig"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Environment": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.Environment"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "Handler": {
+                            "type": "string"
+                        },
+                        "KmsKeyArn": {
+                            "type": "string"
+                        },
+                        "MemorySize": {
+                            "type": "number"
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "Runtime": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Timeout": {
+                            "type": "number"
+                        },
+                        "TracingConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.TracingConfig"
+                        },
+                        "VpcConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.VpcConfig"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Code",
+                        "Handler",
+                        "Role",
+                        "Runtime"
+                    ],
+                    "type": "object"
                 },
-                "Timeout": {
-                    "type": "number"
-                },
-                "TracingConfig": {
-                    "$ref": "#/definitions/AWS::Lambda::Function.TracingConfig"
-                },
-                "VpcConfig": {
-                    "$ref": "#/definitions/AWS::Lambda::Function.VpcConfig"
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Function"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Code",
-                "Handler",
-                "Role",
-                "Runtime"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Lambda::Function.Code": {
+            "additionalProperties": false,
             "properties": {
                 "S3Bucket": {
                     "type": "string"
@@ -10734,6 +13796,7 @@
             "type": "object"
         },
         "AWS::Lambda::Function.DeadLetterConfig": {
+            "additionalProperties": false,
             "properties": {
                 "TargetArn": {
                     "type": "string"
@@ -10742,8 +13805,10 @@
             "type": "object"
         },
         "AWS::Lambda::Function.Environment": {
+            "additionalProperties": false,
             "properties": {
                 "Variables": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -10755,6 +13820,7 @@
             "type": "object"
         },
         "AWS::Lambda::Function.TracingConfig": {
+            "additionalProperties": false,
             "properties": {
                 "Mode": {
                     "type": "string"
@@ -10763,6 +13829,7 @@
             "type": "object"
         },
         "AWS::Lambda::Function.VpcConfig": {
+            "additionalProperties": false,
             "properties": {
                 "SecurityGroupIds": {
                     "items": {
@@ -10784,121 +13851,223 @@
             "type": "object"
         },
         "AWS::Lambda::Permission": {
+            "additionalProperties": false,
             "properties": {
-                "Action": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Action": {
+                            "type": "string"
+                        },
+                        "EventSourceToken": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "Principal": {
+                            "type": "string"
+                        },
+                        "SourceAccount": {
+                            "type": "string"
+                        },
+                        "SourceArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Action",
+                        "FunctionName",
+                        "Principal"
+                    ],
+                    "type": "object"
                 },
-                "EventSourceToken": {
-                    "type": "string"
-                },
-                "FunctionName": {
-                    "type": "string"
-                },
-                "Principal": {
-                    "type": "string"
-                },
-                "SourceAccount": {
-                    "type": "string"
-                },
-                "SourceArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Permission"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Action",
-                "FunctionName",
-                "Principal"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Lambda::Version": {
+            "additionalProperties": false,
             "properties": {
-                "CodeSha256": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeSha256": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "FunctionName"
+                    ],
+                    "type": "object"
                 },
-                "Description": {
-                    "type": "string"
-                },
-                "FunctionName": {
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Version"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "FunctionName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Logs::Destination": {
+            "additionalProperties": false,
             "properties": {
-                "DestinationName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationName": {
+                            "type": "string"
+                        },
+                        "DestinationPolicy": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "TargetArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationName",
+                        "DestinationPolicy",
+                        "RoleArn",
+                        "TargetArn"
+                    ],
+                    "type": "object"
                 },
-                "DestinationPolicy": {
-                    "type": "string"
-                },
-                "RoleArn": {
-                    "type": "string"
-                },
-                "TargetArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::Destination"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DestinationName",
-                "DestinationPolicy",
-                "RoleArn",
-                "TargetArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Logs::LogGroup": {
+            "additionalProperties": false,
             "properties": {
-                "LogGroupName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "RetentionInDays": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 },
-                "RetentionInDays": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::Logs::LogStream": {
-            "properties": {
-                "LogGroupName": {
-                    "type": "string"
-                },
-                "LogStreamName": {
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::LogGroup"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "LogGroupName"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::LogStream": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "LogStreamName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LogGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::LogStream"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Logs::MetricFilter": {
+            "additionalProperties": false,
             "properties": {
-                "FilterPattern": {
-                    "type": "string"
-                },
-                "LogGroupName": {
-                    "type": "string"
-                },
-                "MetricTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Logs::MetricFilter.MetricTransformation"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FilterPattern": {
+                            "type": "string"
+                        },
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "MetricTransformations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Logs::MetricFilter.MetricTransformation"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "FilterPattern",
+                        "LogGroupName",
+                        "MetricTransformations"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::MetricFilter"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "FilterPattern",
-                "LogGroupName",
-                "MetricTransformations"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Logs::MetricFilter.MetricTransformation": {
+            "additionalProperties": false,
             "properties": {
                 "MetricName": {
                     "type": "string"
@@ -10918,88 +14087,124 @@
             "type": "object"
         },
         "AWS::Logs::SubscriptionFilter": {
+            "additionalProperties": false,
             "properties": {
-                "DestinationArn": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationArn": {
+                            "type": "string"
+                        },
+                        "FilterPattern": {
+                            "type": "string"
+                        },
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationArn",
+                        "FilterPattern",
+                        "LogGroupName"
+                    ],
+                    "type": "object"
                 },
-                "FilterPattern": {
-                    "type": "string"
-                },
-                "LogGroupName": {
-                    "type": "string"
-                },
-                "RoleArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::SubscriptionFilter"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DestinationArn",
-                "FilterPattern",
-                "LogGroupName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::App": {
+            "additionalProperties": false,
             "properties": {
-                "AppSource": {
-                    "$ref": "#/definitions/AWS::OpsWorks::App.Source"
-                },
-                "Attributes": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AppSource": {
+                            "$ref": "#/definitions/AWS::OpsWorks::App.Source"
+                        },
+                        "Attributes": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "DataSources": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::App.DataSource"
+                            },
+                            "type": "array"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Domains": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "EnableSsl": {
+                            "type": "boolean"
+                        },
+                        "Environment": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::App.EnvironmentVariable"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Shortname": {
+                            "type": "string"
+                        },
+                        "SslConfiguration": {
+                            "$ref": "#/definitions/AWS::OpsWorks::App.SslConfiguration"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        },
+                        "Type": {
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "Name",
+                        "StackId",
+                        "Type"
+                    ],
                     "type": "object"
                 },
-                "DataSources": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::OpsWorks::App.DataSource"
-                    },
-                    "type": "array"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Domains": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "EnableSsl": {
-                    "type": "boolean"
-                },
-                "Environment": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::OpsWorks::App.EnvironmentVariable"
-                    },
-                    "type": "array"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Shortname": {
-                    "type": "string"
-                },
-                "SslConfiguration": {
-                    "$ref": "#/definitions/AWS::OpsWorks::App.SslConfiguration"
-                },
-                "StackId": {
-                    "type": "string"
-                },
                 "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::App"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Name",
-                "StackId",
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::App.DataSource": {
+            "additionalProperties": false,
             "properties": {
                 "Arn": {
                     "type": "string"
@@ -11014,6 +14219,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::App.EnvironmentVariable": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -11032,6 +14238,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::App.Source": {
+            "additionalProperties": false,
             "properties": {
                 "Password": {
                     "type": "string"
@@ -11055,6 +14262,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::App.SslConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Certificate": {
                     "type": "string"
@@ -11069,106 +14277,141 @@
             "type": "object"
         },
         "AWS::OpsWorks::ElasticLoadBalancerAttachment": {
+            "additionalProperties": false,
             "properties": {
-                "ElasticLoadBalancerName": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ElasticLoadBalancerName": {
+                            "type": "string"
+                        },
+                        "LayerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ElasticLoadBalancerName",
+                        "LayerId"
+                    ],
+                    "type": "object"
                 },
-                "LayerId": {
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ElasticLoadBalancerName",
-                "LayerId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::Instance": {
+            "additionalProperties": false,
             "properties": {
-                "AgentVersion": {
-                    "type": "string"
-                },
-                "AmiId": {
-                    "type": "string"
-                },
-                "Architecture": {
-                    "type": "string"
-                },
-                "AutoScalingType": {
-                    "type": "string"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "BlockDeviceMappings": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::OpsWorks::Instance.BlockDeviceMapping"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AgentVersion": {
+                            "type": "string"
+                        },
+                        "AmiId": {
+                            "type": "string"
+                        },
+                        "Architecture": {
+                            "type": "string"
+                        },
+                        "AutoScalingType": {
+                            "type": "string"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "BlockDeviceMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Instance.BlockDeviceMapping"
+                            },
+                            "type": "array"
+                        },
+                        "EbsOptimized": {
+                            "type": "boolean"
+                        },
+                        "ElasticIps": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Hostname": {
+                            "type": "string"
+                        },
+                        "InstallUpdatesOnBoot": {
+                            "type": "boolean"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "LayerIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Os": {
+                            "type": "string"
+                        },
+                        "RootDeviceType": {
+                            "type": "string"
+                        },
+                        "SshKeyName": {
+                            "type": "string"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tenancy": {
+                            "type": "string"
+                        },
+                        "TimeBasedAutoScaling": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Instance.TimeBasedAutoScaling"
+                        },
+                        "VirtualizationType": {
+                            "type": "string"
+                        },
+                        "Volumes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "InstanceType",
+                        "LayerIds",
+                        "StackId"
+                    ],
+                    "type": "object"
                 },
-                "EbsOptimized": {
-                    "type": "boolean"
-                },
-                "ElasticIps": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Hostname": {
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Instance"
+                    ],
                     "type": "string"
-                },
-                "InstallUpdatesOnBoot": {
-                    "type": "boolean"
-                },
-                "InstanceType": {
-                    "type": "string"
-                },
-                "LayerIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Os": {
-                    "type": "string"
-                },
-                "RootDeviceType": {
-                    "type": "string"
-                },
-                "SshKeyName": {
-                    "type": "string"
-                },
-                "StackId": {
-                    "type": "string"
-                },
-                "SubnetId": {
-                    "type": "string"
-                },
-                "Tenancy": {
-                    "type": "string"
-                },
-                "TimeBasedAutoScaling": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Instance.TimeBasedAutoScaling"
-                },
-                "VirtualizationType": {
-                    "type": "string"
-                },
-                "Volumes": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "InstanceType",
-                "LayerIds",
-                "StackId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::Instance.BlockDeviceMapping": {
+            "additionalProperties": false,
             "properties": {
                 "DeviceName": {
                     "type": "string"
@@ -11186,6 +14429,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Instance.EbsBlockDevice": {
+            "additionalProperties": false,
             "properties": {
                 "DeleteOnTermination": {
                     "type": "boolean"
@@ -11206,8 +14450,10 @@
             "type": "object"
         },
         "AWS::OpsWorks::Instance.TimeBasedAutoScaling": {
+            "additionalProperties": false,
             "properties": {
                 "Friday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11216,6 +14462,7 @@
                     "type": "object"
                 },
                 "Monday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11224,6 +14471,7 @@
                     "type": "object"
                 },
                 "Saturday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11232,6 +14480,7 @@
                     "type": "object"
                 },
                 "Sunday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11240,6 +14489,7 @@
                     "type": "object"
                 },
                 "Thursday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11248,6 +14498,7 @@
                     "type": "object"
                 },
                 "Tuesday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11256,6 +14507,7 @@
                     "type": "object"
                 },
                 "Wednesday": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -11267,88 +14519,107 @@
             "type": "object"
         },
         "AWS::OpsWorks::Layer": {
+            "additionalProperties": false,
             "properties": {
-                "Attributes": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Attributes": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "AutoAssignElasticIps": {
+                            "type": "boolean"
+                        },
+                        "AutoAssignPublicIps": {
+                            "type": "boolean"
+                        },
+                        "CustomInstanceProfileArn": {
                             "type": "string"
+                        },
+                        "CustomJson": {
+                            "type": "object"
+                        },
+                        "CustomRecipes": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer.Recipes"
+                        },
+                        "CustomSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "EnableAutoHealing": {
+                            "type": "boolean"
+                        },
+                        "InstallUpdatesOnBoot": {
+                            "type": "boolean"
+                        },
+                        "LifecycleEventConfiguration": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer.LifecycleEventConfiguration"
+                        },
+                        "LoadBasedAutoScaling": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer.LoadBasedAutoScaling"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Packages": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Shortname": {
+                            "type": "string"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "UseEbsOptimizedInstances": {
+                            "type": "boolean"
+                        },
+                        "VolumeConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Layer.VolumeConfiguration"
+                            },
+                            "type": "array"
                         }
                     },
+                    "required": [
+                        "AutoAssignElasticIps",
+                        "AutoAssignPublicIps",
+                        "EnableAutoHealing",
+                        "Name",
+                        "Shortname",
+                        "StackId",
+                        "Type"
+                    ],
                     "type": "object"
-                },
-                "AutoAssignElasticIps": {
-                    "type": "boolean"
-                },
-                "AutoAssignPublicIps": {
-                    "type": "boolean"
-                },
-                "CustomInstanceProfileArn": {
-                    "type": "string"
-                },
-                "CustomJson": {
-                    "type": "object"
-                },
-                "CustomRecipes": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Layer.Recipes"
-                },
-                "CustomSecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "EnableAutoHealing": {
-                    "type": "boolean"
-                },
-                "InstallUpdatesOnBoot": {
-                    "type": "boolean"
-                },
-                "LifecycleEventConfiguration": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Layer.LifecycleEventConfiguration"
-                },
-                "LoadBasedAutoScaling": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Layer.LoadBasedAutoScaling"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Packages": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Shortname": {
-                    "type": "string"
-                },
-                "StackId": {
-                    "type": "string"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Layer"
+                    ],
                     "type": "string"
-                },
-                "UseEbsOptimizedInstances": {
-                    "type": "boolean"
-                },
-                "VolumeConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::OpsWorks::Layer.VolumeConfiguration"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "AutoAssignElasticIps",
-                "AutoAssignPublicIps",
-                "EnableAutoHealing",
-                "Name",
-                "Shortname",
-                "StackId",
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::Layer.AutoScalingThresholds": {
+            "additionalProperties": false,
             "properties": {
                 "CpuThreshold": {
                     "type": "number"
@@ -11372,6 +14643,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Layer.LifecycleEventConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "ShutdownEventConfiguration": {
                     "$ref": "#/definitions/AWS::OpsWorks::Layer.ShutdownEventConfiguration"
@@ -11380,6 +14652,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Layer.LoadBasedAutoScaling": {
+            "additionalProperties": false,
             "properties": {
                 "DownScaling": {
                     "$ref": "#/definitions/AWS::OpsWorks::Layer.AutoScalingThresholds"
@@ -11394,6 +14667,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Layer.Recipes": {
+            "additionalProperties": false,
             "properties": {
                 "Configure": {
                     "items": {
@@ -11429,6 +14703,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Layer.ShutdownEventConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "DelayUntilElbConnectionsDrained": {
                     "type": "boolean"
@@ -11440,6 +14715,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Layer.VolumeConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Iops": {
                     "type": "number"
@@ -11463,102 +14739,121 @@
             "type": "object"
         },
         "AWS::OpsWorks::Stack": {
+            "additionalProperties": false,
             "properties": {
-                "AgentVersion": {
-                    "type": "string"
-                },
-                "Attributes": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AgentVersion": {
+                            "type": "string"
+                        },
+                        "Attributes": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ChefConfiguration": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack.ChefConfiguration"
+                        },
+                        "CloneAppIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ClonePermissions": {
+                            "type": "boolean"
+                        },
+                        "ConfigurationManager": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack.StackConfigurationManager"
+                        },
+                        "CustomCookbooksSource": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack.Source"
+                        },
+                        "CustomJson": {
+                            "type": "object"
+                        },
+                        "DefaultAvailabilityZone": {
+                            "type": "string"
+                        },
+                        "DefaultInstanceProfileArn": {
+                            "type": "string"
+                        },
+                        "DefaultOs": {
+                            "type": "string"
+                        },
+                        "DefaultRootDeviceType": {
+                            "type": "string"
+                        },
+                        "DefaultSshKeyName": {
+                            "type": "string"
+                        },
+                        "DefaultSubnetId": {
+                            "type": "string"
+                        },
+                        "EcsClusterArn": {
+                            "type": "string"
+                        },
+                        "ElasticIps": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Stack.ElasticIp"
+                            },
+                            "type": "array"
+                        },
+                        "HostnameTheme": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RdsDbInstances": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Stack.RdsDbInstance"
+                            },
+                            "type": "array"
+                        },
+                        "ServiceRoleArn": {
+                            "type": "string"
+                        },
+                        "SourceStackId": {
+                            "type": "string"
+                        },
+                        "UseCustomCookbooks": {
+                            "type": "boolean"
+                        },
+                        "UseOpsworksSecurityGroups": {
+                            "type": "boolean"
+                        },
+                        "VpcId": {
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "DefaultInstanceProfileArn",
+                        "Name",
+                        "ServiceRoleArn"
+                    ],
                     "type": "object"
                 },
-                "ChefConfiguration": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Stack.ChefConfiguration"
-                },
-                "CloneAppIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "ClonePermissions": {
-                    "type": "boolean"
-                },
-                "ConfigurationManager": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Stack.StackConfigurationManager"
-                },
-                "CustomCookbooksSource": {
-                    "$ref": "#/definitions/AWS::OpsWorks::Stack.Source"
-                },
-                "CustomJson": {
-                    "type": "object"
-                },
-                "DefaultAvailabilityZone": {
-                    "type": "string"
-                },
-                "DefaultInstanceProfileArn": {
-                    "type": "string"
-                },
-                "DefaultOs": {
-                    "type": "string"
-                },
-                "DefaultRootDeviceType": {
-                    "type": "string"
-                },
-                "DefaultSshKeyName": {
-                    "type": "string"
-                },
-                "DefaultSubnetId": {
-                    "type": "string"
-                },
-                "EcsClusterArn": {
-                    "type": "string"
-                },
-                "ElasticIps": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::OpsWorks::Stack.ElasticIp"
-                    },
-                    "type": "array"
-                },
-                "HostnameTheme": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "RdsDbInstances": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::OpsWorks::Stack.RdsDbInstance"
-                    },
-                    "type": "array"
-                },
-                "ServiceRoleArn": {
-                    "type": "string"
-                },
-                "SourceStackId": {
-                    "type": "string"
-                },
-                "UseCustomCookbooks": {
-                    "type": "boolean"
-                },
-                "UseOpsworksSecurityGroups": {
-                    "type": "boolean"
-                },
-                "VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Stack"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DefaultInstanceProfileArn",
-                "Name",
-                "ServiceRoleArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::Stack.ChefConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "BerkshelfVersion": {
                     "type": "string"
@@ -11570,6 +14865,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Stack.ElasticIp": {
+            "additionalProperties": false,
             "properties": {
                 "Ip": {
                     "type": "string"
@@ -11584,6 +14880,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Stack.RdsDbInstance": {
+            "additionalProperties": false,
             "properties": {
                 "DbPassword": {
                     "type": "string"
@@ -11603,6 +14900,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Stack.Source": {
+            "additionalProperties": false,
             "properties": {
                 "Password": {
                     "type": "string"
@@ -11626,6 +14924,7 @@
             "type": "object"
         },
         "AWS::OpsWorks::Stack.StackConfigurationManager": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -11637,327 +14936,448 @@
             "type": "object"
         },
         "AWS::OpsWorks::UserProfile": {
+            "additionalProperties": false,
             "properties": {
-                "AllowSelfManagement": {
-                    "type": "boolean"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowSelfManagement": {
+                            "type": "boolean"
+                        },
+                        "IamUserArn": {
+                            "type": "string"
+                        },
+                        "SshPublicKey": {
+                            "type": "string"
+                        },
+                        "SshUsername": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "IamUserArn"
+                    ],
+                    "type": "object"
                 },
-                "IamUserArn": {
-                    "type": "string"
-                },
-                "SshPublicKey": {
-                    "type": "string"
-                },
-                "SshUsername": {
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::UserProfile"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "IamUserArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::OpsWorks::Volume": {
+            "additionalProperties": false,
             "properties": {
-                "Ec2VolumeId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Ec2VolumeId": {
+                            "type": "string"
+                        },
+                        "MountPoint": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Ec2VolumeId",
+                        "StackId"
+                    ],
+                    "type": "object"
                 },
-                "MountPoint": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "StackId": {
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Volume"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Ec2VolumeId",
-                "StackId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBCluster": {
+            "additionalProperties": false,
             "properties": {
-                "AvailabilityZones": {
-                    "type": "string"
-                },
-                "BackupRetentionPeriod": {
-                    "type": "number"
-                },
-                "DBClusterParameterGroupName": {
-                    "type": "string"
-                },
-                "DBSubnetGroupName": {
-                    "type": "string"
-                },
-                "DatabaseName": {
-                    "type": "string"
-                },
-                "Engine": {
-                    "type": "string"
-                },
-                "EngineVersion": {
-                    "type": "string"
-                },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "MasterUserPassword": {
-                    "type": "string"
-                },
-                "MasterUsername": {
-                    "type": "string"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "PreferredBackupWindow": {
-                    "type": "string"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "ReplicationSourceIdentifier": {
-                    "type": "string"
-                },
-                "SnapshotIdentifier": {
-                    "type": "string"
-                },
-                "StorageEncrypted": {
-                    "type": "boolean"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AvailabilityZones": {
+                            "type": "string"
+                        },
+                        "BackupRetentionPeriod": {
+                            "type": "number"
+                        },
+                        "DBClusterParameterGroupName": {
+                            "type": "string"
+                        },
+                        "DBSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "DatabaseName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string"
+                        },
+                        "MasterUsername": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredBackupWindow": {
+                            "type": "string"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "ReplicationSourceIdentifier": {
+                            "type": "string"
+                        },
+                        "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "StorageEncrypted": {
+                            "type": "boolean"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Engine"
+                    ],
+                    "type": "object"
                 },
-                "VpcSecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBCluster"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Engine"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBClusterParameterGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "Family": {
-                    "type": "string"
-                },
-                "Parameters": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Family": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "Family",
+                        "Parameters"
+                    ],
                     "type": "object"
                 },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBClusterParameterGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Description",
-                "Family",
-                "Parameters"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBInstance": {
+            "additionalProperties": false,
             "properties": {
-                "AllocatedStorage": {
-                    "type": "string"
-                },
-                "AllowMajorVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "AutoMinorVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "BackupRetentionPeriod": {
-                    "type": "string"
-                },
-                "CharacterSetName": {
-                    "type": "string"
-                },
-                "CopyTagsToSnapshot": {
-                    "type": "boolean"
-                },
-                "DBClusterIdentifier": {
-                    "type": "string"
-                },
-                "DBInstanceClass": {
-                    "type": "string"
-                },
-                "DBInstanceIdentifier": {
-                    "type": "string"
-                },
-                "DBName": {
-                    "type": "string"
-                },
-                "DBParameterGroupName": {
-                    "type": "string"
-                },
-                "DBSecurityGroups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocatedStorage": {
+                            "type": "string"
+                        },
+                        "AllowMajorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "BackupRetentionPeriod": {
+                            "type": "string"
+                        },
+                        "CharacterSetName": {
+                            "type": "string"
+                        },
+                        "CopyTagsToSnapshot": {
+                            "type": "boolean"
+                        },
+                        "DBClusterIdentifier": {
+                            "type": "string"
+                        },
+                        "DBInstanceClass": {
+                            "type": "string"
+                        },
+                        "DBInstanceIdentifier": {
+                            "type": "string"
+                        },
+                        "DBName": {
+                            "type": "string"
+                        },
+                        "DBParameterGroupName": {
+                            "type": "string"
+                        },
+                        "DBSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "DBSnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "DBSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Domain": {
+                            "type": "string"
+                        },
+                        "DomainIAMRoleName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "Iops": {
+                            "type": "number"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "LicenseModel": {
+                            "type": "string"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string"
+                        },
+                        "MasterUsername": {
+                            "type": "string"
+                        },
+                        "MonitoringInterval": {
+                            "type": "number"
+                        },
+                        "MonitoringRoleArn": {
+                            "type": "string"
+                        },
+                        "MultiAZ": {
+                            "type": "boolean"
+                        },
+                        "OptionGroupName": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "string"
+                        },
+                        "PreferredBackupWindow": {
+                            "type": "string"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PubliclyAccessible": {
+                            "type": "boolean"
+                        },
+                        "SourceDBInstanceIdentifier": {
+                            "type": "string"
+                        },
+                        "StorageEncrypted": {
+                            "type": "boolean"
+                        },
+                        "StorageType": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Timezone": {
+                            "type": "string"
+                        },
+                        "VPCSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "DBInstanceClass"
+                    ],
+                    "type": "object"
                 },
-                "DBSnapshotIdentifier": {
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBInstance"
+                    ],
                     "type": "string"
-                },
-                "DBSubnetGroupName": {
-                    "type": "string"
-                },
-                "Domain": {
-                    "type": "string"
-                },
-                "DomainIAMRoleName": {
-                    "type": "string"
-                },
-                "Engine": {
-                    "type": "string"
-                },
-                "EngineVersion": {
-                    "type": "string"
-                },
-                "Iops": {
-                    "type": "number"
-                },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "LicenseModel": {
-                    "type": "string"
-                },
-                "MasterUserPassword": {
-                    "type": "string"
-                },
-                "MasterUsername": {
-                    "type": "string"
-                },
-                "MonitoringInterval": {
-                    "type": "number"
-                },
-                "MonitoringRoleArn": {
-                    "type": "string"
-                },
-                "MultiAZ": {
-                    "type": "boolean"
-                },
-                "OptionGroupName": {
-                    "type": "string"
-                },
-                "Port": {
-                    "type": "string"
-                },
-                "PreferredBackupWindow": {
-                    "type": "string"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "PubliclyAccessible": {
-                    "type": "boolean"
-                },
-                "SourceDBInstanceIdentifier": {
-                    "type": "string"
-                },
-                "StorageEncrypted": {
-                    "type": "boolean"
-                },
-                "StorageType": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "Timezone": {
-                    "type": "string"
-                },
-                "VPCSecurityGroups": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "DBInstanceClass"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBParameterGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "Family": {
-                    "type": "string"
-                },
-                "Parameters": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
                             "type": "string"
+                        },
+                        "Family": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
+                    "required": [
+                        "Description",
+                        "Family"
+                    ],
                     "type": "object"
                 },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBParameterGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Description",
-                "Family"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBSecurityGroup": {
+            "additionalProperties": false,
             "properties": {
-                "DBSecurityGroupIngress": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::RDS::DBSecurityGroup.Ingress"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DBSecurityGroupIngress": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBSecurityGroup.Ingress"
+                            },
+                            "type": "array"
+                        },
+                        "EC2VpcId": {
+                            "type": "string"
+                        },
+                        "GroupDescription": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "DBSecurityGroupIngress",
+                        "GroupDescription"
+                    ],
+                    "type": "object"
                 },
-                "EC2VpcId": {
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBSecurityGroup"
+                    ],
                     "type": "string"
-                },
-                "GroupDescription": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "DBSecurityGroupIngress",
-                "GroupDescription"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBSecurityGroup.Ingress": {
+            "additionalProperties": false,
             "properties": {
                 "CIDRIP": {
                     "type": "string"
@@ -11975,114 +15395,183 @@
             "type": "object"
         },
         "AWS::RDS::DBSecurityGroupIngress": {
+            "additionalProperties": false,
             "properties": {
-                "CIDRIP": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CIDRIP": {
+                            "type": "string"
+                        },
+                        "DBSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupId": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupOwnerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DBSecurityGroupName"
+                    ],
+                    "type": "object"
                 },
-                "DBSecurityGroupName": {
-                    "type": "string"
-                },
-                "EC2SecurityGroupId": {
-                    "type": "string"
-                },
-                "EC2SecurityGroupName": {
-                    "type": "string"
-                },
-                "EC2SecurityGroupOwnerId": {
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBSecurityGroupIngress"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DBSecurityGroupName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::DBSubnetGroup": {
+            "additionalProperties": false,
             "properties": {
-                "DBSubnetGroupDescription": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DBSubnetGroupDescription": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DBSubnetGroupDescription",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBSubnetGroup"
+                    ],
                     "type": "string"
-                },
-                "SubnetIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "DBSubnetGroupDescription",
-                "SubnetIds"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::EventSubscription": {
+            "additionalProperties": false,
             "properties": {
-                "Enabled": {
-                    "type": "boolean"
-                },
-                "EventCategories": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "EventCategories": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        },
+                        "SourceIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SourceType": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
                 },
-                "SnsTopicArn": {
-                    "type": "string"
-                },
-                "SourceIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "SourceType": {
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::EventSubscription"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "SnsTopicArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::OptionGroup": {
+            "additionalProperties": false,
             "properties": {
-                "EngineName": {
-                    "type": "string"
-                },
-                "MajorEngineVersion": {
-                    "type": "string"
-                },
-                "OptionConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::RDS::OptionGroup.OptionConfiguration"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "EngineName": {
+                            "type": "string"
+                        },
+                        "MajorEngineVersion": {
+                            "type": "string"
+                        },
+                        "OptionConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::OptionGroup.OptionConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "OptionGroupDescription": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "EngineName",
+                        "MajorEngineVersion",
+                        "OptionConfigurations",
+                        "OptionGroupDescription"
+                    ],
+                    "type": "object"
                 },
-                "OptionGroupDescription": {
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::OptionGroup"
+                    ],
                     "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "EngineName",
-                "MajorEngineVersion",
-                "OptionConfigurations",
-                "OptionGroupDescription"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::RDS::OptionGroup.OptionConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "DBSecurityGroupMemberships": {
                     "items": {
@@ -12112,6 +15601,7 @@
             "type": "object"
         },
         "AWS::RDS::OptionGroup.OptionSetting": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -12123,114 +15613,132 @@
             "type": "object"
         },
         "AWS::Redshift::Cluster": {
+            "additionalProperties": false,
             "properties": {
-                "AllowVersionUpgrade": {
-                    "type": "boolean"
-                },
-                "AutomatedSnapshotRetentionPeriod": {
-                    "type": "number"
-                },
-                "AvailabilityZone": {
-                    "type": "string"
-                },
-                "ClusterParameterGroupName": {
-                    "type": "string"
-                },
-                "ClusterSecurityGroups": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutomatedSnapshotRetentionPeriod": {
+                            "type": "number"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "ClusterParameterGroupName": {
+                            "type": "string"
+                        },
+                        "ClusterSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ClusterSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "ClusterType": {
+                            "type": "string"
+                        },
+                        "ClusterVersion": {
+                            "type": "string"
+                        },
+                        "DBName": {
+                            "type": "string"
+                        },
+                        "ElasticIp": {
+                            "type": "string"
+                        },
+                        "Encrypted": {
+                            "type": "boolean"
+                        },
+                        "HsmClientCertificateIdentifier": {
+                            "type": "string"
+                        },
+                        "HsmConfigurationIdentifier": {
+                            "type": "string"
+                        },
+                        "IamRoles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "LoggingProperties": {
+                            "$ref": "#/definitions/AWS::Redshift::Cluster.LoggingProperties"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string"
+                        },
+                        "MasterUsername": {
+                            "type": "string"
+                        },
+                        "NodeType": {
+                            "type": "string"
+                        },
+                        "NumberOfNodes": {
+                            "type": "number"
+                        },
+                        "OwnerAccount": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PubliclyAccessible": {
+                            "type": "boolean"
+                        },
+                        "SnapshotClusterIdentifier": {
+                            "type": "string"
+                        },
+                        "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "ClusterType",
+                        "DBName",
+                        "MasterUserPassword",
+                        "MasterUsername",
+                        "NodeType"
+                    ],
+                    "type": "object"
                 },
-                "ClusterSubnetGroupName": {
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::Cluster"
+                    ],
                     "type": "string"
-                },
-                "ClusterType": {
-                    "type": "string"
-                },
-                "ClusterVersion": {
-                    "type": "string"
-                },
-                "DBName": {
-                    "type": "string"
-                },
-                "ElasticIp": {
-                    "type": "string"
-                },
-                "Encrypted": {
-                    "type": "boolean"
-                },
-                "HsmClientCertificateIdentifier": {
-                    "type": "string"
-                },
-                "HsmConfigurationIdentifier": {
-                    "type": "string"
-                },
-                "IamRoles": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "KmsKeyId": {
-                    "type": "string"
-                },
-                "LoggingProperties": {
-                    "$ref": "#/definitions/AWS::Redshift::Cluster.LoggingProperties"
-                },
-                "MasterUserPassword": {
-                    "type": "string"
-                },
-                "MasterUsername": {
-                    "type": "string"
-                },
-                "NodeType": {
-                    "type": "string"
-                },
-                "NumberOfNodes": {
-                    "type": "number"
-                },
-                "OwnerAccount": {
-                    "type": "string"
-                },
-                "Port": {
-                    "type": "number"
-                },
-                "PreferredMaintenanceWindow": {
-                    "type": "string"
-                },
-                "PubliclyAccessible": {
-                    "type": "boolean"
-                },
-                "SnapshotClusterIdentifier": {
-                    "type": "string"
-                },
-                "SnapshotIdentifier": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "VpcSecurityGroupIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "ClusterType",
-                "DBName",
-                "MasterUserPassword",
-                "MasterUsername",
-                "NodeType"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Redshift::Cluster.LoggingProperties": {
+            "additionalProperties": false,
             "properties": {
                 "BucketName": {
                     "type": "string"
@@ -12245,33 +15753,51 @@
             "type": "object"
         },
         "AWS::Redshift::ClusterParameterGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "ParameterGroupFamily": {
-                    "type": "string"
-                },
-                "Parameters": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Redshift::ClusterParameterGroup.Parameter"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "ParameterGroupFamily": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Redshift::ClusterParameterGroup.Parameter"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Description",
+                        "ParameterGroupFamily"
+                    ],
+                    "type": "object"
                 },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterParameterGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Description",
-                "ParameterGroupFamily"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Redshift::ClusterParameterGroup.Parameter": {
+            "additionalProperties": false,
             "properties": {
                 "ParameterName": {
                     "type": "string"
@@ -12287,84 +15813,153 @@
             "type": "object"
         },
         "AWS::Redshift::ClusterSecurityGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Description"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterSecurityGroup"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Description"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Redshift::ClusterSecurityGroupIngress": {
+            "additionalProperties": false,
             "properties": {
-                "CIDRIP": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CIDRIP": {
+                            "type": "string"
+                        },
+                        "ClusterSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupOwnerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ClusterSecurityGroupName"
+                    ],
+                    "type": "object"
                 },
-                "ClusterSecurityGroupName": {
-                    "type": "string"
-                },
-                "EC2SecurityGroupName": {
-                    "type": "string"
-                },
-                "EC2SecurityGroupOwnerId": {
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterSecurityGroupIngress"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ClusterSecurityGroupName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Redshift::ClusterSubnetGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterSubnetGroup"
+                    ],
                     "type": "string"
-                },
-                "SubnetIds": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "Description",
-                "SubnetIds"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Route53::HealthCheck": {
+            "additionalProperties": false,
             "properties": {
-                "HealthCheckConfig": {
-                    "$ref": "#/definitions/AWS::Route53::HealthCheck.HealthCheckConfig"
-                },
-                "HealthCheckTags": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Route53::HealthCheck.HealthCheckTag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "HealthCheckConfig": {
+                            "$ref": "#/definitions/AWS::Route53::HealthCheck.HealthCheckConfig"
+                        },
+                        "HealthCheckTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::HealthCheck.HealthCheckTag"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "HealthCheckConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::HealthCheck"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "HealthCheckConfig"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Route53::HealthCheck.AlarmIdentifier": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -12380,6 +15975,7 @@
             "type": "object"
         },
         "AWS::Route53::HealthCheck.HealthCheckConfig": {
+            "additionalProperties": false,
             "properties": {
                 "AlarmIdentifier": {
                     "$ref": "#/definitions/AWS::Route53::HealthCheck.AlarmIdentifier"
@@ -12436,6 +16032,7 @@
             "type": "object"
         },
         "AWS::Route53::HealthCheck.HealthCheckTag": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -12451,32 +16048,50 @@
             "type": "object"
         },
         "AWS::Route53::HostedZone": {
+            "additionalProperties": false,
             "properties": {
-                "HostedZoneConfig": {
-                    "$ref": "#/definitions/AWS::Route53::HostedZone.HostedZoneConfig"
-                },
-                "HostedZoneTags": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Route53::HostedZone.HostedZoneTag"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "HostedZoneConfig": {
+                            "$ref": "#/definitions/AWS::Route53::HostedZone.HostedZoneConfig"
+                        },
+                        "HostedZoneTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::HostedZone.HostedZoneTag"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "VPCs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::HostedZone.VPC"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::HostedZone"
+                    ],
                     "type": "string"
-                },
-                "VPCs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Route53::HostedZone.VPC"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Route53::HostedZone.HostedZoneConfig": {
+            "additionalProperties": false,
             "properties": {
                 "Comment": {
                     "type": "string"
@@ -12485,6 +16100,7 @@
             "type": "object"
         },
         "AWS::Route53::HostedZone.HostedZoneTag": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -12500,6 +16116,7 @@
             "type": "object"
         },
         "AWS::Route53::HostedZone.VPC": {
+            "additionalProperties": false,
             "properties": {
                 "VPCId": {
                     "type": "string"
@@ -12515,60 +16132,78 @@
             "type": "object"
         },
         "AWS::Route53::RecordSet": {
+            "additionalProperties": false,
             "properties": {
-                "AliasTarget": {
-                    "$ref": "#/definitions/AWS::Route53::RecordSet.AliasTarget"
-                },
-                "Comment": {
-                    "type": "string"
-                },
-                "Failover": {
-                    "type": "string"
-                },
-                "GeoLocation": {
-                    "$ref": "#/definitions/AWS::Route53::RecordSet.GeoLocation"
-                },
-                "HealthCheckId": {
-                    "type": "string"
-                },
-                "HostedZoneId": {
-                    "type": "string"
-                },
-                "HostedZoneName": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Region": {
-                    "type": "string"
-                },
-                "ResourceRecords": {
-                    "items": {
-                        "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AliasTarget": {
+                            "$ref": "#/definitions/AWS::Route53::RecordSet.AliasTarget"
+                        },
+                        "Comment": {
+                            "type": "string"
+                        },
+                        "Failover": {
+                            "type": "string"
+                        },
+                        "GeoLocation": {
+                            "$ref": "#/definitions/AWS::Route53::RecordSet.GeoLocation"
+                        },
+                        "HealthCheckId": {
+                            "type": "string"
+                        },
+                        "HostedZoneId": {
+                            "type": "string"
+                        },
+                        "HostedZoneName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Region": {
+                            "type": "string"
+                        },
+                        "ResourceRecords": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SetIdentifier": {
+                            "type": "string"
+                        },
+                        "TTL": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "Weight": {
+                            "type": "number"
+                        }
                     },
-                    "type": "array"
-                },
-                "SetIdentifier": {
-                    "type": "string"
-                },
-                "TTL": {
-                    "type": "string"
+                    "required": [
+                        "Name",
+                        "Type"
+                    ],
+                    "type": "object"
                 },
                 "Type": {
+                    "enum": [
+                        "AWS::Route53::RecordSet"
+                    ],
                     "type": "string"
-                },
-                "Weight": {
-                    "type": "number"
                 }
             },
             "required": [
-                "Name",
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Route53::RecordSet.AliasTarget": {
+            "additionalProperties": false,
             "properties": {
                 "DNSName": {
                     "type": "string"
@@ -12587,6 +16222,7 @@
             "type": "object"
         },
         "AWS::Route53::RecordSet.GeoLocation": {
+            "additionalProperties": false,
             "properties": {
                 "ContinentCode": {
                     "type": "string"
@@ -12601,26 +16237,43 @@
             "type": "object"
         },
         "AWS::Route53::RecordSetGroup": {
+            "additionalProperties": false,
             "properties": {
-                "Comment": {
-                    "type": "string"
-                },
-                "HostedZoneId": {
-                    "type": "string"
-                },
-                "HostedZoneName": {
-                    "type": "string"
-                },
-                "RecordSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Route53::RecordSetGroup.RecordSet"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Comment": {
+                            "type": "string"
+                        },
+                        "HostedZoneId": {
+                            "type": "string"
+                        },
+                        "HostedZoneName": {
+                            "type": "string"
+                        },
+                        "RecordSets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::RecordSetGroup.RecordSet"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::RecordSetGroup"
+                    ],
+                    "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Route53::RecordSetGroup.AliasTarget": {
+            "additionalProperties": false,
             "properties": {
                 "DNSName": {
                     "type": "string"
@@ -12639,6 +16292,7 @@
             "type": "object"
         },
         "AWS::Route53::RecordSetGroup.GeoLocation": {
+            "additionalProperties": false,
             "properties": {
                 "ContinentCode": {
                     "type": "string"
@@ -12653,6 +16307,7 @@
             "type": "object"
         },
         "AWS::Route53::RecordSetGroup.RecordSet": {
+            "additionalProperties": false,
             "properties": {
                 "AliasTarget": {
                     "$ref": "#/definitions/AWS::Route53::RecordSetGroup.AliasTarget"
@@ -12707,65 +16362,82 @@
             "type": "object"
         },
         "AWS::S3::Bucket": {
+            "additionalProperties": false,
             "properties": {
-                "AccelerateConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.AccelerateConfiguration"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccelerateConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.AccelerateConfiguration"
+                        },
+                        "AccessControl": {
+                            "type": "string"
+                        },
+                        "AnalyticsConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::S3::Bucket.AnalyticsConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "BucketName": {
+                            "type": "string"
+                        },
+                        "CorsConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.CorsConfiguration"
+                        },
+                        "InventoryConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::S3::Bucket.InventoryConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "LifecycleConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.LifecycleConfiguration"
+                        },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.LoggingConfiguration"
+                        },
+                        "MetricsConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::S3::Bucket.MetricsConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.NotificationConfiguration"
+                        },
+                        "ReplicationConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.ReplicationConfiguration"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VersioningConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.VersioningConfiguration"
+                        },
+                        "WebsiteConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.WebsiteConfiguration"
+                        }
+                    },
+                    "type": "object"
                 },
-                "AccessControl": {
+                "Type": {
+                    "enum": [
+                        "AWS::S3::Bucket"
+                    ],
                     "type": "string"
-                },
-                "AnalyticsConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::S3::Bucket.AnalyticsConfiguration"
-                    },
-                    "type": "array"
-                },
-                "BucketName": {
-                    "type": "string"
-                },
-                "CorsConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.CorsConfiguration"
-                },
-                "InventoryConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::S3::Bucket.InventoryConfiguration"
-                    },
-                    "type": "array"
-                },
-                "LifecycleConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.LifecycleConfiguration"
-                },
-                "LoggingConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.LoggingConfiguration"
-                },
-                "MetricsConfigurations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::S3::Bucket.MetricsConfiguration"
-                    },
-                    "type": "array"
-                },
-                "NotificationConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.NotificationConfiguration"
-                },
-                "ReplicationConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.ReplicationConfiguration"
-                },
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                },
-                "VersioningConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.VersioningConfiguration"
-                },
-                "WebsiteConfiguration": {
-                    "$ref": "#/definitions/AWS::S3::Bucket.WebsiteConfiguration"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::S3::Bucket.AbortIncompleteMultipartUpload": {
+            "additionalProperties": false,
             "properties": {
                 "DaysAfterInitiation": {
                     "type": "number"
@@ -12777,6 +16449,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.AccelerateConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "AccelerationStatus": {
                     "type": "string"
@@ -12788,6 +16461,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.AnalyticsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Id": {
                     "type": "string"
@@ -12812,6 +16486,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.CorsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "CorsRules": {
                     "items": {
@@ -12826,6 +16501,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.CorsRule": {
+            "additionalProperties": false,
             "properties": {
                 "AllowedHeaders": {
                     "items": {
@@ -12865,6 +16541,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.DataExport": {
+            "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "$ref": "#/definitions/AWS::S3::Bucket.Destination"
@@ -12880,6 +16557,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.Destination": {
+            "additionalProperties": false,
             "properties": {
                 "BucketAccountId": {
                     "type": "string"
@@ -12901,6 +16579,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.FilterRule": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -12916,6 +16595,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.InventoryConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "$ref": "#/definitions/AWS::S3::Bucket.Destination"
@@ -12952,6 +16632,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.LambdaConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Event": {
                     "type": "string"
@@ -12970,6 +16651,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.LifecycleConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Rules": {
                     "items": {
@@ -12984,6 +16666,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.LoggingConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "DestinationBucketName": {
                     "type": "string"
@@ -12995,6 +16678,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.MetricsConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Id": {
                     "type": "string"
@@ -13015,6 +16699,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.NoncurrentVersionTransition": {
+            "additionalProperties": false,
             "properties": {
                 "StorageClass": {
                     "type": "string"
@@ -13030,6 +16715,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.NotificationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "LambdaConfigurations": {
                     "items": {
@@ -13053,6 +16739,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.NotificationFilter": {
+            "additionalProperties": false,
             "properties": {
                 "S3Key": {
                     "$ref": "#/definitions/AWS::S3::Bucket.S3KeyFilter"
@@ -13064,6 +16751,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.QueueConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Event": {
                     "type": "string"
@@ -13082,6 +16770,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.RedirectAllRequestsTo": {
+            "additionalProperties": false,
             "properties": {
                 "HostName": {
                     "type": "string"
@@ -13096,6 +16785,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.RedirectRule": {
+            "additionalProperties": false,
             "properties": {
                 "HostName": {
                     "type": "string"
@@ -13116,6 +16806,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.ReplicationConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Role": {
                     "type": "string"
@@ -13134,6 +16825,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.ReplicationDestination": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -13148,6 +16840,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.ReplicationRule": {
+            "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "$ref": "#/definitions/AWS::S3::Bucket.ReplicationDestination"
@@ -13170,6 +16863,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.RoutingRule": {
+            "additionalProperties": false,
             "properties": {
                 "RedirectRule": {
                     "$ref": "#/definitions/AWS::S3::Bucket.RedirectRule"
@@ -13184,6 +16878,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.RoutingRuleCondition": {
+            "additionalProperties": false,
             "properties": {
                 "HttpErrorCodeReturnedEquals": {
                     "type": "string"
@@ -13195,6 +16890,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.Rule": {
+            "additionalProperties": false,
             "properties": {
                 "AbortIncompleteMultipartUpload": {
                     "$ref": "#/definitions/AWS::S3::Bucket.AbortIncompleteMultipartUpload"
@@ -13248,6 +16944,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.S3KeyFilter": {
+            "additionalProperties": false,
             "properties": {
                 "Rules": {
                     "items": {
@@ -13262,6 +16959,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.StorageClassAnalysis": {
+            "additionalProperties": false,
             "properties": {
                 "DataExport": {
                     "$ref": "#/definitions/AWS::S3::Bucket.DataExport"
@@ -13270,6 +16968,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.TagFilter": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -13285,6 +16984,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.TopicConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Event": {
                     "type": "string"
@@ -13303,6 +17003,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.Transition": {
+            "additionalProperties": false,
             "properties": {
                 "StorageClass": {
                     "type": "string"
@@ -13320,6 +17021,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.VersioningConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "Status": {
                     "type": "string"
@@ -13331,6 +17033,7 @@
             "type": "object"
         },
         "AWS::S3::Bucket.WebsiteConfiguration": {
+            "additionalProperties": false,
             "properties": {
                 "ErrorDocument": {
                     "type": "string"
@@ -13351,60 +17054,126 @@
             "type": "object"
         },
         "AWS::S3::BucketPolicy": {
+            "additionalProperties": false,
             "properties": {
-                "Bucket": {
-                    "type": "string"
-                },
-                "PolicyDocument": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Bucket": {
+                            "type": "string"
+                        },
+                        "PolicyDocument": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "Bucket",
+                        "PolicyDocument"
+                    ],
                     "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::BucketPolicy"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Bucket",
-                "PolicyDocument"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::SDB::Domain": {
+            "additionalProperties": false,
             "properties": {
-                "Description": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SDB::Domain"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::SNS::Subscription": {
+            "additionalProperties": false,
             "properties": {
-                "Endpoint": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Endpoint": {
+                            "type": "string"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "TopicArn": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
-                "Protocol": {
-                    "type": "string"
-                },
-                "TopicArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::SNS::Subscription"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::SNS::Topic": {
+            "additionalProperties": false,
             "properties": {
-                "DisplayName": {
-                    "type": "string"
-                },
-                "Subscription": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::SNS::Topic.Subscription"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DisplayName": {
+                            "type": "string"
+                        },
+                        "Subscription": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SNS::Topic.Subscription"
+                            },
+                            "type": "array"
+                        },
+                        "TopicName": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "type": "object"
                 },
-                "TopicName": {
+                "Type": {
+                    "enum": [
+                        "AWS::SNS::Topic"
+                    ],
                     "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::SNS::Topic.Subscription": {
+            "additionalProperties": false,
             "properties": {
                 "Endpoint": {
                     "type": "string"
@@ -13420,114 +17189,183 @@
             "type": "object"
         },
         "AWS::SNS::TopicPolicy": {
+            "additionalProperties": false,
             "properties": {
-                "PolicyDocument": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "Topics": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument",
+                        "Topics"
+                    ],
                     "type": "object"
                 },
-                "Topics": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
+                "Type": {
+                    "enum": [
+                        "AWS::SNS::TopicPolicy"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "PolicyDocument",
-                "Topics"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::SQS::Queue": {
+            "additionalProperties": false,
             "properties": {
-                "ContentBasedDeduplication": {
-                    "type": "boolean"
-                },
-                "DelaySeconds": {
-                    "type": "number"
-                },
-                "FifoQueue": {
-                    "type": "boolean"
-                },
-                "KmsDataKeyReusePeriodSeconds": {
-                    "type": "number"
-                },
-                "KmsMasterKeyId": {
-                    "type": "string"
-                },
-                "MaximumMessageSize": {
-                    "type": "number"
-                },
-                "MessageRetentionPeriod": {
-                    "type": "number"
-                },
-                "QueueName": {
-                    "type": "string"
-                },
-                "ReceiveMessageWaitTimeSeconds": {
-                    "type": "number"
-                },
-                "RedrivePolicy": {
-                    "type": "object"
-                },
-                "VisibilityTimeout": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::SQS::QueuePolicy": {
-            "properties": {
-                "PolicyDocument": {
-                    "type": "object"
-                },
-                "Queues": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "PolicyDocument",
-                "Queues"
-            ],
-            "type": "object"
-        },
-        "AWS::SSM::Association": {
-            "properties": {
-                "DocumentVersion": {
-                    "type": "string"
-                },
-                "InstanceId": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Parameters": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
-                            "$ref": "#/definitions/AWS::SSM::Association.ParameterValues"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContentBasedDeduplication": {
+                            "type": "boolean"
+                        },
+                        "DelaySeconds": {
+                            "type": "number"
+                        },
+                        "FifoQueue": {
+                            "type": "boolean"
+                        },
+                        "KmsDataKeyReusePeriodSeconds": {
+                            "type": "number"
+                        },
+                        "KmsMasterKeyId": {
+                            "type": "string"
+                        },
+                        "MaximumMessageSize": {
+                            "type": "number"
+                        },
+                        "MessageRetentionPeriod": {
+                            "type": "number"
+                        },
+                        "QueueName": {
+                            "type": "string"
+                        },
+                        "ReceiveMessageWaitTimeSeconds": {
+                            "type": "number"
+                        },
+                        "RedrivePolicy": {
+                            "type": "object"
+                        },
+                        "VisibilityTimeout": {
+                            "type": "number"
                         }
                     },
                     "type": "object"
                 },
-                "ScheduleExpression": {
+                "Type": {
+                    "enum": [
+                        "AWS::SQS::Queue"
+                    ],
                     "type": "string"
-                },
-                "Targets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::SSM::Association.Target"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
-                "Name"
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SQS::QueuePolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "Queues": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument",
+                        "Queues"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SQS::QueuePolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Association": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DocumentVersion": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "$ref": "#/definitions/AWS::SSM::Association.ParameterValues"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ScheduleExpression": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SSM::Association.Target"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::Association"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::SSM::Association.ParameterValues": {
+            "additionalProperties": false,
             "properties": {
                 "ParameterValues": {
                     "items": {
@@ -13542,6 +17380,7 @@
             "type": "object"
         },
         "AWS::SSM::Association.Target": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -13560,87 +17399,173 @@
             "type": "object"
         },
         "AWS::SSM::Document": {
+            "additionalProperties": false,
             "properties": {
-                "Content": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Content": {
+                            "type": "object"
+                        },
+                        "DocumentType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Content"
+                    ],
                     "type": "object"
                 },
-                "DocumentType": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "Content"
-            ],
-            "type": "object"
-        },
-        "AWS::SSM::Parameter": {
-            "properties": {
-                "AllowedPattern": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
                 "Type": {
-                    "type": "string"
-                },
-                "Value": {
+                    "enum": [
+                        "AWS::SSM::Document"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
                 "Type",
-                "Value"
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Parameter": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowedPattern": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "Value": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type",
+                        "Value"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::Parameter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::StepFunctions::Activity": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::StepFunctions::Activity"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::StepFunctions::StateMachine": {
+            "additionalProperties": false,
             "properties": {
-                "DefinitionString": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefinitionString": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DefinitionString",
+                        "RoleArn"
+                    ],
+                    "type": "object"
                 },
-                "RoleArn": {
+                "Type": {
+                    "enum": [
+                        "AWS::StepFunctions::StateMachine"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "DefinitionString",
-                "RoleArn"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::ByteMatchSet": {
+            "additionalProperties": false,
             "properties": {
-                "ByteMatchTuples": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::ByteMatchSet.ByteMatchTuple"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ByteMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::ByteMatchSet.ByteMatchTuple"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::ByteMatchSet"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::ByteMatchSet.ByteMatchTuple": {
+            "additionalProperties": false,
             "properties": {
                 "FieldToMatch": {
                     "$ref": "#/definitions/AWS::WAF::ByteMatchSet.FieldToMatch"
@@ -13666,6 +17591,7 @@
             "type": "object"
         },
         "AWS::WAF::ByteMatchSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -13680,23 +17606,41 @@
             "type": "object"
         },
         "AWS::WAF::IPSet": {
+            "additionalProperties": false,
             "properties": {
-                "IPSetDescriptors": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::IPSet.IPSetDescriptor"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IPSetDescriptors": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::IPSet.IPSetDescriptor"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::IPSet"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::IPSet.IPSetDescriptor": {
+            "additionalProperties": false,
             "properties": {
                 "Type": {
                     "type": "string"
@@ -13712,27 +17656,45 @@
             "type": "object"
         },
         "AWS::WAF::Rule": {
+            "additionalProperties": false,
             "properties": {
-                "MetricName": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Predicates": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::Rule.Predicate"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Predicates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::Rule.Predicate"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::Rule"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "MetricName",
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::Rule.Predicate": {
+            "additionalProperties": false,
             "properties": {
                 "DataId": {
                     "type": "string"
@@ -13752,24 +17714,42 @@
             "type": "object"
         },
         "AWS::WAF::SizeConstraintSet": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "SizeConstraints": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::SizeConstraintSet.SizeConstraint"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SizeConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::SizeConstraintSet.SizeConstraint"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name",
+                        "SizeConstraints"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::SizeConstraintSet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Name",
-                "SizeConstraints"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::SizeConstraintSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -13784,6 +17764,7 @@
             "type": "object"
         },
         "AWS::WAF::SizeConstraintSet.SizeConstraint": {
+            "additionalProperties": false,
             "properties": {
                 "ComparisonOperator": {
                     "type": "string"
@@ -13807,23 +17788,41 @@
             "type": "object"
         },
         "AWS::WAF::SqlInjectionMatchSet": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "SqlInjectionMatchTuples": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::SqlInjectionMatchSet.SqlInjectionMatchTuple"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SqlInjectionMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::SqlInjectionMatchSet.SqlInjectionMatchTuple"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::SqlInjectionMatchSet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::SqlInjectionMatchSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -13838,6 +17837,7 @@
             "type": "object"
         },
         "AWS::WAF::SqlInjectionMatchSet.SqlInjectionMatchTuple": {
+            "additionalProperties": false,
             "properties": {
                 "FieldToMatch": {
                     "$ref": "#/definitions/AWS::WAF::SqlInjectionMatchSet.FieldToMatch"
@@ -13853,31 +17853,49 @@
             "type": "object"
         },
         "AWS::WAF::WebACL": {
+            "additionalProperties": false,
             "properties": {
-                "DefaultAction": {
-                    "$ref": "#/definitions/AWS::WAF::WebACL.WafAction"
-                },
-                "MetricName": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::WebACL.ActivatedRule"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultAction": {
+                            "$ref": "#/definitions/AWS::WAF::WebACL.WafAction"
+                        },
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Rules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::WebACL.ActivatedRule"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "DefaultAction",
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::WebACL"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "DefaultAction",
-                "MetricName",
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::WebACL.ActivatedRule": {
+            "additionalProperties": false,
             "properties": {
                 "Action": {
                     "$ref": "#/definitions/AWS::WAF::WebACL.WafAction"
@@ -13897,6 +17915,7 @@
             "type": "object"
         },
         "AWS::WAF::WebACL.WafAction": {
+            "additionalProperties": false,
             "properties": {
                 "Type": {
                     "type": "string"
@@ -13908,24 +17927,42 @@
             "type": "object"
         },
         "AWS::WAF::XssMatchSet": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "XssMatchTuples": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAF::XssMatchSet.XssMatchTuple"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "XssMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::XssMatchSet.XssMatchTuple"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name",
+                        "XssMatchTuples"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::XssMatchSet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Name",
-                "XssMatchTuples"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAF::XssMatchSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -13940,6 +17977,7 @@
             "type": "object"
         },
         "AWS::WAF::XssMatchSet.XssMatchTuple": {
+            "additionalProperties": false,
             "properties": {
                 "FieldToMatch": {
                     "$ref": "#/definitions/AWS::WAF::XssMatchSet.FieldToMatch"
@@ -13955,23 +17993,41 @@
             "type": "object"
         },
         "AWS::WAFRegional::ByteMatchSet": {
+            "additionalProperties": false,
             "properties": {
-                "ByteMatchTuples": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::ByteMatchSet.ByteMatchTuple"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ByteMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::ByteMatchSet.ByteMatchTuple"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::ByteMatchSet"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::ByteMatchSet.ByteMatchTuple": {
+            "additionalProperties": false,
             "properties": {
                 "FieldToMatch": {
                     "$ref": "#/definitions/AWS::WAFRegional::ByteMatchSet.FieldToMatch"
@@ -13997,6 +18053,7 @@
             "type": "object"
         },
         "AWS::WAFRegional::ByteMatchSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -14011,23 +18068,41 @@
             "type": "object"
         },
         "AWS::WAFRegional::IPSet": {
+            "additionalProperties": false,
             "properties": {
-                "IPSetDescriptors": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::IPSet.IPSetDescriptor"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IPSetDescriptors": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::IPSet.IPSetDescriptor"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
                 },
-                "Name": {
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::IPSet"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::IPSet.IPSetDescriptor": {
+            "additionalProperties": false,
             "properties": {
                 "Type": {
                     "type": "string"
@@ -14043,27 +18118,45 @@
             "type": "object"
         },
         "AWS::WAFRegional::Rule": {
+            "additionalProperties": false,
             "properties": {
-                "MetricName": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Predicates": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::Rule.Predicate"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Predicates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::Rule.Predicate"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::Rule"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "MetricName",
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::Rule.Predicate": {
+            "additionalProperties": false,
             "properties": {
                 "DataId": {
                     "type": "string"
@@ -14083,23 +18176,41 @@
             "type": "object"
         },
         "AWS::WAFRegional::SizeConstraintSet": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "SizeConstraints": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::SizeConstraintSet.SizeConstraint"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SizeConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::SizeConstraintSet.SizeConstraint"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::SizeConstraintSet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::SizeConstraintSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -14114,6 +18225,7 @@
             "type": "object"
         },
         "AWS::WAFRegional::SizeConstraintSet.SizeConstraint": {
+            "additionalProperties": false,
             "properties": {
                 "ComparisonOperator": {
                     "type": "string"
@@ -14137,23 +18249,41 @@
             "type": "object"
         },
         "AWS::WAFRegional::SqlInjectionMatchSet": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "SqlInjectionMatchTuples": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::SqlInjectionMatchSet.SqlInjectionMatchTuple"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SqlInjectionMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::SqlInjectionMatchSet.SqlInjectionMatchTuple"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::SqlInjectionMatchSet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::SqlInjectionMatchSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -14168,6 +18298,7 @@
             "type": "object"
         },
         "AWS::WAFRegional::SqlInjectionMatchSet.SqlInjectionMatchTuple": {
+            "additionalProperties": false,
             "properties": {
                 "FieldToMatch": {
                     "$ref": "#/definitions/AWS::WAFRegional::SqlInjectionMatchSet.FieldToMatch"
@@ -14183,31 +18314,49 @@
             "type": "object"
         },
         "AWS::WAFRegional::WebACL": {
+            "additionalProperties": false,
             "properties": {
-                "DefaultAction": {
-                    "$ref": "#/definitions/AWS::WAFRegional::WebACL.Action"
-                },
-                "MetricName": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::WebACL.Rule"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultAction": {
+                            "$ref": "#/definitions/AWS::WAFRegional::WebACL.Action"
+                        },
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Rules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::WebACL.Rule"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "DefaultAction",
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::WebACL"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "DefaultAction",
-                "MetricName",
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::WebACL.Action": {
+            "additionalProperties": false,
             "properties": {
                 "Type": {
                     "type": "string"
@@ -14219,6 +18368,7 @@
             "type": "object"
         },
         "AWS::WAFRegional::WebACL.Rule": {
+            "additionalProperties": false,
             "properties": {
                 "Action": {
                     "$ref": "#/definitions/AWS::WAFRegional::WebACL.Action"
@@ -14238,38 +18388,73 @@
             "type": "object"
         },
         "AWS::WAFRegional::WebACLAssociation": {
+            "additionalProperties": false,
             "properties": {
-                "ResourceArn": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResourceArn": {
+                            "type": "string"
+                        },
+                        "WebACLId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResourceArn",
+                        "WebACLId"
+                    ],
+                    "type": "object"
                 },
-                "WebACLId": {
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::WebACLAssociation"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "ResourceArn",
-                "WebACLId"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::XssMatchSet": {
+            "additionalProperties": false,
             "properties": {
-                "Name": {
-                    "type": "string"
-                },
-                "XssMatchTuples": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFRegional::XssMatchSet.XssMatchTuple"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "XssMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::XssMatchSet.XssMatchTuple"
+                            },
+                            "type": "array"
+                        }
                     },
-                    "type": "array"
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::XssMatchSet"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "Name"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::WAFRegional::XssMatchSet.FieldToMatch": {
+            "additionalProperties": false,
             "properties": {
                 "Data": {
                     "type": "string"
@@ -14284,6 +18469,7 @@
             "type": "object"
         },
         "AWS::WAFRegional::XssMatchSet.XssMatchTuple": {
+            "additionalProperties": false,
             "properties": {
                 "FieldToMatch": {
                     "$ref": "#/definitions/AWS::WAFRegional::XssMatchSet.FieldToMatch"
@@ -14299,30 +18485,47 @@
             "type": "object"
         },
         "AWS::WorkSpaces::Workspace": {
+            "additionalProperties": false,
             "properties": {
-                "BundleId": {
-                    "type": "string"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BundleId": {
+                            "type": "string"
+                        },
+                        "DirectoryId": {
+                            "type": "string"
+                        },
+                        "RootVolumeEncryptionEnabled": {
+                            "type": "boolean"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        },
+                        "UserVolumeEncryptionEnabled": {
+                            "type": "boolean"
+                        },
+                        "VolumeEncryptionKey": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "BundleId",
+                        "DirectoryId",
+                        "UserName"
+                    ],
+                    "type": "object"
                 },
-                "DirectoryId": {
-                    "type": "string"
-                },
-                "RootVolumeEncryptionEnabled": {
-                    "type": "boolean"
-                },
-                "UserName": {
-                    "type": "string"
-                },
-                "UserVolumeEncryptionEnabled": {
-                    "type": "boolean"
-                },
-                "VolumeEncryptionKey": {
+                "Type": {
+                    "enum": [
+                        "AWS::WorkSpaces::Workspace"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "BundleId",
-                "DirectoryId",
-                "UserName"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
@@ -14398,6 +18601,7 @@
             "type": "object"
         },
         "Tag": {
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string"
@@ -14423,7 +18627,7 @@
         "Conditions": {
             "additionalProperties": false,
             "patternProperties": {
-                ".*": {
+                "^[a-zA-Z0-9]+$": {
                     "type": "object"
                 }
             },
@@ -14437,7 +18641,21 @@
         "Mappings": {
             "additionalProperties": false,
             "patternProperties": {
-                ".*": {
+                "^[a-zA-Z0-9]+$": {
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Metadata": {
+            "type": "object"
+        },
+        "Outputs": {
+            "additionalProperties": false,
+            "maxProperties": 60,
+            "minProperties": 1,
+            "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
                     "type": "object"
                 }
             },
@@ -14454,6 +18672,7 @@
             "type": "object"
         },
         "Resources": {
+            "additionalProperties": false,
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                     "anyOf": [
@@ -15130,7 +19349,16 @@
                 }
             },
             "type": "object"
+        },
+        "Transform": {
+            "type": [
+                "object",
+                "string"
+            ]
         }
     },
+    "required": [
+        "Resources"
+    ],
     "type": "object"
 }

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -1,7 +1,270 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
     "definitions": {
-        "AWS::Serverless::Api": {
+        "AWS::ApiGateway::Account": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CloudWatchRoleArn": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Account"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::ApiKey": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StageKeys": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::ApiKey.StageKey"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::ApiKey"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::ApiKey.StageKey": {
+            "additionalProperties": false,
+            "properties": {
+                "RestApiId": {
+                    "type": "string"
+                },
+                "StageName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::Authorizer": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AuthorizerCredentials": {
+                            "type": "string"
+                        },
+                        "AuthorizerResultTtlInSeconds": {
+                            "type": "number"
+                        },
+                        "AuthorizerUri": {
+                            "type": "string"
+                        },
+                        "IdentitySource": {
+                            "type": "string"
+                        },
+                        "IdentityValidationExpression": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ProviderARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Authorizer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::BasePathMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BasePath": {
+                            "type": "string"
+                        },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "Stage": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DomainName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::BasePathMapping"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::ClientCertificate": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::ClientCertificate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Deployment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "StageDescription": {
+                            "$ref": "#/definitions/AWS::ApiGateway::Deployment.StageDescription"
+                        },
+                        "StageName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Deployment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Deployment.MethodSetting": {
+            "additionalProperties": false,
+            "properties": {
+                "CacheDataEncrypted": {
+                    "type": "boolean"
+                },
+                "CacheTtlInSeconds": {
+                    "type": "number"
+                },
+                "CachingEnabled": {
+                    "type": "boolean"
+                },
+                "DataTraceEnabled": {
+                    "type": "boolean"
+                },
+                "HttpMethod": {
+                    "type": "string"
+                },
+                "LoggingLevel": {
+                    "type": "string"
+                },
+                "MetricsEnabled": {
+                    "type": "boolean"
+                },
+                "ResourcePath": {
+                    "type": "string"
+                },
+                "ThrottlingBurstLimit": {
+                    "type": "number"
+                },
+                "ThrottlingRateLimit": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::Deployment.StageDescription": {
+            "additionalProperties": false,
             "properties": {
                 "CacheClusterEnabled": {
                     "type": "boolean"
@@ -9,19 +272,8242 @@
                 "CacheClusterSize": {
                     "type": "string"
                 },
-                "DefinitionBody": {
-                    "type": "object"
+                "CacheDataEncrypted": {
+                    "type": "boolean"
                 },
-                "DefinitionUri": {
-                    "$ref": "#/definitions/AWS::Serverless::Api."
+                "CacheTtlInSeconds": {
+                    "type": "number"
                 },
-                "Name": {
+                "CachingEnabled": {
+                    "type": "boolean"
+                },
+                "ClientCertificateId": {
                     "type": "string"
+                },
+                "DataTraceEnabled": {
+                    "type": "boolean"
+                },
+                "Description": {
+                    "type": "string"
+                },
+                "DocumentationVersion": {
+                    "type": "string"
+                },
+                "LoggingLevel": {
+                    "type": "string"
+                },
+                "MethodSettings": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ApiGateway::Deployment.MethodSetting"
+                    },
+                    "type": "array"
+                },
+                "MetricsEnabled": {
+                    "type": "boolean"
                 },
                 "StageName": {
                     "type": "string"
                 },
+                "ThrottlingBurstLimit": {
+                    "type": "number"
+                },
+                "ThrottlingRateLimit": {
+                    "type": "number"
+                },
                 "Variables": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::DocumentationPart": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Location": {
+                            "$ref": "#/definitions/AWS::ApiGateway::DocumentationPart.Location"
+                        },
+                        "Properties": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Location",
+                        "Properties",
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::DocumentationPart"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::DocumentationPart.Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Method": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "StatusCode": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::DocumentationVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DocumentationVersion": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DocumentationVersion",
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::DocumentationVersion"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::DomainName": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateArn": {
+                            "type": "string"
+                        },
+                        "DomainName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CertificateArn",
+                        "DomainName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::DomainName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::GatewayResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResponseParameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ResponseTemplates": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ResponseType": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "StatusCode": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResponseType",
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::GatewayResponse"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Method": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApiKeyRequired": {
+                            "type": "boolean"
+                        },
+                        "AuthorizationType": {
+                            "type": "string"
+                        },
+                        "AuthorizerId": {
+                            "type": "string"
+                        },
+                        "HttpMethod": {
+                            "type": "string"
+                        },
+                        "Integration": {
+                            "$ref": "#/definitions/AWS::ApiGateway::Method.Integration"
+                        },
+                        "MethodResponses": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::Method.MethodResponse"
+                            },
+                            "type": "array"
+                        },
+                        "RequestModels": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "RequestParameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "HttpMethod",
+                        "ResourceId",
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Method"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Method.Integration": {
+            "additionalProperties": false,
+            "properties": {
+                "CacheKeyParameters": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "CacheNamespace": {
+                    "type": "string"
+                },
+                "Credentials": {
+                    "type": "string"
+                },
+                "IntegrationHttpMethod": {
+                    "type": "string"
+                },
+                "IntegrationResponses": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ApiGateway::Method.IntegrationResponse"
+                    },
+                    "type": "array"
+                },
+                "PassthroughBehavior": {
+                    "type": "string"
+                },
+                "RequestParameters": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "RequestTemplates": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::Method.IntegrationResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "ResponseParameters": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ResponseTemplates": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "SelectionPattern": {
+                    "type": "string"
+                },
+                "StatusCode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "StatusCode"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Method.MethodResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "ResponseModels": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ResponseParameters": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "StatusCode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "StatusCode"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Model": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContentType": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "Schema": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Model"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::RequestValidator": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "ValidateRequestBody": {
+                            "type": "boolean"
+                        },
+                        "ValidateRequestParameters": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::RequestValidator"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Resource": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ParentId": {
+                            "type": "string"
+                        },
+                        "PathPart": {
+                            "type": "string"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ParentId",
+                        "PathPart",
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Resource"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::RestApi": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BinaryMediaTypes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Body": {
+                            "type": "object"
+                        },
+                        "BodyS3Location": {
+                            "$ref": "#/definitions/AWS::ApiGateway::RestApi.S3Location"
+                        },
+                        "CloneFrom": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "FailOnWarnings": {
+                            "type": "boolean"
+                        },
+                        "Mode": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::RestApi"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::RestApi.S3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "ETag": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::Stage": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheClusterEnabled": {
+                            "type": "boolean"
+                        },
+                        "CacheClusterSize": {
+                            "type": "string"
+                        },
+                        "ClientCertificateId": {
+                            "type": "string"
+                        },
+                        "DeploymentId": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DocumentationVersion": {
+                            "type": "string"
+                        },
+                        "MethodSettings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::Stage.MethodSetting"
+                            },
+                            "type": "array"
+                        },
+                        "RestApiId": {
+                            "type": "string"
+                        },
+                        "StageName": {
+                            "type": "string"
+                        },
+                        "Variables": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "RestApiId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::Stage"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::Stage.MethodSetting": {
+            "additionalProperties": false,
+            "properties": {
+                "CacheDataEncrypted": {
+                    "type": "boolean"
+                },
+                "CacheTtlInSeconds": {
+                    "type": "number"
+                },
+                "CachingEnabled": {
+                    "type": "boolean"
+                },
+                "DataTraceEnabled": {
+                    "type": "boolean"
+                },
+                "HttpMethod": {
+                    "type": "string"
+                },
+                "LoggingLevel": {
+                    "type": "string"
+                },
+                "MetricsEnabled": {
+                    "type": "boolean"
+                },
+                "ResourcePath": {
+                    "type": "string"
+                },
+                "ThrottlingBurstLimit": {
+                    "type": "number"
+                },
+                "ThrottlingRateLimit": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::UsagePlan": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApiStages": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.ApiStage"
+                            },
+                            "type": "array"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Quota": {
+                            "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.QuotaSettings"
+                        },
+                        "Throttle": {
+                            "$ref": "#/definitions/AWS::ApiGateway::UsagePlan.ThrottleSettings"
+                        },
+                        "UsagePlanName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::UsagePlan"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ApiGateway::UsagePlan.ApiStage": {
+            "additionalProperties": false,
+            "properties": {
+                "ApiId": {
+                    "type": "string"
+                },
+                "Stage": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::UsagePlan.QuotaSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "Limit": {
+                    "type": "number"
+                },
+                "Offset": {
+                    "type": "number"
+                },
+                "Period": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::UsagePlan.ThrottleSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "BurstLimit": {
+                    "type": "number"
+                },
+                "RateLimit": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGateway::UsagePlanKey": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "KeyId": {
+                            "type": "string"
+                        },
+                        "KeyType": {
+                            "type": "string"
+                        },
+                        "UsagePlanId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "KeyId",
+                        "KeyType",
+                        "UsagePlanId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApiGateway::UsagePlanKey"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalableTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "MaxCapacity": {
+                            "type": "number"
+                        },
+                        "MinCapacity": {
+                            "type": "number"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "RoleARN": {
+                            "type": "string"
+                        },
+                        "ScalableDimension": {
+                            "type": "string"
+                        },
+                        "ServiceNamespace": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "MaxCapacity",
+                        "MinCapacity",
+                        "ResourceId",
+                        "RoleARN",
+                        "ScalableDimension",
+                        "ServiceNamespace"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApplicationAutoScaling::ScalableTarget"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "PolicyType": {
+                            "type": "string"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "ScalableDimension": {
+                            "type": "string"
+                        },
+                        "ScalingTargetId": {
+                            "type": "string"
+                        },
+                        "ServiceNamespace": {
+                            "type": "string"
+                        },
+                        "StepScalingPolicyConfiguration": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.StepScalingPolicyConfiguration"
+                        },
+                        "TargetTrackingScalingPolicyConfiguration": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.TargetTrackingScalingPolicyConfiguration"
+                        }
+                    },
+                    "required": [
+                        "PolicyName",
+                        "PolicyType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ApplicationAutoScaling::ScalingPolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy.CustomizedMetricSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Dimensions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.MetricDimension"
+                    },
+                    "type": "array"
+                },
+                "MetricName": {
+                    "type": "string"
+                },
+                "Namespace": {
+                    "type": "string"
+                },
+                "Statistic": {
+                    "type": "string"
+                },
+                "Unit": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "MetricName",
+                "Namespace",
+                "Statistic"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy.MetricDimension": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "PredefinedMetricType": {
+                    "type": "string"
+                },
+                "ResourceLabel": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PredefinedMetricType"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy.StepAdjustment": {
+            "additionalProperties": false,
+            "properties": {
+                "MetricIntervalLowerBound": {
+                    "type": "number"
+                },
+                "MetricIntervalUpperBound": {
+                    "type": "number"
+                },
+                "ScalingAdjustment": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ScalingAdjustment"
+            ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy.StepScalingPolicyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AdjustmentType": {
+                    "type": "string"
+                },
+                "Cooldown": {
+                    "type": "number"
+                },
+                "MetricAggregationType": {
+                    "type": "string"
+                },
+                "MinAdjustmentMagnitude": {
+                    "type": "number"
+                },
+                "StepAdjustments": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.StepAdjustment"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalingPolicy.TargetTrackingScalingPolicyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CustomizedMetricSpecification": {
+                    "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.CustomizedMetricSpecification"
+                },
+                "PredefinedMetricSpecification": {
+                    "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification"
+                },
+                "ScaleInCooldown": {
+                    "type": "number"
+                },
+                "ScaleOutCooldown": {
+                    "type": "number"
+                },
+                "TargetValue": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "TargetValue"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::AutoScalingGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Cooldown": {
+                            "type": "string"
+                        },
+                        "DesiredCapacity": {
+                            "type": "string"
+                        },
+                        "HealthCheckGracePeriod": {
+                            "type": "number"
+                        },
+                        "HealthCheckType": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "LaunchConfigurationName": {
+                            "type": "string"
+                        },
+                        "LoadBalancerNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "MaxSize": {
+                            "type": "string"
+                        },
+                        "MetricsCollection": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.MetricsCollection"
+                            },
+                            "type": "array"
+                        },
+                        "MinSize": {
+                            "type": "string"
+                        },
+                        "NotificationConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.NotificationConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementGroup": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup.TagProperty"
+                            },
+                            "type": "array"
+                        },
+                        "TargetGroupARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "TerminationPolicies": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "VPCZoneIdentifier": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "MaxSize",
+                        "MinSize"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::AutoScalingGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::AutoScalingGroup.MetricsCollection": {
+            "additionalProperties": false,
+            "properties": {
+                "Granularity": {
+                    "type": "string"
+                },
+                "Metrics": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Granularity"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::AutoScalingGroup.NotificationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "NotificationTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TopicARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TopicARN"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::AutoScalingGroup.TagProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "PropagateAtLaunch": {
+                    "type": "boolean"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "PropagateAtLaunch",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::LaunchConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AssociatePublicIpAddress": {
+                            "type": "boolean"
+                        },
+                        "BlockDeviceMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.BlockDeviceMapping"
+                            },
+                            "type": "array"
+                        },
+                        "ClassicLinkVPCId": {
+                            "type": "string"
+                        },
+                        "ClassicLinkVPCSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "EbsOptimized": {
+                            "type": "boolean"
+                        },
+                        "IamInstanceProfile": {
+                            "type": "string"
+                        },
+                        "ImageId": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "InstanceMonitoring": {
+                            "type": "boolean"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "KernelId": {
+                            "type": "string"
+                        },
+                        "KeyName": {
+                            "type": "string"
+                        },
+                        "PlacementTenancy": {
+                            "type": "string"
+                        },
+                        "RamDiskId": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SpotPrice": {
+                            "type": "string"
+                        },
+                        "UserData": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ImageId",
+                        "InstanceType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::LaunchConfiguration"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::LaunchConfiguration.BlockDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeleteOnTermination": {
+                    "type": "boolean"
+                },
+                "Encrypted": {
+                    "type": "boolean"
+                },
+                "Iops": {
+                    "type": "number"
+                },
+                "SnapshotId": {
+                    "type": "string"
+                },
+                "VolumeSize": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AutoScaling::LaunchConfiguration.BlockDeviceMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DeviceName": {
+                    "type": "string"
+                },
+                "Ebs": {
+                    "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.BlockDevice"
+                },
+                "NoDevice": {
+                    "type": "boolean"
+                },
+                "VirtualName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::LifecycleHook": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoScalingGroupName": {
+                            "type": "string"
+                        },
+                        "DefaultResult": {
+                            "type": "string"
+                        },
+                        "HeartbeatTimeout": {
+                            "type": "number"
+                        },
+                        "LifecycleTransition": {
+                            "type": "string"
+                        },
+                        "NotificationMetadata": {
+                            "type": "string"
+                        },
+                        "NotificationTargetARN": {
+                            "type": "string"
+                        },
+                        "RoleARN": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AutoScalingGroupName",
+                        "LifecycleTransition"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::LifecycleHook"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScalingPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdjustmentType": {
+                            "type": "string"
+                        },
+                        "AutoScalingGroupName": {
+                            "type": "string"
+                        },
+                        "Cooldown": {
+                            "type": "string"
+                        },
+                        "EstimatedInstanceWarmup": {
+                            "type": "number"
+                        },
+                        "MetricAggregationType": {
+                            "type": "string"
+                        },
+                        "MinAdjustmentMagnitude": {
+                            "type": "number"
+                        },
+                        "PolicyType": {
+                            "type": "string"
+                        },
+                        "ScalingAdjustment": {
+                            "type": "number"
+                        },
+                        "StepAdjustments": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.StepAdjustment"
+                            },
+                            "type": "array"
+                        },
+                        "TargetTrackingConfiguration": {
+                            "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.TargetTrackingConfiguration"
+                        }
+                    },
+                    "required": [
+                        "AutoScalingGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::ScalingPolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Dimensions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.MetricDimension"
+                    },
+                    "type": "array"
+                },
+                "MetricName": {
+                    "type": "string"
+                },
+                "Namespace": {
+                    "type": "string"
+                },
+                "Statistic": {
+                    "type": "string"
+                },
+                "Unit": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "MetricName",
+                "Namespace",
+                "Statistic"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScalingPolicy.MetricDimension": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScalingPolicy.PredefinedMetricSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "PredefinedMetricType": {
+                    "type": "string"
+                },
+                "ResourceLabel": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PredefinedMetricType"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScalingPolicy.StepAdjustment": {
+            "additionalProperties": false,
+            "properties": {
+                "MetricIntervalLowerBound": {
+                    "type": "number"
+                },
+                "MetricIntervalUpperBound": {
+                    "type": "number"
+                },
+                "ScalingAdjustment": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ScalingAdjustment"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScalingPolicy.TargetTrackingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CustomizedMetricSpecification": {
+                    "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification"
+                },
+                "DisableScaleIn": {
+                    "type": "boolean"
+                },
+                "PredefinedMetricSpecification": {
+                    "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy.PredefinedMetricSpecification"
+                },
+                "TargetValue": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "TargetValue"
+            ],
+            "type": "object"
+        },
+        "AWS::AutoScaling::ScheduledAction": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoScalingGroupName": {
+                            "type": "string"
+                        },
+                        "DesiredCapacity": {
+                            "type": "number"
+                        },
+                        "EndTime": {
+                            "type": "string"
+                        },
+                        "MaxSize": {
+                            "type": "number"
+                        },
+                        "MinSize": {
+                            "type": "number"
+                        },
+                        "Recurrence": {
+                            "type": "string"
+                        },
+                        "StartTime": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AutoScalingGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AutoScaling::ScheduledAction"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::ComputeEnvironment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ComputeEnvironmentName": {
+                            "type": "string"
+                        },
+                        "ComputeResources": {
+                            "$ref": "#/definitions/AWS::Batch::ComputeEnvironment.ComputeResources"
+                        },
+                        "ServiceRole": {
+                            "type": "string"
+                        },
+                        "State": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ComputeResources",
+                        "ServiceRole",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Batch::ComputeEnvironment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::ComputeEnvironment.ComputeResources": {
+            "additionalProperties": false,
+            "properties": {
+                "BidPercentage": {
+                    "type": "number"
+                },
+                "DesiredvCpus": {
+                    "type": "number"
+                },
+                "Ec2KeyPair": {
+                    "type": "string"
+                },
+                "ImageId": {
+                    "type": "string"
+                },
+                "InstanceRole": {
+                    "type": "string"
+                },
+                "InstanceTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxvCpus": {
+                    "type": "number"
+                },
+                "MinvCpus": {
+                    "type": "number"
+                },
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SpotIamFleetRole": {
+                    "type": "string"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Tags": {
+                    "type": "object"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InstanceRole",
+                "InstanceTypes",
+                "MaxvCpus",
+                "MinvCpus",
+                "SecurityGroupIds",
+                "Subnets",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContainerProperties": {
+                            "$ref": "#/definitions/AWS::Batch::JobDefinition.ContainerProperties"
+                        },
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "type": "object"
+                        },
+                        "RetryStrategy": {
+                            "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ContainerProperties",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Batch::JobDefinition"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.ContainerProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "Command": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Batch::JobDefinition.Environment"
+                    },
+                    "type": "array"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "JobRoleArn": {
+                    "type": "string"
+                },
+                "Memory": {
+                    "type": "number"
+                },
+                "MountPoints": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Batch::JobDefinition.MountPoints"
+                    },
+                    "type": "array"
+                },
+                "Privileged": {
+                    "type": "boolean"
+                },
+                "ReadonlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "Ulimits": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Batch::JobDefinition.Ulimit"
+                    },
+                    "type": "array"
+                },
+                "User": {
+                    "type": "string"
+                },
+                "Vcpus": {
+                    "type": "number"
+                },
+                "Volumes": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Batch::JobDefinition.Volumes"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Image",
+                "Memory",
+                "Vcpus"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.MountPoints": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerPath": {
+                    "type": "string"
+                },
+                "ReadOnly": {
+                    "type": "boolean"
+                },
+                "SourceVolume": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.RetryStrategy": {
+            "additionalProperties": false,
+            "properties": {
+                "Attempts": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.Ulimit": {
+            "additionalProperties": false,
+            "properties": {
+                "HardLimit": {
+                    "type": "number"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "SoftLimit": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "HardLimit",
+                "Name",
+                "SoftLimit"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.Volumes": {
+            "additionalProperties": false,
+            "properties": {
+                "Host": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.VolumesHost"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.VolumesHost": {
+            "additionalProperties": false,
+            "properties": {
+                "SourcePath": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobQueue": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ComputeEnvironmentOrder": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Batch::JobQueue.ComputeEnvironmentOrder"
+                            },
+                            "type": "array"
+                        },
+                        "JobQueueName": {
+                            "type": "string"
+                        },
+                        "Priority": {
+                            "type": "number"
+                        },
+                        "State": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ComputeEnvironmentOrder",
+                        "Priority"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Batch::JobQueue"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Batch::JobQueue.ComputeEnvironmentOrder": {
+            "additionalProperties": false,
+            "properties": {
+                "ComputeEnvironment": {
+                    "type": "string"
+                },
+                "Order": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ComputeEnvironment",
+                "Order"
+            ],
+            "type": "object"
+        },
+        "AWS::CertificateManager::Certificate": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainValidationOptions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CertificateManager::Certificate.DomainValidationOption"
+                            },
+                            "type": "array"
+                        },
+                        "SubjectAlternativeNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DomainName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CertificateManager::Certificate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CertificateManager::Certificate.DomainValidationOption": {
+            "additionalProperties": false,
+            "properties": {
+                "DomainName": {
+                    "type": "string"
+                },
+                "ValidationDomain": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DomainName",
+                "ValidationDomain"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::CustomResource": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ServiceToken": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ServiceToken"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::CustomResource"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::Stack": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "NotificationARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TemplateURL": {
+                            "type": "string"
+                        },
+                        "TimeoutInMinutes": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "TemplateURL"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::Stack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::WaitCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Count": {
+                            "type": "number"
+                        },
+                        "Handle": {
+                            "type": "string"
+                        },
+                        "Timeout": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Handle",
+                        "Timeout"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::WaitCondition"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::WaitConditionHandle": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {},
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::WaitConditionHandle"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DistributionConfig": {
+                            "$ref": "#/definitions/AWS::CloudFront::Distribution.DistributionConfig"
+                        }
+                    },
+                    "required": [
+                        "DistributionConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFront::Distribution"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.CacheBehavior": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "CachedMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Compress": {
+                    "type": "boolean"
+                },
+                "DefaultTTL": {
+                    "type": "number"
+                },
+                "ForwardedValues": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.ForwardedValues"
+                },
+                "MaxTTL": {
+                    "type": "number"
+                },
+                "MinTTL": {
+                    "type": "number"
+                },
+                "PathPattern": {
+                    "type": "string"
+                },
+                "SmoothStreaming": {
+                    "type": "boolean"
+                },
+                "TargetOriginId": {
+                    "type": "string"
+                },
+                "TrustedSigners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ViewerProtocolPolicy": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ForwardedValues",
+                "PathPattern",
+                "TargetOriginId",
+                "ViewerProtocolPolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.Cookies": {
+            "additionalProperties": false,
+            "properties": {
+                "Forward": {
+                    "type": "string"
+                },
+                "WhitelistedNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Forward"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.CustomErrorResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "ErrorCachingMinTTL": {
+                    "type": "number"
+                },
+                "ErrorCode": {
+                    "type": "number"
+                },
+                "ResponseCode": {
+                    "type": "number"
+                },
+                "ResponsePagePath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ErrorCode"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.CustomOriginConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "HTTPPort": {
+                    "type": "number"
+                },
+                "HTTPSPort": {
+                    "type": "number"
+                },
+                "OriginProtocolPolicy": {
+                    "type": "string"
+                },
+                "OriginSSLProtocols": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "OriginProtocolPolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.DefaultCacheBehavior": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "CachedMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Compress": {
+                    "type": "boolean"
+                },
+                "DefaultTTL": {
+                    "type": "number"
+                },
+                "ForwardedValues": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.ForwardedValues"
+                },
+                "MaxTTL": {
+                    "type": "number"
+                },
+                "MinTTL": {
+                    "type": "number"
+                },
+                "SmoothStreaming": {
+                    "type": "boolean"
+                },
+                "TargetOriginId": {
+                    "type": "string"
+                },
+                "TrustedSigners": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ViewerProtocolPolicy": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ForwardedValues",
+                "TargetOriginId",
+                "ViewerProtocolPolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.DistributionConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Aliases": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "CacheBehaviors": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CloudFront::Distribution.CacheBehavior"
+                    },
+                    "type": "array"
+                },
+                "Comment": {
+                    "type": "string"
+                },
+                "CustomErrorResponses": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CloudFront::Distribution.CustomErrorResponse"
+                    },
+                    "type": "array"
+                },
+                "DefaultCacheBehavior": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.DefaultCacheBehavior"
+                },
+                "DefaultRootObject": {
+                    "type": "string"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "HttpVersion": {
+                    "type": "string"
+                },
+                "Logging": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.Logging"
+                },
+                "Origins": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CloudFront::Distribution.Origin"
+                    },
+                    "type": "array"
+                },
+                "PriceClass": {
+                    "type": "string"
+                },
+                "Restrictions": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.Restrictions"
+                },
+                "ViewerCertificate": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.ViewerCertificate"
+                },
+                "WebACLId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DefaultCacheBehavior",
+                "Enabled",
+                "Origins"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.ForwardedValues": {
+            "additionalProperties": false,
+            "properties": {
+                "Cookies": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.Cookies"
+                },
+                "Headers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "QueryString": {
+                    "type": "boolean"
+                },
+                "QueryStringCacheKeys": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "QueryString"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.GeoRestriction": {
+            "additionalProperties": false,
+            "properties": {
+                "Locations": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RestrictionType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RestrictionType"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.Logging": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "IncludeCookies": {
+                    "type": "boolean"
+                },
+                "Prefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Bucket"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.Origin": {
+            "additionalProperties": false,
+            "properties": {
+                "CustomOriginConfig": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.CustomOriginConfig"
+                },
+                "DomainName": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "OriginCustomHeaders": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CloudFront::Distribution.OriginCustomHeader"
+                    },
+                    "type": "array"
+                },
+                "OriginPath": {
+                    "type": "string"
+                },
+                "S3OriginConfig": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.S3OriginConfig"
+                }
+            },
+            "required": [
+                "DomainName",
+                "Id"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.OriginCustomHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "HeaderName": {
+                    "type": "string"
+                },
+                "HeaderValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "HeaderName",
+                "HeaderValue"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.Restrictions": {
+            "additionalProperties": false,
+            "properties": {
+                "GeoRestriction": {
+                    "$ref": "#/definitions/AWS::CloudFront::Distribution.GeoRestriction"
+                }
+            },
+            "required": [
+                "GeoRestriction"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.S3OriginConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "OriginAccessIdentity": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CloudFront::Distribution.ViewerCertificate": {
+            "additionalProperties": false,
+            "properties": {
+                "AcmCertificateArn": {
+                    "type": "string"
+                },
+                "CloudFrontDefaultCertificate": {
+                    "type": "boolean"
+                },
+                "IamCertificateId": {
+                    "type": "string"
+                },
+                "MinimumProtocolVersion": {
+                    "type": "string"
+                },
+                "SslSupportMethod": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CloudTrail::Trail": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CloudWatchLogsLogGroupArn": {
+                            "type": "string"
+                        },
+                        "CloudWatchLogsRoleArn": {
+                            "type": "string"
+                        },
+                        "EnableLogFileValidation": {
+                            "type": "boolean"
+                        },
+                        "EventSelectors": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CloudTrail::Trail.EventSelector"
+                            },
+                            "type": "array"
+                        },
+                        "IncludeGlobalServiceEvents": {
+                            "type": "boolean"
+                        },
+                        "IsLogging": {
+                            "type": "boolean"
+                        },
+                        "IsMultiRegionTrail": {
+                            "type": "boolean"
+                        },
+                        "KMSKeyId": {
+                            "type": "string"
+                        },
+                        "S3BucketName": {
+                            "type": "string"
+                        },
+                        "S3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "SnsTopicName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TrailName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "IsLogging",
+                        "S3BucketName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudTrail::Trail"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudTrail::Trail.DataResource": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudTrail::Trail.EventSelector": {
+            "additionalProperties": false,
+            "properties": {
+                "DataResources": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CloudTrail::Trail.DataResource"
+                    },
+                    "type": "array"
+                },
+                "IncludeManagementEvents": {
+                    "type": "boolean"
+                },
+                "ReadWriteType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CloudWatch::Alarm": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ActionsEnabled": {
+                            "type": "boolean"
+                        },
+                        "AlarmActions": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "AlarmDescription": {
+                            "type": "string"
+                        },
+                        "AlarmName": {
+                            "type": "string"
+                        },
+                        "ComparisonOperator": {
+                            "type": "string"
+                        },
+                        "Dimensions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CloudWatch::Alarm.Dimension"
+                            },
+                            "type": "array"
+                        },
+                        "EvaluateLowSampleCountPercentile": {
+                            "type": "string"
+                        },
+                        "EvaluationPeriods": {
+                            "type": "number"
+                        },
+                        "ExtendedStatistic": {
+                            "type": "string"
+                        },
+                        "InsufficientDataActions": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Namespace": {
+                            "type": "string"
+                        },
+                        "OKActions": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Period": {
+                            "type": "number"
+                        },
+                        "Statistic": {
+                            "type": "string"
+                        },
+                        "Threshold": {
+                            "type": "number"
+                        },
+                        "TreatMissingData": {
+                            "type": "string"
+                        },
+                        "Unit": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ComparisonOperator",
+                        "EvaluationPeriods",
+                        "MetricName",
+                        "Namespace",
+                        "Period",
+                        "Threshold"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudWatch::Alarm"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudWatch::Alarm.Dimension": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudWatch::Dashboard": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DashboardBody": {
+                            "type": "string"
+                        },
+                        "DashboardName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DashboardBody"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudWatch::Dashboard"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Artifacts": {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project.Artifacts"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EncryptionKey": {
+                            "type": "string"
+                        },
+                        "Environment": {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ServiceRole": {
+                            "type": "string"
+                        },
+                        "Source": {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project.Source"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TimeoutInMinutes": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "Artifacts",
+                        "Environment",
+                        "ServiceRole",
+                        "Source"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeBuild::Project"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.Artifacts": {
+            "additionalProperties": false,
+            "properties": {
+                "Location": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "NamespaceType": {
+                    "type": "string"
+                },
+                "Packaging": {
+                    "type": "string"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "ComputeType": {
+                    "type": "string"
+                },
+                "EnvironmentVariables": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodeBuild::Project.EnvironmentVariable"
+                    },
+                    "type": "array"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "PrivilegedMode": {
+                    "type": "boolean"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ComputeType",
+                "Image",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.EnvironmentVariable": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.Source": {
+            "additionalProperties": false,
+            "properties": {
+                "Auth": {
+                    "$ref": "#/definitions/AWS::CodeBuild::Project.SourceAuth"
+                },
+                "BuildSpec": {
+                    "type": "string"
+                },
+                "Location": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.SourceAuth": {
+            "additionalProperties": false,
+            "properties": {
+                "Resource": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeCommit::Repository": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryDescription": {
+                            "type": "string"
+                        },
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "Triggers": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeCommit::Repository.RepositoryTrigger"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "RepositoryName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeCommit::Repository"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeCommit::Repository.RepositoryTrigger": {
+            "additionalProperties": false,
+            "properties": {
+                "Branches": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "CustomData": {
+                    "type": "string"
+                },
+                "DestinationArn": {
+                    "type": "string"
+                },
+                "Events": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::Application": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeDeploy::Application"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeploymentConfigName": {
+                            "type": "string"
+                        },
+                        "MinimumHealthyHosts": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeDeploy::DeploymentConfig"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AlarmConfiguration": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.AlarmConfiguration"
+                        },
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "AutoRollbackConfiguration": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration"
+                        },
+                        "AutoScalingGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Deployment": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.Deployment"
+                        },
+                        "DeploymentConfigName": {
+                            "type": "string"
+                        },
+                        "DeploymentGroupName": {
+                            "type": "string"
+                        },
+                        "DeploymentStyle": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle"
+                        },
+                        "Ec2TagFilters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.EC2TagFilter"
+                            },
+                            "type": "array"
+                        },
+                        "LoadBalancerInfo": {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.LoadBalancerInfo"
+                        },
+                        "OnPremisesInstanceTagFilters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.TagFilter"
+                            },
+                            "type": "array"
+                        },
+                        "ServiceRoleArn": {
+                            "type": "string"
+                        },
+                        "TriggerConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.TriggerConfig"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "ServiceRoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodeDeploy::DeploymentGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.Alarm": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.AlarmConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Alarms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.Alarm"
+                    },
+                    "type": "array"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "IgnorePollAlarmFailure": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "Events": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.Deployment": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "IgnoreApplicationStopFailures": {
+                    "type": "boolean"
+                },
+                "Revision": {
+                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.RevisionLocation"
+                }
+            },
+            "required": [
+                "Revision"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle": {
+            "additionalProperties": false,
+            "properties": {
+                "DeploymentOption": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.EC2TagFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.ELBInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.GitHubLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "CommitId": {
+                    "type": "string"
+                },
+                "Repository": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "CommitId",
+                "Repository"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.LoadBalancerInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "ElbInfoList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.ELBInfo"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.RevisionLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "GitHubLocation": {
+                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.GitHubLocation"
+                },
+                "RevisionType": {
+                    "type": "string"
+                },
+                "S3Location": {
+                    "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup.S3Location"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.S3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "BundleType": {
+                    "type": "string"
+                },
+                "ETag": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Bucket",
+                "Key"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.TagFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodeDeploy::DeploymentGroup.TriggerConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TriggerEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TriggerName": {
+                    "type": "string"
+                },
+                "TriggerTargetArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodePipeline::CustomActionType": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Category": {
+                            "type": "string"
+                        },
+                        "ConfigurationProperties": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ConfigurationProperties"
+                            },
+                            "type": "array"
+                        },
+                        "InputArtifactDetails": {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ArtifactDetails"
+                        },
+                        "OutputArtifactDetails": {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.ArtifactDetails"
+                        },
+                        "Provider": {
+                            "type": "string"
+                        },
+                        "Settings": {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType.Settings"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Category",
+                        "InputArtifactDetails",
+                        "OutputArtifactDetails",
+                        "Provider"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodePipeline::CustomActionType"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::CustomActionType.ArtifactDetails": {
+            "additionalProperties": false,
+            "properties": {
+                "MaximumCount": {
+                    "type": "number"
+                },
+                "MinimumCount": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaximumCount",
+                "MinimumCount"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::CustomActionType.ConfigurationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "boolean"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Queryable": {
+                    "type": "boolean"
+                },
+                "Required": {
+                    "type": "boolean"
+                },
+                "Secret": {
+                    "type": "boolean"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Name",
+                "Required",
+                "Secret"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::CustomActionType.Settings": {
+            "additionalProperties": false,
+            "properties": {
+                "EntityUrlTemplate": {
+                    "type": "string"
+                },
+                "ExecutionUrlTemplate": {
+                    "type": "string"
+                },
+                "RevisionUrlTemplate": {
+                    "type": "string"
+                },
+                "ThirdPartyConfigurationUrl": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ArtifactStore": {
+                            "$ref": "#/definitions/AWS::CodePipeline::Pipeline.ArtifactStore"
+                        },
+                        "DisableInboundStageTransitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodePipeline::Pipeline.StageTransition"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RestartExecutionOnUpdate": {
+                            "type": "boolean"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Stages": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodePipeline::Pipeline.StageDeclaration"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ArtifactStore",
+                        "RoleArn",
+                        "Stages"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CodePipeline::Pipeline"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.ActionDeclaration": {
+            "additionalProperties": false,
+            "properties": {
+                "ActionTypeId": {
+                    "$ref": "#/definitions/AWS::CodePipeline::Pipeline.ActionTypeId"
+                },
+                "Configuration": {
+                    "type": "object"
+                },
+                "InputArtifacts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodePipeline::Pipeline.InputArtifact"
+                    },
+                    "type": "array"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "OutputArtifacts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodePipeline::Pipeline.OutputArtifact"
+                    },
+                    "type": "array"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "RunOrder": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ActionTypeId",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.ActionTypeId": {
+            "additionalProperties": false,
+            "properties": {
+                "Category": {
+                    "type": "string"
+                },
+                "Owner": {
+                    "type": "string"
+                },
+                "Provider": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Category",
+                "Owner",
+                "Provider",
+                "Version"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.ArtifactStore": {
+            "additionalProperties": false,
+            "properties": {
+                "EncryptionKey": {
+                    "$ref": "#/definitions/AWS::CodePipeline::Pipeline.EncryptionKey"
+                },
+                "Location": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Location",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.BlockerDeclaration": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.EncryptionKey": {
+            "additionalProperties": false,
+            "properties": {
+                "Id": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Id",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.InputArtifact": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.OutputArtifact": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.StageDeclaration": {
+            "additionalProperties": false,
+            "properties": {
+                "Actions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodePipeline::Pipeline.ActionDeclaration"
+                    },
+                    "type": "array"
+                },
+                "Blockers": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::CodePipeline::Pipeline.BlockerDeclaration"
+                    },
+                    "type": "array"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Actions",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::CodePipeline::Pipeline.StageTransition": {
+            "additionalProperties": false,
+            "properties": {
+                "Reason": {
+                    "type": "string"
+                },
+                "StageName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Reason",
+                "StageName"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPool": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowUnauthenticatedIdentities": {
+                            "type": "boolean"
+                        },
+                        "CognitoEvents": {
+                            "type": "object"
+                        },
+                        "CognitoIdentityProviders": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::IdentityPool.CognitoIdentityProvider"
+                            },
+                            "type": "array"
+                        },
+                        "CognitoStreams": {
+                            "$ref": "#/definitions/AWS::Cognito::IdentityPool.CognitoStreams"
+                        },
+                        "DeveloperProviderName": {
+                            "type": "string"
+                        },
+                        "IdentityPoolName": {
+                            "type": "string"
+                        },
+                        "OpenIdConnectProviderARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PushSync": {
+                            "$ref": "#/definitions/AWS::Cognito::IdentityPool.PushSync"
+                        },
+                        "SamlProviderARNs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SupportedLoginProviders": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "AllowUnauthenticatedIdentities"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::IdentityPool"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPool.CognitoIdentityProvider": {
+            "additionalProperties": false,
+            "properties": {
+                "ClientId": {
+                    "type": "string"
+                },
+                "ProviderName": {
+                    "type": "string"
+                },
+                "ServerSideTokenCheck": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPool.CognitoStreams": {
+            "additionalProperties": false,
+            "properties": {
+                "RoleArn": {
+                    "type": "string"
+                },
+                "StreamName": {
+                    "type": "string"
+                },
+                "StreamingStatus": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPool.PushSync": {
+            "additionalProperties": false,
+            "properties": {
+                "ApplicationArns": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RoleArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPoolRoleAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IdentityPoolId": {
+                            "type": "string"
+                        },
+                        "RoleMappings": {
+                            "type": "object"
+                        },
+                        "Roles": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "IdentityPoolId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::IdentityPoolRoleAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPoolRoleAttachment.MappingRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Claim": {
+                    "type": "string"
+                },
+                "MatchType": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Claim",
+                "MatchType",
+                "RoleARN",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPoolRoleAttachment.RoleMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "AmbiguousRoleResolution": {
+                    "type": "string"
+                },
+                "RulesConfiguration": {
+                    "$ref": "#/definitions/AWS::Cognito::IdentityPoolRoleAttachment.RulesConfigurationType"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::IdentityPoolRoleAttachment.RulesConfigurationType": {
+            "additionalProperties": false,
+            "properties": {
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Cognito::IdentityPoolRoleAttachment.MappingRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Rules"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdminCreateUserConfig": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.AdminCreateUserConfig"
+                        },
+                        "AliasAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "AutoVerifiedAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "DeviceConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.DeviceConfiguration"
+                        },
+                        "EmailConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.EmailConfiguration"
+                        },
+                        "EmailVerificationMessage": {
+                            "type": "string"
+                        },
+                        "EmailVerificationSubject": {
+                            "type": "string"
+                        },
+                        "LambdaConfig": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.LambdaConfig"
+                        },
+                        "MfaConfiguration": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.Policies"
+                        },
+                        "Schema": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::UserPool.SchemaAttribute"
+                            },
+                            "type": "array"
+                        },
+                        "SmsAuthenticationMessage": {
+                            "type": "string"
+                        },
+                        "SmsConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.SmsConfiguration"
+                        },
+                        "SmsVerificationMessage": {
+                            "type": "string"
+                        },
+                        "UserPoolName": {
+                            "type": "string"
+                        },
+                        "UserPoolTags": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPool"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.AdminCreateUserConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowAdminCreateUserOnly": {
+                    "type": "boolean"
+                },
+                "InviteMessageTemplate": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.InviteMessageTemplate"
+                },
+                "UnusedAccountValidityDays": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.DeviceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ChallengeRequiredOnNewDevice": {
+                    "type": "boolean"
+                },
+                "DeviceOnlyRememberedOnUserPrompt": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.EmailConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplyToEmailAddress": {
+                    "type": "string"
+                },
+                "SourceArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.InviteMessageTemplate": {
+            "additionalProperties": false,
+            "properties": {
+                "EmailMessage": {
+                    "type": "string"
+                },
+                "EmailSubject": {
+                    "type": "string"
+                },
+                "SMSMessage": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.LambdaConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "CreateAuthChallenge": {
+                    "type": "string"
+                },
+                "CustomMessage": {
+                    "type": "string"
+                },
+                "DefineAuthChallenge": {
+                    "type": "string"
+                },
+                "PostAuthentication": {
+                    "type": "string"
+                },
+                "PostConfirmation": {
+                    "type": "string"
+                },
+                "PreAuthentication": {
+                    "type": "string"
+                },
+                "PreSignUp": {
+                    "type": "string"
+                },
+                "VerifyAuthChallengeResponse": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.NumberAttributeConstraints": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxValue": {
+                    "type": "string"
+                },
+                "MinValue": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.PasswordPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "MinimumLength": {
+                    "type": "number"
+                },
+                "RequireLowercase": {
+                    "type": "boolean"
+                },
+                "RequireNumbers": {
+                    "type": "boolean"
+                },
+                "RequireSymbols": {
+                    "type": "boolean"
+                },
+                "RequireUppercase": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.Policies": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordPolicy": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.PasswordPolicy"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.SchemaAttribute": {
+            "additionalProperties": false,
+            "properties": {
+                "AttributeDataType": {
+                    "type": "string"
+                },
+                "DeveloperOnlyAttribute": {
+                    "type": "boolean"
+                },
+                "Mutable": {
+                    "type": "boolean"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "NumberAttributeConstraints": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.NumberAttributeConstraints"
+                },
+                "Required": {
+                    "type": "boolean"
+                },
+                "StringAttributeConstraints": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.StringAttributeConstraints"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.SmsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ExternalId": {
+                    "type": "string"
+                },
+                "SnsCallerArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.StringAttributeConstraints": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxLength": {
+                    "type": "string"
+                },
+                "MinLength": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPoolClient": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ClientName": {
+                            "type": "string"
+                        },
+                        "ExplicitAuthFlows": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "GenerateSecret": {
+                            "type": "boolean"
+                        },
+                        "ReadAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "RefreshTokenValidity": {
+                            "type": "number"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        },
+                        "WriteAttributes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "UserPoolId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolClient"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::UserPoolGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "Precedence": {
+                            "type": "number"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "UserPoolId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::UserPoolUser": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DesiredDeliveryMediums": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ForceAliasCreation": {
+                            "type": "boolean"
+                        },
+                        "MessageAction": {
+                            "type": "string"
+                        },
+                        "UserAttributes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::UserPoolUser.AttributeType"
+                            },
+                            "type": "array"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        },
+                        "Username": {
+                            "type": "string"
+                        },
+                        "ValidationData": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Cognito::UserPoolUser.AttributeType"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "UserPoolId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolUser"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Cognito::UserPoolUser.AttributeType": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPoolUserToGroupAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "UserPoolId": {
+                            "type": "string"
+                        },
+                        "Username": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "GroupName",
+                        "UserPoolId",
+                        "Username"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Cognito::UserPoolUserToGroupAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConfigRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConfigRuleName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "InputParameters": {
+                            "type": "object"
+                        },
+                        "MaximumExecutionFrequency": {
+                            "type": "string"
+                        },
+                        "Scope": {
+                            "$ref": "#/definitions/AWS::Config::ConfigRule.Scope"
+                        },
+                        "Source": {
+                            "$ref": "#/definitions/AWS::Config::ConfigRule.Source"
+                        }
+                    },
+                    "required": [
+                        "Source"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConfigRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConfigRule.Scope": {
+            "additionalProperties": false,
+            "properties": {
+                "ComplianceResourceId": {
+                    "type": "string"
+                },
+                "ComplianceResourceTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TagKey": {
+                    "type": "string"
+                },
+                "TagValue": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Config::ConfigRule.Source": {
+            "additionalProperties": false,
+            "properties": {
+                "Owner": {
+                    "type": "string"
+                },
+                "SourceDetails": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Config::ConfigRule.SourceDetail"
+                    },
+                    "type": "array"
+                },
+                "SourceIdentifier": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Owner",
+                "SourceIdentifier"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConfigRule.SourceDetail": {
+            "additionalProperties": false,
+            "properties": {
+                "EventSource": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "MessageType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EventSource",
+                "MessageType"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConfigurationRecorder": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RecordingGroup": {
+                            "$ref": "#/definitions/AWS::Config::ConfigurationRecorder.RecordingGroup"
+                        },
+                        "RoleARN": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RoleARN"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConfigurationRecorder"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConfigurationRecorder.RecordingGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "AllSupported": {
+                    "type": "boolean"
+                },
+                "IncludeGlobalResourceTypes": {
+                    "type": "boolean"
+                },
+                "ResourceTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Config::DeliveryChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConfigSnapshotDeliveryProperties": {
+                            "$ref": "#/definitions/AWS::Config::DeliveryChannel.ConfigSnapshotDeliveryProperties"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "S3BucketName": {
+                            "type": "string"
+                        },
+                        "S3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "SnsTopicARN": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "S3BucketName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::DeliveryChannel"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::DeliveryChannel.ConfigSnapshotDeliveryProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "DeliveryFrequency": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DAX::Cluster": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ClusterName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "IAMRoleARN": {
+                            "type": "string"
+                        },
+                        "NodeType": {
+                            "type": "string"
+                        },
+                        "NotificationTopicARN": {
+                            "type": "string"
+                        },
+                        "ParameterGroupName": {
+                            "type": "string"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "ReplicationFactor": {
+                            "type": "number"
+                        },
+                        "SecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "IAMRoleARN",
+                        "NodeType",
+                        "ReplicationFactor"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DAX::Cluster"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DAX::ParameterGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "ParameterGroupName": {
+                            "type": "string"
+                        },
+                        "ParameterNameValues": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DAX::ParameterGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::DAX::SubnetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SubnetGroupName": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DAX::SubnetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::Certificate": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateIdentifier": {
+                            "type": "string"
+                        },
+                        "CertificatePem": {
+                            "type": "string"
+                        },
+                        "CertificateWallet": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::Certificate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::Endpoint": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateArn": {
+                            "type": "string"
+                        },
+                        "DatabaseName": {
+                            "type": "string"
+                        },
+                        "DynamoDbSettings": {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint.DynamoDbSettings"
+                        },
+                        "EndpointIdentifier": {
+                            "type": "string"
+                        },
+                        "EndpointType": {
+                            "type": "string"
+                        },
+                        "EngineName": {
+                            "type": "string"
+                        },
+                        "ExtraConnectionAttributes": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "MongoDbSettings": {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint.MongoDbSettings"
+                        },
+                        "Password": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "S3Settings": {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint.S3Settings"
+                        },
+                        "ServerName": {
+                            "type": "string"
+                        },
+                        "SslMode": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Username": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "EndpointType",
+                        "EngineName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::Endpoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::Endpoint.DynamoDbSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "ServiceAccessRoleArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DMS::Endpoint.MongoDbSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "AuthMechanism": {
+                    "type": "string"
+                },
+                "AuthSource": {
+                    "type": "string"
+                },
+                "AuthType": {
+                    "type": "string"
+                },
+                "DatabaseName": {
+                    "type": "string"
+                },
+                "DocsToInvestigate": {
+                    "type": "string"
+                },
+                "ExtractDocId": {
+                    "type": "string"
+                },
+                "NestingLevel": {
+                    "type": "string"
+                },
+                "Password": {
+                    "type": "string"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "ServerName": {
+                    "type": "string"
+                },
+                "Username": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DMS::Endpoint.S3Settings": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketFolder": {
+                    "type": "string"
+                },
+                "BucketName": {
+                    "type": "string"
+                },
+                "CompressionType": {
+                    "type": "string"
+                },
+                "CsvDelimiter": {
+                    "type": "string"
+                },
+                "CsvRowDelimiter": {
+                    "type": "string"
+                },
+                "ExternalTableDefinition": {
+                    "type": "string"
+                },
+                "ServiceAccessRoleArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DMS::EventSubscription": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "EventCategories": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        },
+                        "SourceIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SourceType": {
+                            "type": "string"
+                        },
+                        "SubscriptionName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::EventSubscription"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::ReplicationInstance": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocatedStorage": {
+                            "type": "number"
+                        },
+                        "AllowMajorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "MultiAZ": {
+                            "type": "boolean"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PubliclyAccessible": {
+                            "type": "boolean"
+                        },
+                        "ReplicationInstanceClass": {
+                            "type": "string"
+                        },
+                        "ReplicationInstanceIdentifier": {
+                            "type": "string"
+                        },
+                        "ReplicationSubnetGroupIdentifier": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ReplicationInstanceClass"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::ReplicationInstance"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::ReplicationSubnetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ReplicationSubnetGroupDescription": {
+                            "type": "string"
+                        },
+                        "ReplicationSubnetGroupIdentifier": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ReplicationSubnetGroupDescription",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::ReplicationSubnetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DMS::ReplicationTask": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CdcStartTime": {
+                            "type": "number"
+                        },
+                        "MigrationType": {
+                            "type": "string"
+                        },
+                        "ReplicationInstanceArn": {
+                            "type": "string"
+                        },
+                        "ReplicationTaskIdentifier": {
+                            "type": "string"
+                        },
+                        "ReplicationTaskSettings": {
+                            "type": "string"
+                        },
+                        "SourceEndpointArn": {
+                            "type": "string"
+                        },
+                        "TableMappings": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TargetEndpointArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "MigrationType",
+                        "ReplicationInstanceArn",
+                        "SourceEndpointArn",
+                        "TableMappings",
+                        "TargetEndpointArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DMS::ReplicationTask"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Activate": {
+                            "type": "boolean"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ParameterObjects": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterObject"
+                            },
+                            "type": "array"
+                        },
+                        "ParameterValues": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterValue"
+                            },
+                            "type": "array"
+                        },
+                        "PipelineObjects": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.PipelineObject"
+                            },
+                            "type": "array"
+                        },
+                        "PipelineTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DataPipeline::Pipeline.PipelineTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "ParameterObjects"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DataPipeline::Pipeline"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline.Field": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "RefValue": {
+                    "type": "string"
+                },
+                "StringValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline.ParameterAttribute": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "StringValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "StringValue"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline.ParameterObject": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::DataPipeline::Pipeline.ParameterAttribute"
+                    },
+                    "type": "array"
+                },
+                "Id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Attributes",
+                "Id"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline.ParameterValue": {
+            "additionalProperties": false,
+            "properties": {
+                "Id": {
+                    "type": "string"
+                },
+                "StringValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Id",
+                "StringValue"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline.PipelineObject": {
+            "additionalProperties": false,
+            "properties": {
+                "Fields": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::DataPipeline::Pipeline.Field"
+                    },
+                    "type": "array"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Fields",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::DataPipeline::Pipeline.PipelineTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::DirectoryService::MicrosoftAD": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CreateAlias": {
+                            "type": "boolean"
+                        },
+                        "EnableSso": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Password": {
+                            "type": "string"
+                        },
+                        "ShortName": {
+                            "type": "string"
+                        },
+                        "VpcSettings": {
+                            "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD.VpcSettings"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "Password",
+                        "VpcSettings"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DirectoryService::MicrosoftAD"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DirectoryService::MicrosoftAD.VpcSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "VpcId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "SubnetIds",
+                "VpcId"
+            ],
+            "type": "object"
+        },
+        "AWS::DirectoryService::SimpleAD": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CreateAlias": {
+                            "type": "boolean"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnableSso": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Password": {
+                            "type": "string"
+                        },
+                        "ShortName": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "string"
+                        },
+                        "VpcSettings": {
+                            "$ref": "#/definitions/AWS::DirectoryService::SimpleAD.VpcSettings"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "Password",
+                        "Size",
+                        "VpcSettings"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DirectoryService::SimpleAD"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DirectoryService::SimpleAD.VpcSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "VpcId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "SubnetIds",
+                "VpcId"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AttributeDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.AttributeDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "GlobalSecondaryIndexes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.GlobalSecondaryIndex"
+                            },
+                            "type": "array"
+                        },
+                        "KeySchema": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.KeySchema"
+                            },
+                            "type": "array"
+                        },
+                        "LocalSecondaryIndexes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::DynamoDB::Table.LocalSecondaryIndex"
+                            },
+                            "type": "array"
+                        },
+                        "ProvisionedThroughput": {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table.ProvisionedThroughput"
+                        },
+                        "StreamSpecification": {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table.StreamSpecification"
+                        },
+                        "TableName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TimeToLiveSpecification": {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table.TimeToLiveSpecification"
+                        }
+                    },
+                    "required": [
+                        "KeySchema",
+                        "ProvisionedThroughput"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DynamoDB::Table"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.AttributeDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "AttributeName": {
+                    "type": "string"
+                },
+                "AttributeType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AttributeName",
+                "AttributeType"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.GlobalSecondaryIndex": {
+            "additionalProperties": false,
+            "properties": {
+                "IndexName": {
+                    "type": "string"
+                },
+                "KeySchema": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::DynamoDB::Table.KeySchema"
+                    },
+                    "type": "array"
+                },
+                "Projection": {
+                    "$ref": "#/definitions/AWS::DynamoDB::Table.Projection"
+                },
+                "ProvisionedThroughput": {
+                    "$ref": "#/definitions/AWS::DynamoDB::Table.ProvisionedThroughput"
+                }
+            },
+            "required": [
+                "IndexName",
+                "KeySchema",
+                "Projection",
+                "ProvisionedThroughput"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.KeySchema": {
+            "additionalProperties": false,
+            "properties": {
+                "AttributeName": {
+                    "type": "string"
+                },
+                "KeyType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AttributeName",
+                "KeyType"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.LocalSecondaryIndex": {
+            "additionalProperties": false,
+            "properties": {
+                "IndexName": {
+                    "type": "string"
+                },
+                "KeySchema": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::DynamoDB::Table.KeySchema"
+                    },
+                    "type": "array"
+                },
+                "Projection": {
+                    "$ref": "#/definitions/AWS::DynamoDB::Table.Projection"
+                }
+            },
+            "required": [
+                "IndexName",
+                "KeySchema",
+                "Projection"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.Projection": {
+            "additionalProperties": false,
+            "properties": {
+                "NonKeyAttributes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ProjectionType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.ProvisionedThroughput": {
+            "additionalProperties": false,
+            "properties": {
+                "ReadCapacityUnits": {
+                    "type": "number"
+                },
+                "WriteCapacityUnits": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ReadCapacityUnits",
+                "WriteCapacityUnits"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.StreamSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "StreamViewType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "StreamViewType"
+            ],
+            "type": "object"
+        },
+        "AWS::DynamoDB::Table.TimeToLiveSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "AttributeName": {
+                    "type": "string"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "AttributeName",
+                "Enabled"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::CustomerGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BgpAsn": {
+                            "type": "number"
+                        },
+                        "IpAddress": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "BgpAsn",
+                        "IpAddress",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::CustomerGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::DHCPOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainNameServers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetbiosNameServers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetbiosNodeType": {
+                            "type": "number"
+                        },
+                        "NtpServers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::DHCPOptions"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::EIP": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Domain": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::EIP"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::EIPAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocationId": {
+                            "type": "string"
+                        },
+                        "EIP": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        },
+                        "PrivateIpAddress": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::EIPAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::EgressOnlyInternetGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::EgressOnlyInternetGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::FlowLog": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeliverLogsPermissionArn": {
+                            "type": "string"
+                        },
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "ResourceId": {
+                            "type": "string"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "TrafficType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeliverLogsPermissionArn",
+                        "LogGroupName",
+                        "ResourceId",
+                        "ResourceType",
+                        "TrafficType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::FlowLog"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Host": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoPlacement": {
+                            "type": "string"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AvailabilityZone",
+                        "InstanceType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Host"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdditionalInfo": {
+                            "type": "string"
+                        },
+                        "Affinity": {
+                            "type": "string"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "BlockDeviceMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.BlockDeviceMapping"
+                            },
+                            "type": "array"
+                        },
+                        "DisableApiTermination": {
+                            "type": "boolean"
+                        },
+                        "EbsOptimized": {
+                            "type": "boolean"
+                        },
+                        "HostId": {
+                            "type": "string"
+                        },
+                        "IamInstanceProfile": {
+                            "type": "string"
+                        },
+                        "ImageId": {
+                            "type": "string"
+                        },
+                        "InstanceInitiatedShutdownBehavior": {
+                            "type": "string"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "Ipv6AddressCount": {
+                            "type": "number"
+                        },
+                        "Ipv6Addresses": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.InstanceIpv6Address"
+                            },
+                            "type": "array"
+                        },
+                        "KernelId": {
+                            "type": "string"
+                        },
+                        "KeyName": {
+                            "type": "string"
+                        },
+                        "Monitoring": {
+                            "type": "boolean"
+                        },
+                        "NetworkInterfaces": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.NetworkInterface"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementGroupName": {
+                            "type": "string"
+                        },
+                        "PrivateIpAddress": {
+                            "type": "string"
+                        },
+                        "RamdiskId": {
+                            "type": "string"
+                        },
+                        "SecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SourceDestCheck": {
+                            "type": "boolean"
+                        },
+                        "SsmAssociations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.SsmAssociation"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Tenancy": {
+                            "type": "string"
+                        },
+                        "UserData": {
+                            "type": "string"
+                        },
+                        "Volumes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::Instance.Volume"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ImageId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Instance"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.AssociationParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.BlockDeviceMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DeviceName": {
+                    "type": "string"
+                },
+                "Ebs": {
+                    "$ref": "#/definitions/AWS::EC2::Instance.Ebs"
+                },
+                "NoDevice": {
+                    "$ref": "#/definitions/AWS::EC2::Instance.NoDevice"
+                },
+                "VirtualName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.Ebs": {
+            "additionalProperties": false,
+            "properties": {
+                "DeleteOnTermination": {
+                    "type": "boolean"
+                },
+                "Encrypted": {
+                    "type": "boolean"
+                },
+                "Iops": {
+                    "type": "number"
+                },
+                "SnapshotId": {
+                    "type": "string"
+                },
+                "VolumeSize": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::Instance.InstanceIpv6Address": {
+            "additionalProperties": false,
+            "properties": {
+                "Ipv6Address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Ipv6Address"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.NetworkInterface": {
+            "additionalProperties": false,
+            "properties": {
+                "AssociatePublicIpAddress": {
+                    "type": "boolean"
+                },
+                "DeleteOnTermination": {
+                    "type": "boolean"
+                },
+                "Description": {
+                    "type": "string"
+                },
+                "DeviceIndex": {
+                    "type": "string"
+                },
+                "GroupSet": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Ipv6AddressCount": {
+                    "type": "number"
+                },
+                "Ipv6Addresses": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::Instance.InstanceIpv6Address"
+                    },
+                    "type": "array"
+                },
+                "NetworkInterfaceId": {
+                    "type": "string"
+                },
+                "PrivateIpAddress": {
+                    "type": "string"
+                },
+                "PrivateIpAddresses": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::Instance.PrivateIpAddressSpecification"
+                    },
+                    "type": "array"
+                },
+                "SecondaryPrivateIpAddressCount": {
+                    "type": "number"
+                },
+                "SubnetId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceIndex"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.NoDevice": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::EC2::Instance.PrivateIpAddressSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Primary": {
+                    "type": "boolean"
+                },
+                "PrivateIpAddress": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Primary",
+                "PrivateIpAddress"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.SsmAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "AssociationParameters": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::Instance.AssociationParameter"
+                    },
+                    "type": "array"
+                },
+                "DocumentName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DocumentName"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.Volume": {
+            "additionalProperties": false,
+            "properties": {
+                "Device": {
+                    "type": "string"
+                },
+                "VolumeId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Device",
+                "VolumeId"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::InternetGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::InternetGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NatGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocationId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "AllocationId",
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NatGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkAcl": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkAcl"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkAclEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "Egress": {
+                            "type": "boolean"
+                        },
+                        "Icmp": {
+                            "$ref": "#/definitions/AWS::EC2::NetworkAclEntry.Icmp"
+                        },
+                        "Ipv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "NetworkAclId": {
+                            "type": "string"
+                        },
+                        "PortRange": {
+                            "$ref": "#/definitions/AWS::EC2::NetworkAclEntry.PortRange"
+                        },
+                        "Protocol": {
+                            "type": "number"
+                        },
+                        "RuleAction": {
+                            "type": "string"
+                        },
+                        "RuleNumber": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "CidrBlock",
+                        "NetworkAclId",
+                        "Protocol",
+                        "RuleAction",
+                        "RuleNumber"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkAclEntry"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkAclEntry.Icmp": {
+            "additionalProperties": false,
+            "properties": {
+                "Code": {
+                    "type": "number"
+                },
+                "Type": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkAclEntry.PortRange": {
+            "additionalProperties": false,
+            "properties": {
+                "From": {
+                    "type": "number"
+                },
+                "To": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInterface": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "GroupSet": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "InterfaceType": {
+                            "type": "string"
+                        },
+                        "Ipv6AddressCount": {
+                            "type": "number"
+                        },
+                        "Ipv6Addresses": {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInterface.InstanceIpv6Address"
+                        },
+                        "PrivateIpAddress": {
+                            "type": "string"
+                        },
+                        "PrivateIpAddresses": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::NetworkInterface.PrivateIpAddressSpecification"
+                            },
+                            "type": "array"
+                        },
+                        "SecondaryPrivateIpAddressCount": {
+                            "type": "number"
+                        },
+                        "SourceDestCheck": {
+                            "type": "boolean"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInterface"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInterface.InstanceIpv6Address": {
+            "additionalProperties": false,
+            "properties": {
+                "Ipv6Address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Ipv6Address"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInterface.PrivateIpAddressSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Primary": {
+                    "type": "boolean"
+                },
+                "PrivateIpAddress": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Primary",
+                "PrivateIpAddress"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInterfaceAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeleteOnTermination": {
+                            "type": "boolean"
+                        },
+                        "DeviceIndex": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeviceIndex",
+                        "InstanceId",
+                        "NetworkInterfaceId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInterfaceAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInterfacePermission": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AwsAccountId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        },
+                        "Permission": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AwsAccountId",
+                        "NetworkInterfaceId",
+                        "Permission"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInterfacePermission"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::PlacementGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Strategy": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::PlacementGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Route": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "DestinationIpv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "GatewayId": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "NatGatewayId": {
+                            "type": "string"
+                        },
+                        "NetworkInterfaceId": {
+                            "type": "string"
+                        },
+                        "RouteTableId": {
+                            "type": "string"
+                        },
+                        "VpcPeeringConnectionId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RouteTableId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Route"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::RouteTable": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::RouteTable"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SecurityGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupDescription": {
+                            "type": "string"
+                        },
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "SecurityGroupEgress": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::SecurityGroup.Egress"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityGroupIngress": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EC2::SecurityGroup.Ingress"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "GroupDescription"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SecurityGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SecurityGroup.Egress": {
+            "additionalProperties": false,
+            "properties": {
+                "CidrIp": {
+                    "type": "string"
+                },
+                "CidrIpv6": {
+                    "type": "string"
+                },
+                "DestinationPrefixListId": {
+                    "type": "string"
+                },
+                "DestinationSecurityGroupId": {
+                    "type": "string"
+                },
+                "FromPort": {
+                    "type": "number"
+                },
+                "IpProtocol": {
+                    "type": "string"
+                },
+                "ToPort": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "IpProtocol"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SecurityGroup.Ingress": {
+            "additionalProperties": false,
+            "properties": {
+                "CidrIp": {
+                    "type": "string"
+                },
+                "CidrIpv6": {
+                    "type": "string"
+                },
+                "FromPort": {
+                    "type": "number"
+                },
+                "IpProtocol": {
+                    "type": "string"
+                },
+                "SourceSecurityGroupId": {
+                    "type": "string"
+                },
+                "SourceSecurityGroupName": {
+                    "type": "string"
+                },
+                "SourceSecurityGroupOwnerId": {
+                    "type": "string"
+                },
+                "ToPort": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "IpProtocol"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SecurityGroupEgress": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrIp": {
+                            "type": "string"
+                        },
+                        "CidrIpv6": {
+                            "type": "string"
+                        },
+                        "DestinationPrefixListId": {
+                            "type": "string"
+                        },
+                        "DestinationSecurityGroupId": {
+                            "type": "string"
+                        },
+                        "FromPort": {
+                            "type": "number"
+                        },
+                        "GroupId": {
+                            "type": "string"
+                        },
+                        "IpProtocol": {
+                            "type": "string"
+                        },
+                        "ToPort": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "GroupId",
+                        "IpProtocol"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SecurityGroupEgress"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SecurityGroupIngress": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrIp": {
+                            "type": "string"
+                        },
+                        "CidrIpv6": {
+                            "type": "string"
+                        },
+                        "FromPort": {
+                            "type": "number"
+                        },
+                        "GroupId": {
+                            "type": "string"
+                        },
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "IpProtocol": {
+                            "type": "string"
+                        },
+                        "SourceSecurityGroupId": {
+                            "type": "string"
+                        },
+                        "SourceSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "SourceSecurityGroupOwnerId": {
+                            "type": "string"
+                        },
+                        "ToPort": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "IpProtocol"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SecurityGroupIngress"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "SpotFleetRequestConfigData": {
+                            "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetRequestConfigData"
+                        }
+                    },
+                    "required": [
+                        "SpotFleetRequestConfigData"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SpotFleet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.BlockDeviceMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DeviceName": {
+                    "type": "string"
+                },
+                "Ebs": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.EbsBlockDevice"
+                },
+                "NoDevice": {
+                    "type": "string"
+                },
+                "VirtualName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.EbsBlockDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeleteOnTermination": {
+                    "type": "boolean"
+                },
+                "Encrypted": {
+                    "type": "boolean"
+                },
+                "Iops": {
+                    "type": "number"
+                },
+                "SnapshotId": {
+                    "type": "string"
+                },
+                "VolumeSize": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.GroupIdentifier": {
+            "additionalProperties": false,
+            "properties": {
+                "GroupId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "GroupId"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.IamInstanceProfileSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.InstanceIpv6Address": {
+            "additionalProperties": false,
+            "properties": {
+                "Ipv6Address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Ipv6Address"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.InstanceNetworkInterfaceSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "AssociatePublicIpAddress": {
+                    "type": "boolean"
+                },
+                "DeleteOnTermination": {
+                    "type": "boolean"
+                },
+                "Description": {
+                    "type": "string"
+                },
+                "DeviceIndex": {
+                    "type": "number"
+                },
+                "Groups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Ipv6AddressCount": {
+                    "type": "number"
+                },
+                "Ipv6Addresses": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::SpotFleet.InstanceIpv6Address"
+                    },
+                    "type": "array"
+                },
+                "NetworkInterfaceId": {
+                    "type": "string"
+                },
+                "PrivateIpAddresses": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::SpotFleet.PrivateIpAddressSpecification"
+                    },
+                    "type": "array"
+                },
+                "SecondaryPrivateIpAddressCount": {
+                    "type": "number"
+                },
+                "SubnetId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.PrivateIpAddressSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Primary": {
+                    "type": "boolean"
+                },
+                "PrivateIpAddress": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PrivateIpAddress"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotFleetLaunchSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockDeviceMappings": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::SpotFleet.BlockDeviceMapping"
+                    },
+                    "type": "array"
+                },
+                "EbsOptimized": {
+                    "type": "boolean"
+                },
+                "IamInstanceProfile": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.IamInstanceProfileSpecification"
+                },
+                "ImageId": {
+                    "type": "string"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "KernelId": {
+                    "type": "string"
+                },
+                "KeyName": {
+                    "type": "string"
+                },
+                "Monitoring": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetMonitoring"
+                },
+                "NetworkInterfaces": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::SpotFleet.InstanceNetworkInterfaceSpecification"
+                    },
+                    "type": "array"
+                },
+                "Placement": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotPlacement"
+                },
+                "RamdiskId": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::SpotFleet.GroupIdentifier"
+                    },
+                    "type": "array"
+                },
+                "SpotPrice": {
+                    "type": "string"
+                },
+                "SubnetId": {
+                    "type": "string"
+                },
+                "UserData": {
+                    "type": "string"
+                },
+                "WeightedCapacity": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ImageId",
+                "InstanceType"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotFleetMonitoring": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotFleetRequestConfigData": {
+            "additionalProperties": false,
+            "properties": {
+                "AllocationStrategy": {
+                    "type": "string"
+                },
+                "ExcessCapacityTerminationPolicy": {
+                    "type": "string"
+                },
+                "IamFleetRole": {
+                    "type": "string"
+                },
+                "LaunchSpecifications": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetLaunchSpecification"
+                    },
+                    "type": "array"
+                },
+                "ReplaceUnhealthyInstances": {
+                    "type": "boolean"
+                },
+                "SpotPrice": {
+                    "type": "string"
+                },
+                "TargetCapacity": {
+                    "type": "number"
+                },
+                "TerminateInstancesWithExpiration": {
+                    "type": "boolean"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "ValidFrom": {
+                    "type": "string"
+                },
+                "ValidUntil": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "IamFleetRole",
+                "LaunchSpecifications",
+                "SpotPrice",
+                "TargetCapacity"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotPlacement": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZone": {
+                    "type": "string"
+                },
+                "GroupName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::Subnet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AssignIpv6AddressOnCreation": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "Ipv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "MapPublicIpOnLaunch": {
+                            "type": "boolean"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CidrBlock",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Subnet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SubnetCidrBlock": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Ipv6CidrBlock": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Ipv6CidrBlock",
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SubnetCidrBlock"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SubnetNetworkAclAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "NetworkAclId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "NetworkAclId",
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SubnetNetworkAclAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::SubnetRouteTableAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RouteTableId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RouteTableId",
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::SubnetRouteTableAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::TrunkInterfaceAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BranchInterfaceId": {
+                            "type": "string"
+                        },
+                        "GREKey": {
+                            "type": "number"
+                        },
+                        "TrunkInterfaceId": {
+                            "type": "string"
+                        },
+                        "VLANId": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "BranchInterfaceId",
+                        "TrunkInterfaceId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::TrunkInterfaceAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPC": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "EnableDnsHostnames": {
+                            "type": "boolean"
+                        },
+                        "EnableDnsSupport": {
+                            "type": "boolean"
+                        },
+                        "InstanceTenancy": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "CidrBlock"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPC"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPCCidrBlock": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AmazonProvidedIpv6CidrBlock": {
+                            "type": "boolean"
+                        },
+                        "CidrBlock": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCCidrBlock"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPCDHCPOptionsAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DhcpOptionsId": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DhcpOptionsId",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCDHCPOptionsAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPCEndpoint": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "RouteTableIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ServiceName": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ServiceName",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCEndpoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPCGatewayAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InternetGatewayId": {
+                            "type": "string"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        },
+                        "VpnGatewayId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCGatewayAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPCPeeringConnection": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PeerOwnerId": {
+                            "type": "string"
+                        },
+                        "PeerRoleArn": {
+                            "type": "string"
+                        },
+                        "PeerVpcId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "PeerVpcId",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCPeeringConnection"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPNConnection": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CustomerGatewayId": {
+                            "type": "string"
+                        },
+                        "StaticRoutesOnly": {
+                            "type": "boolean"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "VpnGatewayId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CustomerGatewayId",
+                        "Type",
+                        "VpnGatewayId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNConnection"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPNConnectionRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "VpnConnectionId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationCidrBlock",
+                        "VpnConnectionId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNConnectionRoute"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPNGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNGateway"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VPNGatewayRoutePropagation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RouteTableIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "VpnGatewayId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "RouteTableIds",
+                        "VpnGatewayId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPNGatewayRoutePropagation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::Volume": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoEnableIO": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "Encrypted": {
+                            "type": "boolean"
+                        },
+                        "Iops": {
+                            "type": "number"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "number"
+                        },
+                        "SnapshotId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VolumeType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AvailabilityZone"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::Volume"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::VolumeAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Device": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "VolumeId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Device",
+                        "InstanceId",
+                        "VolumeId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VolumeAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECR::Repository": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "RepositoryPolicyText": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECR::Repository"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::Cluster": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ClusterName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECS::Cluster"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::Service": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Cluster": {
+                            "type": "string"
+                        },
+                        "DeploymentConfiguration": {
+                            "$ref": "#/definitions/AWS::ECS::Service.DeploymentConfiguration"
+                        },
+                        "DesiredCount": {
+                            "type": "number"
+                        },
+                        "LoadBalancers": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::Service.LoadBalancer"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::Service.PlacementConstraint"
+                            },
+                            "type": "array"
+                        },
+                        "PlacementStrategies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::Service.PlacementStrategy"
+                            },
+                            "type": "array"
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "ServiceName": {
+                            "type": "string"
+                        },
+                        "TaskDefinition": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "TaskDefinition"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECS::Service"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::Service.DeploymentConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "MaximumPercent": {
+                    "type": "number"
+                },
+                "MinimumHealthyPercent": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::Service.LoadBalancer": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerName": {
+                    "type": "string"
+                },
+                "ContainerPort": {
+                    "type": "number"
+                },
+                "LoadBalancerName": {
+                    "type": "string"
+                },
+                "TargetGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ContainerPort"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::Service.PlacementConstraint": {
+            "additionalProperties": false,
+            "properties": {
+                "Expression": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::Service.PlacementStrategy": {
+            "additionalProperties": false,
+            "properties": {
+                "Field": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContainerDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::TaskDefinition.ContainerDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "Family": {
+                            "type": "string"
+                        },
+                        "NetworkMode": {
+                            "type": "string"
+                        },
+                        "PlacementConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint"
+                            },
+                            "type": "array"
+                        },
+                        "TaskRoleArn": {
+                            "type": "string"
+                        },
+                        "Volumes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ECS::TaskDefinition.Volume"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECS::TaskDefinition"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.ContainerDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "Command": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Cpu": {
+                    "type": "number"
+                },
+                "DisableNetworking": {
+                    "type": "boolean"
+                },
+                "DnsSearchDomains": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "DnsServers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "DockerLabels": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "DockerSecurityOptions": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "EntryPoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.KeyValuePair"
+                    },
+                    "type": "array"
+                },
+                "Essential": {
+                    "type": "boolean"
+                },
+                "ExtraHosts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.HostEntry"
+                    },
+                    "type": "array"
+                },
+                "Hostname": {
+                    "type": "string"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "Links": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "LogConfiguration": {
+                    "$ref": "#/definitions/AWS::ECS::TaskDefinition.LogConfiguration"
+                },
+                "Memory": {
+                    "type": "number"
+                },
+                "MemoryReservation": {
+                    "type": "number"
+                },
+                "MountPoints": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.MountPoint"
+                    },
+                    "type": "array"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "PortMappings": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.PortMapping"
+                    },
+                    "type": "array"
+                },
+                "Privileged": {
+                    "type": "boolean"
+                },
+                "ReadonlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "Ulimits": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.Ulimit"
+                    },
+                    "type": "array"
+                },
+                "User": {
+                    "type": "string"
+                },
+                "VolumesFrom": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.VolumeFrom"
+                    },
+                    "type": "array"
+                },
+                "WorkingDirectory": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.HostEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Hostname": {
+                    "type": "string"
+                },
+                "IpAddress": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Hostname",
+                "IpAddress"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.HostVolumeProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "SourcePath": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.KeyValuePair": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.LogConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "LogDriver": {
+                    "type": "string"
+                },
+                "Options": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -31,11 +8517,9022 @@
                 }
             },
             "required": [
-                "StageName"
+                "LogDriver"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.MountPoint": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerPath": {
+                    "type": "string"
+                },
+                "ReadOnly": {
+                    "type": "boolean"
+                },
+                "SourceVolume": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.PortMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerPort": {
+                    "type": "number"
+                },
+                "HostPort": {
+                    "type": "number"
+                },
+                "Protocol": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint": {
+            "additionalProperties": false,
+            "properties": {
+                "Expression": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.Ulimit": {
+            "additionalProperties": false,
+            "properties": {
+                "HardLimit": {
+                    "type": "number"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "SoftLimit": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "HardLimit",
+                "Name",
+                "SoftLimit"
+            ],
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.Volume": {
+            "additionalProperties": false,
+            "properties": {
+                "Host": {
+                    "$ref": "#/definitions/AWS::ECS::TaskDefinition.HostVolumeProperties"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ECS::TaskDefinition.VolumeFrom": {
+            "additionalProperties": false,
+            "properties": {
+                "ReadOnly": {
+                    "type": "boolean"
+                },
+                "SourceContainer": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EFS::FileSystem": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Encrypted": {
+                            "type": "boolean"
+                        },
+                        "FileSystemTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EFS::FileSystem.ElasticFileSystemTag"
+                            },
+                            "type": "array"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "PerformanceMode": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EFS::FileSystem"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EFS::FileSystem.ElasticFileSystemTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EFS::MountTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FileSystemId": {
+                            "type": "string"
+                        },
+                        "IpAddress": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "FileSystemId",
+                        "SecurityGroups",
+                        "SubnetId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EFS::MountTarget"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AdditionalInfo": {
+                            "type": "object"
+                        },
+                        "Applications": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::Cluster.Application"
+                            },
+                            "type": "array"
+                        },
+                        "AutoScalingRole": {
+                            "type": "string"
+                        },
+                        "BootstrapActions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::Cluster.BootstrapActionConfig"
+                            },
+                            "type": "array"
+                        },
+                        "Configurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::Cluster.Configuration"
+                            },
+                            "type": "array"
+                        },
+                        "Instances": {
+                            "$ref": "#/definitions/AWS::EMR::Cluster.JobFlowInstancesConfig"
+                        },
+                        "JobFlowRole": {
+                            "type": "string"
+                        },
+                        "LogUri": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ReleaseLabel": {
+                            "type": "string"
+                        },
+                        "ScaleDownBehavior": {
+                            "type": "string"
+                        },
+                        "SecurityConfiguration": {
+                            "type": "string"
+                        },
+                        "ServiceRole": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VisibleToAllUsers": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "Instances",
+                        "JobFlowRole",
+                        "Name",
+                        "ServiceRole"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::Cluster"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.Application": {
+            "additionalProperties": false,
+            "properties": {
+                "AdditionalInfo": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Args": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.AutoScalingPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Constraints": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.ScalingConstraints"
+                },
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.ScalingRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Constraints",
+                "Rules"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.BootstrapActionConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "ScriptBootstrapAction": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.ScriptBootstrapActionConfig"
+                }
+            },
+            "required": [
+                "Name",
+                "ScriptBootstrapAction"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.CloudWatchAlarmDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "ComparisonOperator": {
+                    "type": "string"
+                },
+                "Dimensions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.MetricDimension"
+                    },
+                    "type": "array"
+                },
+                "EvaluationPeriods": {
+                    "type": "number"
+                },
+                "MetricName": {
+                    "type": "string"
+                },
+                "Namespace": {
+                    "type": "string"
+                },
+                "Period": {
+                    "type": "number"
+                },
+                "Statistic": {
+                    "type": "string"
+                },
+                "Threshold": {
+                    "type": "number"
+                },
+                "Unit": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ComparisonOperator",
+                "MetricName",
+                "Period",
+                "Threshold"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.Configuration": {
+            "additionalProperties": false,
+            "properties": {
+                "Classification": {
+                    "type": "string"
+                },
+                "ConfigurationProperties": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Configurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.Configuration"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.EbsBlockDeviceConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "VolumeSpecification": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.VolumeSpecification"
+                },
+                "VolumesPerInstance": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "VolumeSpecification"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.EbsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "EbsBlockDeviceConfigs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.EbsBlockDeviceConfig"
+                    },
+                    "type": "array"
+                },
+                "EbsOptimized": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.InstanceFleetConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceTypeConfigs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.InstanceTypeConfig"
+                    },
+                    "type": "array"
+                },
+                "LaunchSpecifications": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.InstanceFleetProvisioningSpecifications"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "TargetOnDemandCapacity": {
+                    "type": "number"
+                },
+                "TargetSpotCapacity": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.InstanceFleetProvisioningSpecifications": {
+            "additionalProperties": false,
+            "properties": {
+                "SpotSpecification": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.SpotProvisioningSpecification"
+                }
+            },
+            "required": [
+                "SpotSpecification"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.InstanceGroupConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AutoScalingPolicy": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.AutoScalingPolicy"
+                },
+                "BidPrice": {
+                    "type": "string"
+                },
+                "Configurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.Configuration"
+                    },
+                    "type": "array"
+                },
+                "EbsConfiguration": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.EbsConfiguration"
+                },
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "Market": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.InstanceTypeConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BidPrice": {
+                    "type": "string"
+                },
+                "BidPriceAsPercentageOfOnDemandPrice": {
+                    "type": "number"
+                },
+                "Configurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Cluster.Configuration"
+                    },
+                    "type": "array"
+                },
+                "EbsConfiguration": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.EbsConfiguration"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "WeightedCapacity": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceType"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.JobFlowInstancesConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AdditionalMasterSecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AdditionalSlaveSecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "CoreInstanceFleet": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.InstanceFleetConfig"
+                },
+                "CoreInstanceGroup": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.InstanceGroupConfig"
+                },
+                "Ec2KeyName": {
+                    "type": "string"
+                },
+                "Ec2SubnetId": {
+                    "type": "string"
+                },
+                "EmrManagedMasterSecurityGroup": {
+                    "type": "string"
+                },
+                "EmrManagedSlaveSecurityGroup": {
+                    "type": "string"
+                },
+                "HadoopVersion": {
+                    "type": "string"
+                },
+                "MasterInstanceFleet": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.InstanceFleetConfig"
+                },
+                "MasterInstanceGroup": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.InstanceGroupConfig"
+                },
+                "Placement": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.PlacementType"
+                },
+                "ServiceAccessSecurityGroup": {
+                    "type": "string"
+                },
+                "TerminationProtected": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.MetricDimension": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.PlacementType": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZone": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AvailabilityZone"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.ScalingAction": {
+            "additionalProperties": false,
+            "properties": {
+                "Market": {
+                    "type": "string"
+                },
+                "SimpleScalingPolicyConfiguration": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.SimpleScalingPolicyConfiguration"
+                }
+            },
+            "required": [
+                "SimpleScalingPolicyConfiguration"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.ScalingConstraints": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxCapacity": {
+                    "type": "number"
+                },
+                "MinCapacity": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxCapacity",
+                "MinCapacity"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.ScalingRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Action": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.ScalingAction"
+                },
+                "Description": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Trigger": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.ScalingTrigger"
+                }
+            },
+            "required": [
+                "Action",
+                "Name",
+                "Trigger"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.ScalingTrigger": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchAlarmDefinition": {
+                    "$ref": "#/definitions/AWS::EMR::Cluster.CloudWatchAlarmDefinition"
+                }
+            },
+            "required": [
+                "CloudWatchAlarmDefinition"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.ScriptBootstrapActionConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Args": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Path"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.SimpleScalingPolicyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AdjustmentType": {
+                    "type": "string"
+                },
+                "CoolDown": {
+                    "type": "number"
+                },
+                "ScalingAdjustment": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ScalingAdjustment"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.SpotProvisioningSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockDurationMinutes": {
+                    "type": "number"
+                },
+                "TimeoutAction": {
+                    "type": "string"
+                },
+                "TimeoutDurationMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "TimeoutAction",
+                "TimeoutDurationMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Cluster.VolumeSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Iops": {
+                    "type": "number"
+                },
+                "SizeInGB": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "SizeInGB",
+                "VolumeType"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ClusterId": {
+                            "type": "string"
+                        },
+                        "InstanceFleetType": {
+                            "type": "string"
+                        },
+                        "InstanceTypeConfigs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.InstanceTypeConfig"
+                            },
+                            "type": "array"
+                        },
+                        "LaunchSpecifications": {
+                            "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.InstanceFleetProvisioningSpecifications"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "TargetOnDemandCapacity": {
+                            "type": "number"
+                        },
+                        "TargetSpotCapacity": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "ClusterId",
+                        "InstanceFleetType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::InstanceFleetConfig"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.Configuration": {
+            "additionalProperties": false,
+            "properties": {
+                "Classification": {
+                    "type": "string"
+                },
+                "ConfigurationProperties": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Configurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.Configuration"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.EbsBlockDeviceConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "VolumeSpecification": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.VolumeSpecification"
+                },
+                "VolumesPerInstance": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "VolumeSpecification"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.EbsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "EbsBlockDeviceConfigs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.EbsBlockDeviceConfig"
+                    },
+                    "type": "array"
+                },
+                "EbsOptimized": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.InstanceFleetProvisioningSpecifications": {
+            "additionalProperties": false,
+            "properties": {
+                "SpotSpecification": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.SpotProvisioningSpecification"
+                }
+            },
+            "required": [
+                "SpotSpecification"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.InstanceTypeConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BidPrice": {
+                    "type": "string"
+                },
+                "BidPriceAsPercentageOfOnDemandPrice": {
+                    "type": "number"
+                },
+                "Configurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.Configuration"
+                    },
+                    "type": "array"
+                },
+                "EbsConfiguration": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig.EbsConfiguration"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "WeightedCapacity": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceType"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.SpotProvisioningSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockDurationMinutes": {
+                    "type": "number"
+                },
+                "TimeoutAction": {
+                    "type": "string"
+                },
+                "TimeoutDurationMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "TimeoutAction",
+                "TimeoutDurationMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceFleetConfig.VolumeSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Iops": {
+                    "type": "number"
+                },
+                "SizeInGB": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "SizeInGB",
+                "VolumeType"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoScalingPolicy": {
+                            "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.AutoScalingPolicy"
+                        },
+                        "BidPrice": {
+                            "type": "string"
+                        },
+                        "Configurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.Configuration"
+                            },
+                            "type": "array"
+                        },
+                        "EbsConfiguration": {
+                            "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.EbsConfiguration"
+                        },
+                        "InstanceCount": {
+                            "type": "number"
+                        },
+                        "InstanceRole": {
+                            "type": "string"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "JobFlowId": {
+                            "type": "string"
+                        },
+                        "Market": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "InstanceCount",
+                        "InstanceRole",
+                        "InstanceType",
+                        "JobFlowId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::InstanceGroupConfig"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.AutoScalingPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Constraints": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.ScalingConstraints"
+                },
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.ScalingRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Constraints",
+                "Rules"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.CloudWatchAlarmDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "ComparisonOperator": {
+                    "type": "string"
+                },
+                "Dimensions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.MetricDimension"
+                    },
+                    "type": "array"
+                },
+                "EvaluationPeriods": {
+                    "type": "number"
+                },
+                "MetricName": {
+                    "type": "string"
+                },
+                "Namespace": {
+                    "type": "string"
+                },
+                "Period": {
+                    "type": "number"
+                },
+                "Statistic": {
+                    "type": "string"
+                },
+                "Threshold": {
+                    "type": "number"
+                },
+                "Unit": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ComparisonOperator",
+                "MetricName",
+                "Period",
+                "Threshold"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.Configuration": {
+            "additionalProperties": false,
+            "properties": {
+                "Classification": {
+                    "type": "string"
+                },
+                "ConfigurationProperties": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Configurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.Configuration"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.EbsBlockDeviceConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "VolumeSpecification": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.VolumeSpecification"
+                },
+                "VolumesPerInstance": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "VolumeSpecification"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.EbsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "EbsBlockDeviceConfigs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.EbsBlockDeviceConfig"
+                    },
+                    "type": "array"
+                },
+                "EbsOptimized": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.MetricDimension": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.ScalingAction": {
+            "additionalProperties": false,
+            "properties": {
+                "Market": {
+                    "type": "string"
+                },
+                "SimpleScalingPolicyConfiguration": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.SimpleScalingPolicyConfiguration"
+                }
+            },
+            "required": [
+                "SimpleScalingPolicyConfiguration"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.ScalingConstraints": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxCapacity": {
+                    "type": "number"
+                },
+                "MinCapacity": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxCapacity",
+                "MinCapacity"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.ScalingRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Action": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.ScalingAction"
+                },
+                "Description": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Trigger": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.ScalingTrigger"
+                }
+            },
+            "required": [
+                "Action",
+                "Name",
+                "Trigger"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.ScalingTrigger": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchAlarmDefinition": {
+                    "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig.CloudWatchAlarmDefinition"
+                }
+            },
+            "required": [
+                "CloudWatchAlarmDefinition"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.SimpleScalingPolicyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AdjustmentType": {
+                    "type": "string"
+                },
+                "CoolDown": {
+                    "type": "number"
+                },
+                "ScalingAdjustment": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ScalingAdjustment"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::InstanceGroupConfig.VolumeSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "Iops": {
+                    "type": "number"
+                },
+                "SizeInGB": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "SizeInGB",
+                "VolumeType"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::SecurityConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SecurityConfiguration": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "SecurityConfiguration"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::SecurityConfiguration"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Step": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ActionOnFailure": {
+                            "type": "string"
+                        },
+                        "HadoopJarStep": {
+                            "$ref": "#/definitions/AWS::EMR::Step.HadoopJarStepConfig"
+                        },
+                        "JobFlowId": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ActionOnFailure",
+                        "HadoopJarStep",
+                        "JobFlowId",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EMR::Step"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Step.HadoopJarStepConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Args": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Jar": {
+                    "type": "string"
+                },
+                "MainClass": {
+                    "type": "string"
+                },
+                "StepProperties": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EMR::Step.KeyValue"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Jar"
+            ],
+            "type": "object"
+        },
+        "AWS::EMR::Step.KeyValue": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::CacheCluster": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AZMode": {
+                            "type": "string"
+                        },
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "CacheNodeType": {
+                            "type": "string"
+                        },
+                        "CacheParameterGroupName": {
+                            "type": "string"
+                        },
+                        "CacheSecurityGroupNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "CacheSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "ClusterName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "NotificationTopicArn": {
+                            "type": "string"
+                        },
+                        "NumCacheNodes": {
+                            "type": "number"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredAvailabilityZone": {
+                            "type": "string"
+                        },
+                        "PreferredAvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "SnapshotArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnapshotName": {
+                            "type": "string"
+                        },
+                        "SnapshotRetentionLimit": {
+                            "type": "number"
+                        },
+                        "SnapshotWindow": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "CacheNodeType",
+                        "Engine",
+                        "NumCacheNodes"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::CacheCluster"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::ParameterGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheParameterGroupFamily": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Properties": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "CacheParameterGroupFamily",
+                        "Description"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::ParameterGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::ReplicationGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutomaticFailoverEnabled": {
+                            "type": "boolean"
+                        },
+                        "CacheNodeType": {
+                            "type": "string"
+                        },
+                        "CacheParameterGroupName": {
+                            "type": "string"
+                        },
+                        "CacheSecurityGroupNames": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "CacheSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "NodeGroupConfiguration": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElastiCache::ReplicationGroup.NodeGroupConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationTopicArn": {
+                            "type": "string"
+                        },
+                        "NumCacheClusters": {
+                            "type": "number"
+                        },
+                        "NumNodeGroups": {
+                            "type": "number"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredCacheClusterAZs": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PrimaryClusterId": {
+                            "type": "string"
+                        },
+                        "ReplicasPerNodeGroup": {
+                            "type": "number"
+                        },
+                        "ReplicationGroupDescription": {
+                            "type": "string"
+                        },
+                        "ReplicationGroupId": {
+                            "type": "string"
+                        },
+                        "SecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnapshotArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnapshotName": {
+                            "type": "string"
+                        },
+                        "SnapshotRetentionLimit": {
+                            "type": "number"
+                        },
+                        "SnapshotWindow": {
+                            "type": "string"
+                        },
+                        "SnapshottingClusterId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ReplicationGroupDescription"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::ReplicationGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::ReplicationGroup.NodeGroupConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PrimaryAvailabilityZone": {
+                    "type": "string"
+                },
+                "ReplicaAvailabilityZones": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ReplicaCount": {
+                    "type": "number"
+                },
+                "Slots": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::SecurityGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Description"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::SecurityGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::SecurityGroupIngress": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupOwnerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CacheSecurityGroupName",
+                        "EC2SecurityGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::SecurityGroupIngress"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::SubnetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::SubnetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "ResourceLifecycleConfig": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::Application"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.ApplicationResourceLifecycleConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "ServiceRole": {
+                    "type": "string"
+                },
+                "VersionLifecycleConfig": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.ApplicationVersionLifecycleConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.ApplicationVersionLifecycleConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxAgeRule": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.MaxAgeRule"
+                },
+                "MaxCountRule": {
+                    "$ref": "#/definitions/AWS::ElasticBeanstalk::Application.MaxCountRule"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.MaxAgeRule": {
+            "additionalProperties": false,
+            "properties": {
+                "DeleteSourceFromS3": {
+                    "type": "boolean"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "MaxAgeInDays": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Application.MaxCountRule": {
+            "additionalProperties": false,
+            "properties": {
+                "DeleteSourceFromS3": {
+                    "type": "boolean"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "MaxCount": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::ApplicationVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SourceBundle": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::ApplicationVersion.SourceBundle"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "SourceBundle"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::ApplicationVersion"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::ApplicationVersion.SourceBundle": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Bucket": {
+                    "type": "string"
+                },
+                "S3Key": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Bucket",
+                "S3Key"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::ConfigurationTemplate": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnvironmentId": {
+                            "type": "string"
+                        },
+                        "OptionSettings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate.ConfigurationOptionSetting"
+                            },
+                            "type": "array"
+                        },
+                        "PlatformArn": {
+                            "type": "string"
+                        },
+                        "SolutionStackName": {
+                            "type": "string"
+                        },
+                        "SourceConfiguration": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate.SourceConfiguration"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::ConfigurationTemplate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::ConfigurationTemplate.ConfigurationOptionSetting": {
+            "additionalProperties": false,
+            "properties": {
+                "Namespace": {
+                    "type": "string"
+                },
+                "OptionName": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Namespace",
+                "OptionName"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::ConfigurationTemplate.SourceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ApplicationName": {
+                    "type": "string"
+                },
+                "TemplateName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ApplicationName",
+                "TemplateName"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "CNAMEPrefix": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnvironmentName": {
+                            "type": "string"
+                        },
+                        "OptionSettings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.OptionSetting"
+                            },
+                            "type": "array"
+                        },
+                        "PlatformArn": {
+                            "type": "string"
+                        },
+                        "SolutionStackName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TemplateName": {
+                            "type": "string"
+                        },
+                        "Tier": {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment.Tier"
+                        },
+                        "VersionLabel": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticBeanstalk::Environment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Environment.OptionSetting": {
+            "additionalProperties": false,
+            "properties": {
+                "Namespace": {
+                    "type": "string"
+                },
+                "OptionName": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Namespace",
+                "OptionName"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticBeanstalk::Environment.Tier": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessLoggingPolicy": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.AccessLoggingPolicy"
+                        },
+                        "AppCookieStickinessPolicy": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.AppCookieStickinessPolicy"
+                            },
+                            "type": "array"
+                        },
+                        "AvailabilityZones": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ConnectionDrainingPolicy": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.ConnectionDrainingPolicy"
+                        },
+                        "ConnectionSettings": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.ConnectionSettings"
+                        },
+                        "CrossZone": {
+                            "type": "boolean"
+                        },
+                        "HealthCheck": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.HealthCheck"
+                        },
+                        "Instances": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "LBCookieStickinessPolicy": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.LBCookieStickinessPolicy"
+                            },
+                            "type": "array"
+                        },
+                        "Listeners": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.Listeners"
+                            },
+                            "type": "array"
+                        },
+                        "LoadBalancerName": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer.Policies"
+                            },
+                            "type": "array"
+                        },
+                        "Scheme": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Subnets": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Listeners"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancing::LoadBalancer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.AccessLoggingPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "EmitInterval": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "S3BucketName": {
+                    "type": "string"
+                },
+                "S3BucketPrefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Enabled",
+                "S3BucketName"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.AppCookieStickinessPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "CookieName": {
+                    "type": "string"
+                },
+                "PolicyName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "CookieName",
+                "PolicyName"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.ConnectionDrainingPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "Timeout": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Enabled"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.ConnectionSettings": {
+            "additionalProperties": false,
+            "properties": {
+                "IdleTimeout": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "IdleTimeout"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.HealthCheck": {
+            "additionalProperties": false,
+            "properties": {
+                "HealthyThreshold": {
+                    "type": "string"
+                },
+                "Interval": {
+                    "type": "string"
+                },
+                "Target": {
+                    "type": "string"
+                },
+                "Timeout": {
+                    "type": "string"
+                },
+                "UnhealthyThreshold": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "HealthyThreshold",
+                "Interval",
+                "Target",
+                "Timeout",
+                "UnhealthyThreshold"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.LBCookieStickinessPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "CookieExpirationPeriod": {
+                    "type": "string"
+                },
+                "PolicyName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.Listeners": {
+            "additionalProperties": false,
+            "properties": {
+                "InstancePort": {
+                    "type": "string"
+                },
+                "InstanceProtocol": {
+                    "type": "string"
+                },
+                "LoadBalancerPort": {
+                    "type": "string"
+                },
+                "PolicyNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SSLCertificateId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InstancePort",
+                "LoadBalancerPort",
+                "Protocol"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancing::LoadBalancer.Policies": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "items": {
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "InstancePorts": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "LoadBalancerPorts": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "PolicyName": {
+                    "type": "string"
+                },
+                "PolicyType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Attributes",
+                "PolicyName",
+                "PolicyType"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Certificates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.Certificate"
+                            },
+                            "type": "array"
+                        },
+                        "DefaultActions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.Action"
+                            },
+                            "type": "array"
+                        },
+                        "LoadBalancerArn": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "SslPolicy": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DefaultActions",
+                        "LoadBalancerArn",
+                        "Port",
+                        "Protocol"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::Listener"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.Action": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TargetGroupArn",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.Certificate": {
+            "additionalProperties": false,
+            "properties": {
+                "CertificateArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Certificates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate"
+                            },
+                            "type": "array"
+                        },
+                        "ListenerArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Certificates",
+                        "ListenerArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::ListenerCertificate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerCertificate.Certificate": {
+            "additionalProperties": false,
+            "properties": {
+                "CertificateArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Actions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.Action"
+                            },
+                            "type": "array"
+                        },
+                        "Conditions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.RuleCondition"
+                            },
+                            "type": "array"
+                        },
+                        "ListenerArn": {
+                            "type": "string"
+                        },
+                        "Priority": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "Actions",
+                        "Conditions",
+                        "ListenerArn",
+                        "Priority"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::ListenerRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.Action": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TargetGroupArn",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.RuleCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "Field": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IpAddressType": {
+                            "type": "string"
+                        },
+                        "LoadBalancerAttributes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Scheme": {
+                            "type": "string"
+                        },
+                        "SecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SubnetMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping"
+                            },
+                            "type": "array"
+                        },
+                        "Subnets": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::LoadBalancer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::LoadBalancer.SubnetMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "AllocationId": {
+                    "type": "string"
+                },
+                "SubnetId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AllocationId",
+                "SubnetId"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::TargetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "HealthCheckIntervalSeconds": {
+                            "type": "number"
+                        },
+                        "HealthCheckPath": {
+                            "type": "string"
+                        },
+                        "HealthCheckPort": {
+                            "type": "string"
+                        },
+                        "HealthCheckProtocol": {
+                            "type": "string"
+                        },
+                        "HealthCheckTimeoutSeconds": {
+                            "type": "number"
+                        },
+                        "HealthyThresholdCount": {
+                            "type": "number"
+                        },
+                        "Matcher": {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.Matcher"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "TargetGroupAttributes": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetGroupAttribute"
+                            },
+                            "type": "array"
+                        },
+                        "TargetType": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription"
+                            },
+                            "type": "array"
+                        },
+                        "UnhealthyThresholdCount": {
+                            "type": "number"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Port",
+                        "Protocol",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElasticLoadBalancingV2::TargetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::TargetGroup.Matcher": {
+            "additionalProperties": false,
+            "properties": {
+                "HttpCode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "HttpCode"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::TargetGroup.TargetDescription": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZone": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Port": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Id"
+            ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::TargetGroup.TargetGroupAttribute": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessPolicies": {
+                            "type": "object"
+                        },
+                        "AdvancedOptions": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "EBSOptions": {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain.EBSOptions"
+                        },
+                        "ElasticsearchClusterConfig": {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain.ElasticsearchClusterConfig"
+                        },
+                        "ElasticsearchVersion": {
+                            "type": "string"
+                        },
+                        "SnapshotOptions": {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain.SnapshotOptions"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Elasticsearch::Domain"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.EBSOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "EBSEnabled": {
+                    "type": "boolean"
+                },
+                "Iops": {
+                    "type": "number"
+                },
+                "VolumeSize": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.ElasticsearchClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DedicatedMasterCount": {
+                    "type": "number"
+                },
+                "DedicatedMasterEnabled": {
+                    "type": "boolean"
+                },
+                "DedicatedMasterType": {
+                    "type": "string"
+                },
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "ZoneAwarenessEnabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.SnapshotOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "AutomatedSnapshotStartHour": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Events::Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EventPattern": {
+                            "type": "object"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "ScheduleExpression": {
+                            "type": "string"
+                        },
+                        "State": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Events::Rule.Target"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Events::Rule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.EcsParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "TaskCount": {
+                    "type": "number"
+                },
+                "TaskDefinitionArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TaskDefinitionArn"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.InputTransformer": {
+            "additionalProperties": false,
+            "properties": {
+                "InputPathsMap": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "InputTemplate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InputTemplate"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.KinesisParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "PartitionKeyPath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PartitionKeyPath"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.RunCommandParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "RunCommandTargets": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Events::Rule.RunCommandTarget"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "RunCommandTargets"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.RunCommandTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.Target": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "EcsParameters": {
+                    "$ref": "#/definitions/AWS::Events::Rule.EcsParameters"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Input": {
+                    "type": "string"
+                },
+                "InputPath": {
+                    "type": "string"
+                },
+                "InputTransformer": {
+                    "$ref": "#/definitions/AWS::Events::Rule.InputTransformer"
+                },
+                "KinesisParameters": {
+                    "$ref": "#/definitions/AWS::Events::Rule.KinesisParameters"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "RunCommandParameters": {
+                    "$ref": "#/definitions/AWS::Events::Rule.RunCommandParameters"
+                }
+            },
+            "required": [
+                "Arn",
+                "Id"
+            ],
+            "type": "object"
+        },
+        "AWS::GameLift::Alias": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RoutingStrategy": {
+                            "$ref": "#/definitions/AWS::GameLift::Alias.RoutingStrategy"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "RoutingStrategy"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GameLift::Alias"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::GameLift::Alias.RoutingStrategy": {
+            "additionalProperties": false,
+            "properties": {
+                "FleetId": {
+                    "type": "string"
+                },
+                "Message": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::GameLift::Build": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StorageLocation": {
+                            "$ref": "#/definitions/AWS::GameLift::Build.S3Location"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GameLift::Build"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::GameLift::Build.S3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Bucket",
+                "Key",
+                "RoleArn"
+            ],
+            "type": "object"
+        },
+        "AWS::GameLift::Fleet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BuildId": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DesiredEC2Instances": {
+                            "type": "number"
+                        },
+                        "EC2InboundPermissions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::GameLift::Fleet.IpPermission"
+                            },
+                            "type": "array"
+                        },
+                        "EC2InstanceType": {
+                            "type": "string"
+                        },
+                        "LogPaths": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "MaxSize": {
+                            "type": "number"
+                        },
+                        "MinSize": {
+                            "type": "number"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "ServerLaunchParameters": {
+                            "type": "string"
+                        },
+                        "ServerLaunchPath": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "BuildId",
+                        "DesiredEC2Instances",
+                        "EC2InstanceType",
+                        "Name",
+                        "ServerLaunchPath"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GameLift::Fleet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::GameLift::Fleet.IpPermission": {
+            "additionalProperties": false,
+            "properties": {
+                "FromPort": {
+                    "type": "number"
+                },
+                "IpRange": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "ToPort": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "FromPort",
+                "IpRange",
+                "Protocol",
+                "ToPort"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::AccessKey": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Serial": {
+                            "type": "number"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "UserName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::AccessKey"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::Group": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "ManagedPolicyArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::IAM::Group.Policy"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::Group"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::Group.Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "PolicyDocument": {
+                    "type": "object"
+                },
+                "PolicyName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PolicyDocument",
+                "PolicyName"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::InstanceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InstanceProfileName": {
+                            "type": "string"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Roles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Roles"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::InstanceProfile"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::ManagedPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Groups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ManagedPolicyName": {
+                            "type": "string"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "Roles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Users": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::ManagedPolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Groups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "Roles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Users": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument",
+                        "PolicyName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::Policy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::Role": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AssumeRolePolicyDocument": {
+                            "type": "object"
+                        },
+                        "ManagedPolicyArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::IAM::Role.Policy"
+                            },
+                            "type": "array"
+                        },
+                        "RoleName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AssumeRolePolicyDocument"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::Role"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::Role.Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "PolicyDocument": {
+                    "type": "object"
+                },
+                "PolicyName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PolicyDocument",
+                "PolicyName"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::User": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Groups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "LoginProfile": {
+                            "$ref": "#/definitions/AWS::IAM::User.LoginProfile"
+                        },
+                        "ManagedPolicyArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Path": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::IAM::User.Policy"
+                            },
+                            "type": "array"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::User"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::User.LoginProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "Password": {
+                    "type": "string"
+                },
+                "PasswordResetRequired": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "Password"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::User.Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "PolicyDocument": {
+                    "type": "object"
+                },
+                "PolicyName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "PolicyDocument",
+                "PolicyName"
+            ],
+            "type": "object"
+        },
+        "AWS::IAM::UserToGroupAddition": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "GroupName": {
+                            "type": "string"
+                        },
+                        "Users": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "GroupName",
+                        "Users"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IAM::UserToGroupAddition"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::Certificate": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CertificateSigningRequest": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "CertificateSigningRequest",
+                        "Status"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::Certificate"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::Policy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::PolicyPrincipalAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "Principal": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "PolicyName",
+                        "Principal"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::PolicyPrincipalAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::Thing": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AttributePayload": {
+                            "$ref": "#/definitions/AWS::IoT::Thing.AttributePayload"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::Thing"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::Thing.AttributePayload": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::ThingPrincipalAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Principal": {
+                            "type": "string"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Principal",
+                        "ThingName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::ThingPrincipalAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RuleName": {
+                            "type": "string"
+                        },
+                        "TopicRulePayload": {
+                            "$ref": "#/definitions/AWS::IoT::TopicRule.TopicRulePayload"
+                        }
+                    },
+                    "required": [
+                        "TopicRulePayload"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoT::TopicRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.Action": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudwatchAlarm": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.CloudwatchAlarmAction"
+                },
+                "CloudwatchMetric": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.CloudwatchMetricAction"
+                },
+                "DynamoDB": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.DynamoDBAction"
+                },
+                "DynamoDBv2": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.DynamoDBv2Action"
+                },
+                "Elasticsearch": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.ElasticsearchAction"
+                },
+                "Firehose": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.FirehoseAction"
+                },
+                "Kinesis": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.KinesisAction"
+                },
+                "Lambda": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.LambdaAction"
+                },
+                "Republish": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.RepublishAction"
+                },
+                "S3": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.S3Action"
+                },
+                "Sns": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.SnsAction"
+                },
+                "Sqs": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.SqsAction"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.CloudwatchAlarmAction": {
+            "additionalProperties": false,
+            "properties": {
+                "AlarmName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "StateReason": {
+                    "type": "string"
+                },
+                "StateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AlarmName",
+                "RoleArn",
+                "StateReason",
+                "StateValue"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.CloudwatchMetricAction": {
+            "additionalProperties": false,
+            "properties": {
+                "MetricName": {
+                    "type": "string"
+                },
+                "MetricNamespace": {
+                    "type": "string"
+                },
+                "MetricTimestamp": {
+                    "type": "string"
+                },
+                "MetricUnit": {
+                    "type": "string"
+                },
+                "MetricValue": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "MetricName",
+                "MetricNamespace",
+                "MetricUnit",
+                "MetricValue",
+                "RoleArn"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.DynamoDBAction": {
+            "additionalProperties": false,
+            "properties": {
+                "HashKeyField": {
+                    "type": "string"
+                },
+                "HashKeyType": {
+                    "type": "string"
+                },
+                "HashKeyValue": {
+                    "type": "string"
+                },
+                "PayloadField": {
+                    "type": "string"
+                },
+                "RangeKeyField": {
+                    "type": "string"
+                },
+                "RangeKeyType": {
+                    "type": "string"
+                },
+                "RangeKeyValue": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "TableName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "HashKeyField",
+                "HashKeyValue",
+                "RangeKeyField",
+                "RangeKeyValue",
+                "RoleArn",
+                "TableName"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.DynamoDBv2Action": {
+            "additionalProperties": false,
+            "properties": {
+                "PutItem": {
+                    "$ref": "#/definitions/AWS::IoT::TopicRule.PutItemInput"
+                },
+                "RoleArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.ElasticsearchAction": {
+            "additionalProperties": false,
+            "properties": {
+                "Endpoint": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Index": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Endpoint",
+                "Id",
+                "Index",
+                "RoleArn",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.FirehoseAction": {
+            "additionalProperties": false,
+            "properties": {
+                "DeliveryStreamName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Separator": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeliveryStreamName",
+                "RoleArn"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.KinesisAction": {
+            "additionalProperties": false,
+            "properties": {
+                "PartitionKey": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "StreamName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn",
+                "StreamName"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.LambdaAction": {
+            "additionalProperties": false,
+            "properties": {
+                "FunctionArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.PutItemInput": {
+            "additionalProperties": false,
+            "properties": {
+                "TableName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TableName"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.RepublishAction": {
+            "additionalProperties": false,
+            "properties": {
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Topic": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn",
+                "Topic"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.S3Action": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketName": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketName",
+                "Key",
+                "RoleArn"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.SnsAction": {
+            "additionalProperties": false,
+            "properties": {
+                "MessageFormat": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "TargetArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn",
+                "TargetArn"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.SqsAction": {
+            "additionalProperties": false,
+            "properties": {
+                "QueueUrl": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "UseBase64": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "QueueUrl",
+                "RoleArn"
+            ],
+            "type": "object"
+        },
+        "AWS::IoT::TopicRule.TopicRulePayload": {
+            "additionalProperties": false,
+            "properties": {
+                "Actions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::IoT::TopicRule.Action"
+                    },
+                    "type": "array"
+                },
+                "AwsIotSqlVersion": {
+                    "type": "string"
+                },
+                "Description": {
+                    "type": "string"
+                },
+                "RuleDisabled": {
+                    "type": "boolean"
+                },
+                "Sql": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Actions",
+                "RuleDisabled",
+                "Sql"
+            ],
+            "type": "object"
+        },
+        "AWS::KMS::Alias": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AliasName": {
+                            "type": "string"
+                        },
+                        "TargetKeyId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "AliasName",
+                        "TargetKeyId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KMS::Alias"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::KMS::Key": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "EnableKeyRotation": {
+                            "type": "boolean"
+                        },
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "KeyPolicy": {
+                            "type": "object"
+                        },
+                        "KeyUsage": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "KeyPolicy"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KMS::Key"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Kinesis::Stream": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RetentionPeriodHours": {
+                            "type": "number"
+                        },
+                        "ShardCount": {
+                            "type": "number"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ShardCount"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Kinesis::Stream"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationCode": {
+                            "type": "string"
+                        },
+                        "ApplicationDescription": {
+                            "type": "string"
+                        },
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Inputs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::KinesisAnalytics::Application.Input"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Inputs"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisAnalytics::Application"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.CSVMappingParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordColumnDelimiter": {
+                    "type": "string"
+                },
+                "RecordRowDelimiter": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RecordColumnDelimiter",
+                "RecordRowDelimiter"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.Input": {
+            "additionalProperties": false,
+            "properties": {
+                "InputParallelism": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.InputParallelism"
+                },
+                "InputSchema": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.InputSchema"
+                },
+                "KinesisFirehoseInput": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.KinesisFirehoseInput"
+                },
+                "KinesisStreamsInput": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.KinesisStreamsInput"
+                },
+                "NamePrefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InputSchema",
+                "NamePrefix"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.InputParallelism": {
+            "additionalProperties": false,
+            "properties": {
+                "Count": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.InputSchema": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordColumns": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::KinesisAnalytics::Application.RecordColumn"
+                    },
+                    "type": "array"
+                },
+                "RecordEncoding": {
+                    "type": "string"
+                },
+                "RecordFormat": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.RecordFormat"
+                }
+            },
+            "required": [
+                "RecordColumns",
+                "RecordFormat"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.JSONMappingParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordRowPath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RecordRowPath"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.KinesisFirehoseInput": {
+            "additionalProperties": false,
+            "properties": {
+                "ResourceARN": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ResourceARN",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.KinesisStreamsInput": {
+            "additionalProperties": false,
+            "properties": {
+                "ResourceARN": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ResourceARN",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.MappingParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "CSVMappingParameters": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.CSVMappingParameters"
+                },
+                "JSONMappingParameters": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.JSONMappingParameters"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.RecordColumn": {
+            "additionalProperties": false,
+            "properties": {
+                "Mapping": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "SqlType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "SqlType"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::Application.RecordFormat": {
+            "additionalProperties": false,
+            "properties": {
+                "MappingParameters": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::Application.MappingParameters"
+                },
+                "RecordFormatType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RecordFormatType"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "Output": {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.Output"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "Output"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisAnalytics::ApplicationOutput"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationOutput.DestinationSchema": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordFormatType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationOutput.KinesisFirehoseOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "ResourceARN": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ResourceARN",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationOutput.KinesisStreamsOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "ResourceARN": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ResourceARN",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationOutput.Output": {
+            "additionalProperties": false,
+            "properties": {
+                "DestinationSchema": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.DestinationSchema"
+                },
+                "KinesisFirehoseOutput": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.KinesisFirehoseOutput"
+                },
+                "KinesisStreamsOutput": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput.KinesisStreamsOutput"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DestinationSchema"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "ReferenceDataSource": {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceDataSource"
+                        }
+                    },
+                    "required": [
+                        "ApplicationName",
+                        "ReferenceDataSource"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisAnalytics::ApplicationReferenceDataSource"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.CSVMappingParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordColumnDelimiter": {
+                    "type": "string"
+                },
+                "RecordRowDelimiter": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RecordColumnDelimiter",
+                "RecordRowDelimiter"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.JSONMappingParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordRowPath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RecordRowPath"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.MappingParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "CSVMappingParameters": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.CSVMappingParameters"
+                },
+                "JSONMappingParameters": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.JSONMappingParameters"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.RecordColumn": {
+            "additionalProperties": false,
+            "properties": {
+                "Mapping": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "SqlType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "SqlType"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.RecordFormat": {
+            "additionalProperties": false,
+            "properties": {
+                "MappingParameters": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.MappingParameters"
+                },
+                "RecordFormatType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RecordFormatType"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceDataSource": {
+            "additionalProperties": false,
+            "properties": {
+                "ReferenceSchema": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceSchema"
+                },
+                "S3ReferenceDataSource": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.S3ReferenceDataSource"
+                },
+                "TableName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ReferenceSchema"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.ReferenceSchema": {
+            "additionalProperties": false,
+            "properties": {
+                "RecordColumns": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.RecordColumn"
+                    },
+                    "type": "array"
+                },
+                "RecordEncoding": {
+                    "type": "string"
+                },
+                "RecordFormat": {
+                    "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource.RecordFormat"
+                }
+            },
+            "required": [
+                "RecordColumns",
+                "RecordFormat"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisAnalytics::ApplicationReferenceDataSource.S3ReferenceDataSource": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketARN": {
+                    "type": "string"
+                },
+                "FileKey": {
+                    "type": "string"
+                },
+                "ReferenceRoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketARN",
+                "FileKey",
+                "ReferenceRoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeliveryStreamName": {
+                            "type": "string"
+                        },
+                        "DeliveryStreamType": {
+                            "type": "string"
+                        },
+                        "ElasticsearchDestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration"
+                        },
+                        "ExtendedS3DestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration"
+                        },
+                        "KinesisStreamSourceConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration"
+                        },
+                        "RedshiftDestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.RedshiftDestinationConfiguration"
+                        },
+                        "S3DestinationConfiguration": {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::KinesisFirehose::DeliveryStream"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.BufferingHints": {
+            "additionalProperties": false,
+            "properties": {
+                "IntervalInSeconds": {
+                    "type": "number"
+                },
+                "SizeInMBs": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "IntervalInSeconds",
+                "SizeInMBs"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "LogGroupName": {
+                    "type": "string"
+                },
+                "LogStreamName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.CopyCommand": {
+            "additionalProperties": false,
+            "properties": {
+                "CopyOptions": {
+                    "type": "string"
+                },
+                "DataTableColumns": {
+                    "type": "string"
+                },
+                "DataTableName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataTableName"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.ElasticsearchBufferingHints": {
+            "additionalProperties": false,
+            "properties": {
+                "IntervalInSeconds": {
+                    "type": "number"
+                },
+                "SizeInMBs": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "IntervalInSeconds",
+                "SizeInMBs"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BufferingHints": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchBufferingHints"
+                },
+                "CloudWatchLoggingOptions": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions"
+                },
+                "DomainARN": {
+                    "type": "string"
+                },
+                "IndexName": {
+                    "type": "string"
+                },
+                "IndexRotationPeriod": {
+                    "type": "string"
+                },
+                "ProcessingConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ProcessingConfiguration"
+                },
+                "RetryOptions": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ElasticsearchRetryOptions"
+                },
+                "RoleARN": {
+                    "type": "string"
+                },
+                "S3BackupMode": {
+                    "type": "string"
+                },
+                "S3Configuration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration"
+                },
+                "TypeName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BufferingHints",
+                "DomainARN",
+                "IndexName",
+                "IndexRotationPeriod",
+                "RetryOptions",
+                "RoleARN",
+                "S3BackupMode",
+                "S3Configuration",
+                "TypeName"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.ElasticsearchRetryOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "DurationInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.EncryptionConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "KMSEncryptionConfig": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.KMSEncryptionConfig"
+                },
+                "NoEncryptionConfig": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketARN": {
+                    "type": "string"
+                },
+                "BufferingHints": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.BufferingHints"
+                },
+                "CloudWatchLoggingOptions": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions"
+                },
+                "CompressionFormat": {
+                    "type": "string"
+                },
+                "EncryptionConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.EncryptionConfiguration"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "ProcessingConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "type": "string"
+                },
+                "S3BackupConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration"
+                },
+                "S3BackupMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketARN",
+                "BufferingHints",
+                "CompressionFormat",
+                "Prefix",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.KMSEncryptionConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSKMSKeyARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AWSKMSKeyARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.KinesisStreamSourceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "KinesisStreamARN": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KinesisStreamARN",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.ProcessingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "Processors": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.Processor"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Enabled",
+                "Processors"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.Processor": {
+            "additionalProperties": false,
+            "properties": {
+                "Parameters": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ProcessorParameter"
+                    },
+                    "type": "array"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Parameters",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.ProcessorParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.RedshiftDestinationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLoggingOptions": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions"
+                },
+                "ClusterJDBCURL": {
+                    "type": "string"
+                },
+                "CopyCommand": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.CopyCommand"
+                },
+                "Password": {
+                    "type": "string"
+                },
+                "ProcessingConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.ProcessingConfiguration"
+                },
+                "RoleARN": {
+                    "type": "string"
+                },
+                "S3Configuration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration"
+                },
+                "Username": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ClusterJDBCURL",
+                "CopyCommand",
+                "Password",
+                "RoleARN",
+                "S3Configuration",
+                "Username"
+            ],
+            "type": "object"
+        },
+        "AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketARN": {
+                    "type": "string"
+                },
+                "BufferingHints": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.BufferingHints"
+                },
+                "CloudWatchLoggingOptions": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.CloudWatchLoggingOptions"
+                },
+                "CompressionFormat": {
+                    "type": "string"
+                },
+                "EncryptionConfiguration": {
+                    "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream.EncryptionConfiguration"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "RoleARN": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketARN",
+                "BufferingHints",
+                "CompressionFormat",
+                "Prefix",
+                "RoleARN"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Alias": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "FunctionVersion": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "FunctionName",
+                        "FunctionVersion",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Alias"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::EventSourceMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BatchSize": {
+                            "type": "number"
+                        },
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "EventSourceArn": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "StartingPosition": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "EventSourceArn",
+                        "FunctionName",
+                        "StartingPosition"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::EventSourceMapping"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Function": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Code": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.Code"
+                        },
+                        "DeadLetterConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.DeadLetterConfig"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Environment": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.Environment"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "Handler": {
+                            "type": "string"
+                        },
+                        "KmsKeyArn": {
+                            "type": "string"
+                        },
+                        "MemorySize": {
+                            "type": "number"
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "Runtime": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Timeout": {
+                            "type": "number"
+                        },
+                        "TracingConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.TracingConfig"
+                        },
+                        "VpcConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.VpcConfig"
+                        }
+                    },
+                    "required": [
+                        "Code",
+                        "Handler",
+                        "Role",
+                        "Runtime"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Function"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Function.Code": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Bucket": {
+                    "type": "string"
+                },
+                "S3Key": {
+                    "type": "string"
+                },
+                "S3ObjectVersion": {
+                    "type": "string"
+                },
+                "ZipFile": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::Function.DeadLetterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::Function.Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "Variables": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::Function.TracingConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Mode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::Function.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "SubnetIds"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Permission": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Action": {
+                            "type": "string"
+                        },
+                        "EventSourceToken": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "Principal": {
+                            "type": "string"
+                        },
+                        "SourceAccount": {
+                            "type": "string"
+                        },
+                        "SourceArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Action",
+                        "FunctionName",
+                        "Principal"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Permission"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Version": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeSha256": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "FunctionName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Lambda::Version"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::Destination": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationName": {
+                            "type": "string"
+                        },
+                        "DestinationPolicy": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "TargetArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationName",
+                        "DestinationPolicy",
+                        "RoleArn",
+                        "TargetArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::Destination"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::LogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "RetentionInDays": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::LogGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::LogStream": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "LogStreamName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LogGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::LogStream"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::MetricFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FilterPattern": {
+                            "type": "string"
+                        },
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "MetricTransformations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Logs::MetricFilter.MetricTransformation"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "FilterPattern",
+                        "LogGroupName",
+                        "MetricTransformations"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::MetricFilter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::MetricFilter.MetricTransformation": {
+            "additionalProperties": false,
+            "properties": {
+                "MetricName": {
+                    "type": "string"
+                },
+                "MetricNamespace": {
+                    "type": "string"
+                },
+                "MetricValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "MetricName",
+                "MetricNamespace",
+                "MetricValue"
+            ],
+            "type": "object"
+        },
+        "AWS::Logs::SubscriptionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationArn": {
+                            "type": "string"
+                        },
+                        "FilterPattern": {
+                            "type": "string"
+                        },
+                        "LogGroupName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationArn",
+                        "FilterPattern",
+                        "LogGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Logs::SubscriptionFilter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::App": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AppSource": {
+                            "$ref": "#/definitions/AWS::OpsWorks::App.Source"
+                        },
+                        "Attributes": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "DataSources": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::App.DataSource"
+                            },
+                            "type": "array"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Domains": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "EnableSsl": {
+                            "type": "boolean"
+                        },
+                        "Environment": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::App.EnvironmentVariable"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Shortname": {
+                            "type": "string"
+                        },
+                        "SslConfiguration": {
+                            "$ref": "#/definitions/AWS::OpsWorks::App.SslConfiguration"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "StackId",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::App"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::App.DataSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "DatabaseName": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::App.EnvironmentVariable": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Secure": {
+                    "type": "boolean"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::App.Source": {
+            "additionalProperties": false,
+            "properties": {
+                "Password": {
+                    "type": "string"
+                },
+                "Revision": {
+                    "type": "string"
+                },
+                "SshKey": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Url": {
+                    "type": "string"
+                },
+                "Username": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::App.SslConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Certificate": {
+                    "type": "string"
+                },
+                "Chain": {
+                    "type": "string"
+                },
+                "PrivateKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::ElasticLoadBalancerAttachment": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ElasticLoadBalancerName": {
+                            "type": "string"
+                        },
+                        "LayerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ElasticLoadBalancerName",
+                        "LayerId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Instance": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AgentVersion": {
+                            "type": "string"
+                        },
+                        "AmiId": {
+                            "type": "string"
+                        },
+                        "Architecture": {
+                            "type": "string"
+                        },
+                        "AutoScalingType": {
+                            "type": "string"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "BlockDeviceMappings": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Instance.BlockDeviceMapping"
+                            },
+                            "type": "array"
+                        },
+                        "EbsOptimized": {
+                            "type": "boolean"
+                        },
+                        "ElasticIps": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Hostname": {
+                            "type": "string"
+                        },
+                        "InstallUpdatesOnBoot": {
+                            "type": "boolean"
+                        },
+                        "InstanceType": {
+                            "type": "string"
+                        },
+                        "LayerIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Os": {
+                            "type": "string"
+                        },
+                        "RootDeviceType": {
+                            "type": "string"
+                        },
+                        "SshKeyName": {
+                            "type": "string"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        },
+                        "SubnetId": {
+                            "type": "string"
+                        },
+                        "Tenancy": {
+                            "type": "string"
+                        },
+                        "TimeBasedAutoScaling": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Instance.TimeBasedAutoScaling"
+                        },
+                        "VirtualizationType": {
+                            "type": "string"
+                        },
+                        "Volumes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "InstanceType",
+                        "LayerIds",
+                        "StackId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Instance"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Instance.BlockDeviceMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DeviceName": {
+                    "type": "string"
+                },
+                "Ebs": {
+                    "$ref": "#/definitions/AWS::OpsWorks::Instance.EbsBlockDevice"
+                },
+                "NoDevice": {
+                    "type": "string"
+                },
+                "VirtualName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Instance.EbsBlockDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeleteOnTermination": {
+                    "type": "boolean"
+                },
+                "Iops": {
+                    "type": "number"
+                },
+                "SnapshotId": {
+                    "type": "string"
+                },
+                "VolumeSize": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Instance.TimeBasedAutoScaling": {
+            "additionalProperties": false,
+            "properties": {
+                "Friday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Monday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Saturday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Sunday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Thursday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Tuesday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Wednesday": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Attributes": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "AutoAssignElasticIps": {
+                            "type": "boolean"
+                        },
+                        "AutoAssignPublicIps": {
+                            "type": "boolean"
+                        },
+                        "CustomInstanceProfileArn": {
+                            "type": "string"
+                        },
+                        "CustomJson": {
+                            "type": "object"
+                        },
+                        "CustomRecipes": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer.Recipes"
+                        },
+                        "CustomSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "EnableAutoHealing": {
+                            "type": "boolean"
+                        },
+                        "InstallUpdatesOnBoot": {
+                            "type": "boolean"
+                        },
+                        "LifecycleEventConfiguration": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer.LifecycleEventConfiguration"
+                        },
+                        "LoadBasedAutoScaling": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer.LoadBasedAutoScaling"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Packages": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Shortname": {
+                            "type": "string"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "UseEbsOptimizedInstances": {
+                            "type": "boolean"
+                        },
+                        "VolumeConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Layer.VolumeConfiguration"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "AutoAssignElasticIps",
+                        "AutoAssignPublicIps",
+                        "EnableAutoHealing",
+                        "Name",
+                        "Shortname",
+                        "StackId",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Layer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer.AutoScalingThresholds": {
+            "additionalProperties": false,
+            "properties": {
+                "CpuThreshold": {
+                    "type": "number"
+                },
+                "IgnoreMetricsTime": {
+                    "type": "number"
+                },
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "LoadThreshold": {
+                    "type": "number"
+                },
+                "MemoryThreshold": {
+                    "type": "number"
+                },
+                "ThresholdsWaitTime": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer.LifecycleEventConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ShutdownEventConfiguration": {
+                    "$ref": "#/definitions/AWS::OpsWorks::Layer.ShutdownEventConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer.LoadBasedAutoScaling": {
+            "additionalProperties": false,
+            "properties": {
+                "DownScaling": {
+                    "$ref": "#/definitions/AWS::OpsWorks::Layer.AutoScalingThresholds"
+                },
+                "Enable": {
+                    "type": "boolean"
+                },
+                "UpScaling": {
+                    "$ref": "#/definitions/AWS::OpsWorks::Layer.AutoScalingThresholds"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer.Recipes": {
+            "additionalProperties": false,
+            "properties": {
+                "Configure": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Deploy": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Setup": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Shutdown": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Undeploy": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer.ShutdownEventConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DelayUntilElbConnectionsDrained": {
+                    "type": "boolean"
+                },
+                "ExecutionTimeout": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Layer.VolumeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Iops": {
+                    "type": "number"
+                },
+                "MountPoint": {
+                    "type": "string"
+                },
+                "NumberOfDisks": {
+                    "type": "number"
+                },
+                "RaidLevel": {
+                    "type": "number"
+                },
+                "Size": {
+                    "type": "number"
+                },
+                "VolumeType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Stack": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AgentVersion": {
+                            "type": "string"
+                        },
+                        "Attributes": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ChefConfiguration": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack.ChefConfiguration"
+                        },
+                        "CloneAppIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ClonePermissions": {
+                            "type": "boolean"
+                        },
+                        "ConfigurationManager": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack.StackConfigurationManager"
+                        },
+                        "CustomCookbooksSource": {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack.Source"
+                        },
+                        "CustomJson": {
+                            "type": "object"
+                        },
+                        "DefaultAvailabilityZone": {
+                            "type": "string"
+                        },
+                        "DefaultInstanceProfileArn": {
+                            "type": "string"
+                        },
+                        "DefaultOs": {
+                            "type": "string"
+                        },
+                        "DefaultRootDeviceType": {
+                            "type": "string"
+                        },
+                        "DefaultSshKeyName": {
+                            "type": "string"
+                        },
+                        "DefaultSubnetId": {
+                            "type": "string"
+                        },
+                        "EcsClusterArn": {
+                            "type": "string"
+                        },
+                        "ElasticIps": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Stack.ElasticIp"
+                            },
+                            "type": "array"
+                        },
+                        "HostnameTheme": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "RdsDbInstances": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::OpsWorks::Stack.RdsDbInstance"
+                            },
+                            "type": "array"
+                        },
+                        "ServiceRoleArn": {
+                            "type": "string"
+                        },
+                        "SourceStackId": {
+                            "type": "string"
+                        },
+                        "UseCustomCookbooks": {
+                            "type": "boolean"
+                        },
+                        "UseOpsworksSecurityGroups": {
+                            "type": "boolean"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DefaultInstanceProfileArn",
+                        "Name",
+                        "ServiceRoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Stack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Stack.ChefConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BerkshelfVersion": {
+                    "type": "string"
+                },
+                "ManageBerkshelf": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Stack.ElasticIp": {
+            "additionalProperties": false,
+            "properties": {
+                "Ip": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Ip"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Stack.RdsDbInstance": {
+            "additionalProperties": false,
+            "properties": {
+                "DbPassword": {
+                    "type": "string"
+                },
+                "DbUser": {
+                    "type": "string"
+                },
+                "RdsDbInstanceArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DbPassword",
+                "DbUser",
+                "RdsDbInstanceArn"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Stack.Source": {
+            "additionalProperties": false,
+            "properties": {
+                "Password": {
+                    "type": "string"
+                },
+                "Revision": {
+                    "type": "string"
+                },
+                "SshKey": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Url": {
+                    "type": "string"
+                },
+                "Username": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::Stack.StackConfigurationManager": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::OpsWorks::UserProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowSelfManagement": {
+                            "type": "boolean"
+                        },
+                        "IamUserArn": {
+                            "type": "string"
+                        },
+                        "SshPublicKey": {
+                            "type": "string"
+                        },
+                        "SshUsername": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "IamUserArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::UserProfile"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::OpsWorks::Volume": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Ec2VolumeId": {
+                            "type": "string"
+                        },
+                        "MountPoint": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StackId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Ec2VolumeId",
+                        "StackId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::OpsWorks::Volume"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBCluster": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AvailabilityZones": {
+                            "type": "string"
+                        },
+                        "BackupRetentionPeriod": {
+                            "type": "number"
+                        },
+                        "DBClusterParameterGroupName": {
+                            "type": "string"
+                        },
+                        "DBSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "DatabaseName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string"
+                        },
+                        "MasterUsername": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredBackupWindow": {
+                            "type": "string"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "ReplicationSourceIdentifier": {
+                            "type": "string"
+                        },
+                        "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "StorageEncrypted": {
+                            "type": "boolean"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Engine"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBCluster"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBClusterParameterGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Family": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "Family",
+                        "Parameters"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBClusterParameterGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBInstance": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllocatedStorage": {
+                            "type": "string"
+                        },
+                        "AllowMajorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutoMinorVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "BackupRetentionPeriod": {
+                            "type": "string"
+                        },
+                        "CharacterSetName": {
+                            "type": "string"
+                        },
+                        "CopyTagsToSnapshot": {
+                            "type": "boolean"
+                        },
+                        "DBClusterIdentifier": {
+                            "type": "string"
+                        },
+                        "DBInstanceClass": {
+                            "type": "string"
+                        },
+                        "DBInstanceIdentifier": {
+                            "type": "string"
+                        },
+                        "DBName": {
+                            "type": "string"
+                        },
+                        "DBParameterGroupName": {
+                            "type": "string"
+                        },
+                        "DBSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "DBSnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "DBSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "Domain": {
+                            "type": "string"
+                        },
+                        "DomainIAMRoleName": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
+                        },
+                        "Iops": {
+                            "type": "number"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "LicenseModel": {
+                            "type": "string"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string"
+                        },
+                        "MasterUsername": {
+                            "type": "string"
+                        },
+                        "MonitoringInterval": {
+                            "type": "number"
+                        },
+                        "MonitoringRoleArn": {
+                            "type": "string"
+                        },
+                        "MultiAZ": {
+                            "type": "boolean"
+                        },
+                        "OptionGroupName": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "string"
+                        },
+                        "PreferredBackupWindow": {
+                            "type": "string"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PubliclyAccessible": {
+                            "type": "boolean"
+                        },
+                        "SourceDBInstanceIdentifier": {
+                            "type": "string"
+                        },
+                        "StorageEncrypted": {
+                            "type": "boolean"
+                        },
+                        "StorageType": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Timezone": {
+                            "type": "string"
+                        },
+                        "VPCSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DBInstanceClass"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBInstance"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBParameterGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Family": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "Family"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBParameterGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBSecurityGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DBSecurityGroupIngress": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBSecurityGroup.Ingress"
+                            },
+                            "type": "array"
+                        },
+                        "EC2VpcId": {
+                            "type": "string"
+                        },
+                        "GroupDescription": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DBSecurityGroupIngress",
+                        "GroupDescription"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBSecurityGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBSecurityGroup.Ingress": {
+            "additionalProperties": false,
+            "properties": {
+                "CIDRIP": {
+                    "type": "string"
+                },
+                "EC2SecurityGroupId": {
+                    "type": "string"
+                },
+                "EC2SecurityGroupName": {
+                    "type": "string"
+                },
+                "EC2SecurityGroupOwnerId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::RDS::DBSecurityGroupIngress": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CIDRIP": {
+                            "type": "string"
+                        },
+                        "DBSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupId": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupOwnerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DBSecurityGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBSecurityGroupIngress"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBSubnetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DBSubnetGroupDescription": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DBSubnetGroupDescription",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::DBSubnetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::EventSubscription": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Enabled": {
+                            "type": "boolean"
+                        },
+                        "EventCategories": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        },
+                        "SourceIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SourceType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::EventSubscription"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::OptionGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "EngineName": {
+                            "type": "string"
+                        },
+                        "MajorEngineVersion": {
+                            "type": "string"
+                        },
+                        "OptionConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::OptionGroup.OptionConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "OptionGroupDescription": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "EngineName",
+                        "MajorEngineVersion",
+                        "OptionConfigurations",
+                        "OptionGroupDescription"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::RDS::OptionGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::OptionGroup.OptionConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DBSecurityGroupMemberships": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "OptionName": {
+                    "type": "string"
+                },
+                "OptionSettings": {
+                    "$ref": "#/definitions/AWS::RDS::OptionGroup.OptionSetting"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "VpcSecurityGroupMemberships": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "OptionName"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::OptionGroup.OptionSetting": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Redshift::Cluster": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowVersionUpgrade": {
+                            "type": "boolean"
+                        },
+                        "AutomatedSnapshotRetentionPeriod": {
+                            "type": "number"
+                        },
+                        "AvailabilityZone": {
+                            "type": "string"
+                        },
+                        "ClusterParameterGroupName": {
+                            "type": "string"
+                        },
+                        "ClusterSecurityGroups": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "ClusterSubnetGroupName": {
+                            "type": "string"
+                        },
+                        "ClusterType": {
+                            "type": "string"
+                        },
+                        "ClusterVersion": {
+                            "type": "string"
+                        },
+                        "DBName": {
+                            "type": "string"
+                        },
+                        "ElasticIp": {
+                            "type": "string"
+                        },
+                        "Encrypted": {
+                            "type": "boolean"
+                        },
+                        "HsmClientCertificateIdentifier": {
+                            "type": "string"
+                        },
+                        "HsmConfigurationIdentifier": {
+                            "type": "string"
+                        },
+                        "IamRoles": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "KmsKeyId": {
+                            "type": "string"
+                        },
+                        "LoggingProperties": {
+                            "$ref": "#/definitions/AWS::Redshift::Cluster.LoggingProperties"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string"
+                        },
+                        "MasterUsername": {
+                            "type": "string"
+                        },
+                        "NodeType": {
+                            "type": "string"
+                        },
+                        "NumberOfNodes": {
+                            "type": "number"
+                        },
+                        "OwnerAccount": {
+                            "type": "string"
+                        },
+                        "Port": {
+                            "type": "number"
+                        },
+                        "PreferredMaintenanceWindow": {
+                            "type": "string"
+                        },
+                        "PubliclyAccessible": {
+                            "type": "boolean"
+                        },
+                        "SnapshotClusterIdentifier": {
+                            "type": "string"
+                        },
+                        "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VpcSecurityGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ClusterType",
+                        "DBName",
+                        "MasterUserPassword",
+                        "MasterUsername",
+                        "NodeType"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::Cluster"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Redshift::Cluster.LoggingProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketName": {
+                    "type": "string"
+                },
+                "S3KeyPrefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketName"
+            ],
+            "type": "object"
+        },
+        "AWS::Redshift::ClusterParameterGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "ParameterGroupFamily": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Redshift::ClusterParameterGroup.Parameter"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "ParameterGroupFamily"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterParameterGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Redshift::ClusterParameterGroup.Parameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
+            ],
+            "type": "object"
+        },
+        "AWS::Redshift::ClusterSecurityGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterSecurityGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Redshift::ClusterSecurityGroupIngress": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CIDRIP": {
+                            "type": "string"
+                        },
+                        "ClusterSecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupName": {
+                            "type": "string"
+                        },
+                        "EC2SecurityGroupOwnerId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ClusterSecurityGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterSecurityGroupIngress"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Redshift::ClusterSubnetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SubnetIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Description",
+                        "SubnetIds"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Redshift::ClusterSubnetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HealthCheck": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "HealthCheckConfig": {
+                            "$ref": "#/definitions/AWS::Route53::HealthCheck.HealthCheckConfig"
+                        },
+                        "HealthCheckTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::HealthCheck.HealthCheckTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "HealthCheckConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::HealthCheck"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HealthCheck.AlarmIdentifier": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Region": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Region"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HealthCheck.HealthCheckConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AlarmIdentifier": {
+                    "$ref": "#/definitions/AWS::Route53::HealthCheck.AlarmIdentifier"
+                },
+                "ChildHealthChecks": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "EnableSNI": {
+                    "type": "boolean"
+                },
+                "FailureThreshold": {
+                    "type": "number"
+                },
+                "FullyQualifiedDomainName": {
+                    "type": "string"
+                },
+                "HealthThreshold": {
+                    "type": "number"
+                },
+                "IPAddress": {
+                    "type": "string"
+                },
+                "InsufficientDataHealthStatus": {
+                    "type": "string"
+                },
+                "Inverted": {
+                    "type": "boolean"
+                },
+                "MeasureLatency": {
+                    "type": "boolean"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "RequestInterval": {
+                    "type": "number"
+                },
+                "ResourcePath": {
+                    "type": "string"
+                },
+                "SearchString": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HealthCheck.HealthCheckTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HostedZone": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "HostedZoneConfig": {
+                            "$ref": "#/definitions/AWS::Route53::HostedZone.HostedZoneConfig"
+                        },
+                        "HostedZoneTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::HostedZone.HostedZoneTag"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "VPCs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::HostedZone.VPC"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::HostedZone"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HostedZone.HostedZoneConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Comment": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Route53::HostedZone.HostedZoneTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::HostedZone.VPC": {
+            "additionalProperties": false,
+            "properties": {
+                "VPCId": {
+                    "type": "string"
+                },
+                "VPCRegion": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "VPCId",
+                "VPCRegion"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::RecordSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AliasTarget": {
+                            "$ref": "#/definitions/AWS::Route53::RecordSet.AliasTarget"
+                        },
+                        "Comment": {
+                            "type": "string"
+                        },
+                        "Failover": {
+                            "type": "string"
+                        },
+                        "GeoLocation": {
+                            "$ref": "#/definitions/AWS::Route53::RecordSet.GeoLocation"
+                        },
+                        "HealthCheckId": {
+                            "type": "string"
+                        },
+                        "HostedZoneId": {
+                            "type": "string"
+                        },
+                        "HostedZoneName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Region": {
+                            "type": "string"
+                        },
+                        "ResourceRecords": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SetIdentifier": {
+                            "type": "string"
+                        },
+                        "TTL": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "Weight": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::RecordSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::RecordSet.AliasTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "DNSName": {
+                    "type": "string"
+                },
+                "EvaluateTargetHealth": {
+                    "type": "boolean"
+                },
+                "HostedZoneId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DNSName",
+                "HostedZoneId"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::RecordSet.GeoLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "ContinentCode": {
+                    "type": "string"
+                },
+                "CountryCode": {
+                    "type": "string"
+                },
+                "SubdivisionCode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Route53::RecordSetGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Comment": {
+                            "type": "string"
+                        },
+                        "HostedZoneId": {
+                            "type": "string"
+                        },
+                        "HostedZoneName": {
+                            "type": "string"
+                        },
+                        "RecordSets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Route53::RecordSetGroup.RecordSet"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Route53::RecordSetGroup"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::RecordSetGroup.AliasTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "DNSName": {
+                    "type": "string"
+                },
+                "EvaluateTargetHealth": {
+                    "type": "boolean"
+                },
+                "HostedZoneId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DNSName",
+                "HostedZoneId"
+            ],
+            "type": "object"
+        },
+        "AWS::Route53::RecordSetGroup.GeoLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "ContinentCode": {
+                    "type": "string"
+                },
+                "CountryCode": {
+                    "type": "string"
+                },
+                "SubdivisionCode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Route53::RecordSetGroup.RecordSet": {
+            "additionalProperties": false,
+            "properties": {
+                "AliasTarget": {
+                    "$ref": "#/definitions/AWS::Route53::RecordSetGroup.AliasTarget"
+                },
+                "Comment": {
+                    "type": "string"
+                },
+                "Failover": {
+                    "type": "string"
+                },
+                "GeoLocation": {
+                    "$ref": "#/definitions/AWS::Route53::RecordSetGroup.GeoLocation"
+                },
+                "HealthCheckId": {
+                    "type": "string"
+                },
+                "HostedZoneId": {
+                    "type": "string"
+                },
+                "HostedZoneName": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Region": {
+                    "type": "string"
+                },
+                "ResourceRecords": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SetIdentifier": {
+                    "type": "string"
+                },
+                "TTL": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Name",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccelerateConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.AccelerateConfiguration"
+                        },
+                        "AccessControl": {
+                            "type": "string"
+                        },
+                        "AnalyticsConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::S3::Bucket.AnalyticsConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "BucketName": {
+                            "type": "string"
+                        },
+                        "CorsConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.CorsConfiguration"
+                        },
+                        "InventoryConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::S3::Bucket.InventoryConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "LifecycleConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.LifecycleConfiguration"
+                        },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.LoggingConfiguration"
+                        },
+                        "MetricsConfigurations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::S3::Bucket.MetricsConfiguration"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.NotificationConfiguration"
+                        },
+                        "ReplicationConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.ReplicationConfiguration"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "VersioningConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.VersioningConfiguration"
+                        },
+                        "WebsiteConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::Bucket.WebsiteConfiguration"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::Bucket"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.AbortIncompleteMultipartUpload": {
+            "additionalProperties": false,
+            "properties": {
+                "DaysAfterInitiation": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "DaysAfterInitiation"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.AccelerateConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AccelerationStatus": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AccelerationStatus"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.AnalyticsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Id": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "StorageClassAnalysis": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.StorageClassAnalysis"
+                },
+                "TagFilters": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.TagFilter"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Id",
+                "StorageClassAnalysis"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.CorsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CorsRules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.CorsRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "CorsRules"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.CorsRule": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowedMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowedOrigins": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ExposedHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "MaxAge": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "AllowedMethods",
+                "AllowedOrigins"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.DataExport": {
+            "additionalProperties": false,
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.Destination"
+                },
+                "OutputSchemaVersion": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destination",
+                "OutputSchemaVersion"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.Destination": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketAccountId": {
+                    "type": "string"
+                },
+                "BucketArn": {
+                    "type": "string"
+                },
+                "Format": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketArn",
+                "Format"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.FilterRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.InventoryConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.Destination"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "IncludedObjectVersions": {
+                    "type": "string"
+                },
+                "OptionalFields": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "ScheduleFrequency": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destination",
+                "Enabled",
+                "Id",
+                "IncludedObjectVersions",
+                "ScheduleFrequency"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.LambdaConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Event": {
+                    "type": "string"
+                },
+                "Filter": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.NotificationFilter"
+                },
+                "Function": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Event",
+                "Function"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.LifecycleConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.Rule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Rules"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DestinationBucketName": {
+                    "type": "string"
+                },
+                "LogFilePrefix": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::Bucket.MetricsConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Id": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "TagFilters": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.TagFilter"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Id"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.NoncurrentVersionTransition": {
+            "additionalProperties": false,
+            "properties": {
+                "StorageClass": {
+                    "type": "string"
+                },
+                "TransitionInDays": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "StorageClass",
+                "TransitionInDays"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.NotificationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaConfigurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.LambdaConfiguration"
+                    },
+                    "type": "array"
+                },
+                "QueueConfigurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.QueueConfiguration"
+                    },
+                    "type": "array"
+                },
+                "TopicConfigurations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.TopicConfiguration"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::Bucket.NotificationFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Key": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.S3KeyFilter"
+                }
+            },
+            "required": [
+                "S3Key"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.QueueConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Event": {
+                    "type": "string"
+                },
+                "Filter": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.NotificationFilter"
+                },
+                "Queue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Event",
+                "Queue"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.RedirectAllRequestsTo": {
+            "additionalProperties": false,
+            "properties": {
+                "HostName": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "HostName"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.RedirectRule": {
+            "additionalProperties": false,
+            "properties": {
+                "HostName": {
+                    "type": "string"
+                },
+                "HttpRedirectCode": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "ReplaceKeyPrefixWith": {
+                    "type": "string"
+                },
+                "ReplaceKeyWith": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::Bucket.ReplicationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Role": {
+                    "type": "string"
+                },
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.ReplicationRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Role",
+                "Rules"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.ReplicationDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "StorageClass": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Bucket"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.ReplicationRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.ReplicationDestination"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destination",
+                "Prefix",
+                "Status"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.RoutingRule": {
+            "additionalProperties": false,
+            "properties": {
+                "RedirectRule": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.RedirectRule"
+                },
+                "RoutingRuleCondition": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.RoutingRuleCondition"
+                }
+            },
+            "required": [
+                "RedirectRule"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.RoutingRuleCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "HttpErrorCodeReturnedEquals": {
+                    "type": "string"
+                },
+                "KeyPrefixEquals": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::Bucket.Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "AbortIncompleteMultipartUpload": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.AbortIncompleteMultipartUpload"
+                },
+                "ExpirationDate": {
+                    "type": "string"
+                },
+                "ExpirationInDays": {
+                    "type": "number"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "NoncurrentVersionExpirationInDays": {
+                    "type": "number"
+                },
+                "NoncurrentVersionTransition": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.NoncurrentVersionTransition"
+                },
+                "NoncurrentVersionTransitions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.NoncurrentVersionTransition"
+                    },
+                    "type": "array"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                },
+                "TagFilters": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.TagFilter"
+                    },
+                    "type": "array"
+                },
+                "Transition": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.Transition"
+                },
+                "Transitions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.Transition"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Status"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.S3KeyFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "Rules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.FilterRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Rules"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.StorageClassAnalysis": {
+            "additionalProperties": false,
+            "properties": {
+                "DataExport": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.DataExport"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::Bucket.TagFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.TopicConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Event": {
+                    "type": "string"
+                },
+                "Filter": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.NotificationFilter"
+                },
+                "Topic": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Event",
+                "Topic"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.Transition": {
+            "additionalProperties": false,
+            "properties": {
+                "StorageClass": {
+                    "type": "string"
+                },
+                "TransitionDate": {
+                    "type": "string"
+                },
+                "TransitionInDays": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "StorageClass"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.VersioningConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Status"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::Bucket.WebsiteConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ErrorDocument": {
+                    "type": "string"
+                },
+                "IndexDocument": {
+                    "type": "string"
+                },
+                "RedirectAllRequestsTo": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.RedirectAllRequestsTo"
+                },
+                "RoutingRules": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::S3::Bucket.RoutingRule"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::BucketPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Bucket": {
+                            "type": "string"
+                        },
+                        "PolicyDocument": {
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "Bucket",
+                        "PolicyDocument"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::BucketPolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SDB::Domain": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SDB::Domain"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SNS::Subscription": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Endpoint": {
+                            "type": "string"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "TopicArn": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SNS::Subscription"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SNS::Topic": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DisplayName": {
+                            "type": "string"
+                        },
+                        "Subscription": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SNS::Topic.Subscription"
+                            },
+                            "type": "array"
+                        },
+                        "TopicName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SNS::Topic"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SNS::Topic.Subscription": {
+            "additionalProperties": false,
+            "properties": {
+                "Endpoint": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Endpoint",
+                "Protocol"
+            ],
+            "type": "object"
+        },
+        "AWS::SNS::TopicPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "Topics": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument",
+                        "Topics"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SNS::TopicPolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SQS::Queue": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ContentBasedDeduplication": {
+                            "type": "boolean"
+                        },
+                        "DelaySeconds": {
+                            "type": "number"
+                        },
+                        "FifoQueue": {
+                            "type": "boolean"
+                        },
+                        "KmsDataKeyReusePeriodSeconds": {
+                            "type": "number"
+                        },
+                        "KmsMasterKeyId": {
+                            "type": "string"
+                        },
+                        "MaximumMessageSize": {
+                            "type": "number"
+                        },
+                        "MessageRetentionPeriod": {
+                            "type": "number"
+                        },
+                        "QueueName": {
+                            "type": "string"
+                        },
+                        "ReceiveMessageWaitTimeSeconds": {
+                            "type": "number"
+                        },
+                        "RedrivePolicy": {
+                            "type": "object"
+                        },
+                        "VisibilityTimeout": {
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SQS::Queue"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SQS::QueuePolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PolicyDocument": {
+                            "type": "object"
+                        },
+                        "Queues": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PolicyDocument",
+                        "Queues"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SQS::QueuePolicy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Association": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DocumentVersion": {
+                            "type": "string"
+                        },
+                        "InstanceId": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Parameters": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "$ref": "#/definitions/AWS::SSM::Association.ParameterValues"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "ScheduleExpression": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SSM::Association.Target"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::Association"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Association.ParameterValues": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterValues": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "ParameterValues"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Association.Target": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Document": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Content": {
+                            "type": "object"
+                        },
+                        "DocumentType": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Content"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::Document"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::Parameter": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowedPattern": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        },
+                        "Value": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type",
+                        "Value"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::Parameter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::Api": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CacheClusterEnabled": {
+                            "type": "boolean"
+                        },
+                        "CacheClusterSize": {
+                            "type": "string"
+                        },
+                        "DefinitionBody": {
+                            "type": "object"
+                        },
+                        "DefinitionUri": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::Api.S3Location"
+                                }
+                            ]
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "StageName": {
+                            "type": "string"
+                        },
+                        "Variables": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "StageName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Serverless::Api"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Serverless::Api.S3Location": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -55,76 +17552,127 @@
             "type": "object"
         },
         "AWS::Serverless::Function": {
+            "additionalProperties": false,
             "properties": {
-                "CodeUri": {
-                    "$ref": "#/definitions/AWS::Serverless::Function."
-                },
-                "DeadLetterQueue": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.DeadLetterQueue"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Environment": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.FunctionEnvironment"
-                },
-                "Events": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
-                            "$ref": "#/definitions/AWS::Serverless::Function.EventSource"
-                        }
-                    },
-                    "type": "object"
-                },
-                "FunctionName": {
-                    "type": "string"
-                },
-                "Handler": {
-                    "type": "string"
-                },
-                "KmsKeyArn": {
-                    "type": "string"
-                },
-                "MemorySize": {
-                    "type": "number"
-                },
-                "Policies": {
-                    "$ref": "#/definitions/AWS::Serverless::Function."
-                },
-                "Role": {
-                    "type": "string"
-                },
-                "Runtime": {
-                    "type": "string"
-                },
-                "Tags": {
-                    "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeUri": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::Function.S3Location"
+                                }
+                            ]
+                        },
+                        "DeadLetterQueue": {
+                            "$ref": "#/definitions/AWS::Serverless::Function.DeadLetterQueue"
+                        },
+                        "Description": {
                             "type": "string"
+                        },
+                        "Environment": {
+                            "$ref": "#/definitions/AWS::Serverless::Function.FunctionEnvironment"
+                        },
+                        "Events": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "$ref": "#/definitions/AWS::Serverless::Function.EventSource"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "FunctionName": {
+                            "type": "string"
+                        },
+                        "Handler": {
+                            "type": "string"
+                        },
+                        "KmsKeyArn": {
+                            "type": "string"
+                        },
+                        "MemorySize": {
+                            "type": "number"
+                        },
+                        "Policies": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::Function.IAMPolicyDocument"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/AWS::Serverless::Function.IAMPolicyDocument"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "Runtime": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Timeout": {
+                            "type": "number"
+                        },
+                        "Tracing": {
+                            "type": "string"
+                        },
+                        "VpcConfig": {
+                            "$ref": "#/definitions/AWS::Serverless::Function.VpcConfig"
                         }
                     },
+                    "required": [
+                        "CodeUri",
+                        "Handler",
+                        "Runtime"
+                    ],
                     "type": "object"
                 },
-                "Timeout": {
-                    "type": "number"
-                },
-                "Tracing": {
+                "Type": {
+                    "enum": [
+                        "AWS::Serverless::Function"
+                    ],
                     "type": "string"
-                },
-                "VpcConfig": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.VpcConfig"
                 }
             },
             "required": [
-                "CodeUri",
-                "Handler",
-                "Runtime"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
         "AWS::Serverless::Function.AlexaSkillEvent": {
+            "additionalProperties": false,
             "properties": {
                 "Variables": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -136,6 +17684,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.ApiEvent": {
+            "additionalProperties": false,
             "properties": {
                 "Method": {
                     "type": "string"
@@ -154,6 +17703,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.CloudWatchEventEvent": {
+            "additionalProperties": false,
             "properties": {
                 "Input": {
                     "type": "string"
@@ -171,6 +17721,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.DeadLetterQueue": {
+            "additionalProperties": false,
             "properties": {
                 "TargetArn": {
                     "type": "string"
@@ -186,6 +17737,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.DynamoDBEvent": {
+            "additionalProperties": false,
             "properties": {
                 "BatchSize": {
                     "type": "number"
@@ -205,9 +17757,38 @@
             "type": "object"
         },
         "AWS::Serverless::Function.EventSource": {
+            "additionalProperties": false,
             "properties": {
                 "Properties": {
-                    "$ref": "#/definitions/AWS::Serverless::Function."
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.S3Event"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.SNSEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.KinesisEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.DynamoDBEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.ApiEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.ScheduleEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.CloudWatchEventEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.IoTRuleEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::Function.AlexaSkillEvent"
+                        }
+                    ]
                 },
                 "Type": {
                     "type": "string"
@@ -220,8 +17801,10 @@
             "type": "object"
         },
         "AWS::Serverless::Function.FunctionEnvironment": {
+            "additionalProperties": false,
             "properties": {
                 "Variables": {
+                    "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
                             "type": "string"
@@ -236,6 +17819,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.IAMPolicyDocument": {
+            "additionalProperties": false,
             "properties": {
                 "Statement": {
                     "type": "object"
@@ -247,6 +17831,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.IoTRuleEvent": {
+            "additionalProperties": false,
             "properties": {
                 "AwsIotSqlVersion": {
                     "type": "string"
@@ -261,6 +17846,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.KinesisEvent": {
+            "additionalProperties": false,
             "properties": {
                 "BatchSize": {
                     "type": "number"
@@ -279,12 +17865,25 @@
             "type": "object"
         },
         "AWS::Serverless::Function.S3Event": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
                 },
                 "Events": {
-                    "$ref": "#/definitions/AWS::Serverless::Function."
+                    "anyOf": [
+                        {
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
                 },
                 "Filter": {
                     "$ref": "#/definitions/AWS::Serverless::Function.S3NotificationFilter"
@@ -297,6 +17896,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.S3Location": {
+            "additionalProperties": false,
             "properties": {
                 "Bucket": {
                     "type": "string"
@@ -316,6 +17916,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.S3NotificationFilter": {
+            "additionalProperties": false,
             "properties": {
                 "S3Key": {
                     "type": "string"
@@ -327,6 +17928,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.SNSEvent": {
+            "additionalProperties": false,
             "properties": {
                 "Topic": {
                     "type": "string"
@@ -338,6 +17940,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.ScheduleEvent": {
+            "additionalProperties": false,
             "properties": {
                 "Input": {
                     "type": "string"
@@ -352,6 +17955,7 @@
             "type": "object"
         },
         "AWS::Serverless::Function.VpcConfig": {
+            "additionalProperties": false,
             "properties": {
                 "SecurityGroupIds": {
                     "items": {
@@ -373,17 +17977,34 @@
             "type": "object"
         },
         "AWS::Serverless::SimpleTable": {
+            "additionalProperties": false,
             "properties": {
-                "PrimaryKey": {
-                    "$ref": "#/definitions/AWS::Serverless::SimpleTable.PrimaryKey"
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PrimaryKey": {
+                            "$ref": "#/definitions/AWS::Serverless::SimpleTable.PrimaryKey"
+                        },
+                        "ProvisionedThroughput": {
+                            "$ref": "#/definitions/AWS::Serverless::SimpleTable.ProvisionedThroughput"
+                        }
+                    },
+                    "type": "object"
                 },
-                "ProvisionedThroughput": {
-                    "$ref": "#/definitions/AWS::Serverless::SimpleTable.ProvisionedThroughput"
+                "Type": {
+                    "enum": [
+                        "AWS::Serverless::SimpleTable"
+                    ],
+                    "type": "string"
                 }
             },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Serverless::SimpleTable.PrimaryKey": {
+            "additionalProperties": false,
             "properties": {
                 "Name": {
                     "type": "string"
@@ -398,6 +18019,7 @@
             "type": "object"
         },
         "AWS::Serverless::SimpleTable.ProvisionedThroughput": {
+            "additionalProperties": false,
             "properties": {
                 "ReadCapacityUnits": {
                     "type": "number"
@@ -408,6 +18030,1065 @@
             },
             "required": [
                 "WriteCapacityUnits"
+            ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::Activity": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::StepFunctions::Activity"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefinitionString": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DefinitionString",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::StepFunctions::StateMachine"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::ByteMatchSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ByteMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::ByteMatchSet.ByteMatchTuple"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::ByteMatchSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::ByteMatchSet.ByteMatchTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAF::ByteMatchSet.FieldToMatch"
+                },
+                "PositionalConstraint": {
+                    "type": "string"
+                },
+                "TargetString": {
+                    "type": "string"
+                },
+                "TargetStringBase64": {
+                    "type": "string"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::ByteMatchSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::IPSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IPSetDescriptors": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::IPSet.IPSetDescriptor"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::IPSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::IPSet.IPSetDescriptor": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Predicates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::Rule.Predicate"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::Rule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::Rule.Predicate": {
+            "additionalProperties": false,
+            "properties": {
+                "DataId": {
+                    "type": "string"
+                },
+                "Negated": {
+                    "type": "boolean"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataId",
+                "Negated",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::SizeConstraintSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SizeConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::SizeConstraintSet.SizeConstraint"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "SizeConstraints"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::SizeConstraintSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::SizeConstraintSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::SizeConstraintSet.SizeConstraint": {
+            "additionalProperties": false,
+            "properties": {
+                "ComparisonOperator": {
+                    "type": "string"
+                },
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAF::SizeConstraintSet.FieldToMatch"
+                },
+                "Size": {
+                    "type": "number"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::SqlInjectionMatchSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SqlInjectionMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::SqlInjectionMatchSet.SqlInjectionMatchTuple"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::SqlInjectionMatchSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::SqlInjectionMatchSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::SqlInjectionMatchSet.SqlInjectionMatchTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAF::SqlInjectionMatchSet.FieldToMatch"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::WebACL": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultAction": {
+                            "$ref": "#/definitions/AWS::WAF::WebACL.WafAction"
+                        },
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Rules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::WebACL.ActivatedRule"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DefaultAction",
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::WebACL"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::WebACL.ActivatedRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Action": {
+                    "$ref": "#/definitions/AWS::WAF::WebACL.WafAction"
+                },
+                "Priority": {
+                    "type": "number"
+                },
+                "RuleId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Action",
+                "Priority",
+                "RuleId"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::WebACL.WafAction": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::XssMatchSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "XssMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAF::XssMatchSet.XssMatchTuple"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "XssMatchTuples"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAF::XssMatchSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::XssMatchSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAF::XssMatchSet.XssMatchTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAF::XssMatchSet.FieldToMatch"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::ByteMatchSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ByteMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::ByteMatchSet.ByteMatchTuple"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::ByteMatchSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::ByteMatchSet.ByteMatchTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAFRegional::ByteMatchSet.FieldToMatch"
+                },
+                "PositionalConstraint": {
+                    "type": "string"
+                },
+                "TargetString": {
+                    "type": "string"
+                },
+                "TargetStringBase64": {
+                    "type": "string"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::ByteMatchSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::IPSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "IPSetDescriptors": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::IPSet.IPSetDescriptor"
+                            },
+                            "type": "array"
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::IPSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::IPSet.IPSetDescriptor": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Predicates": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::Rule.Predicate"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::Rule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::Rule.Predicate": {
+            "additionalProperties": false,
+            "properties": {
+                "DataId": {
+                    "type": "string"
+                },
+                "Negated": {
+                    "type": "boolean"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataId",
+                "Negated",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::SizeConstraintSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SizeConstraints": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::SizeConstraintSet.SizeConstraint"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::SizeConstraintSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::SizeConstraintSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::SizeConstraintSet.SizeConstraint": {
+            "additionalProperties": false,
+            "properties": {
+                "ComparisonOperator": {
+                    "type": "string"
+                },
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAFRegional::SizeConstraintSet.FieldToMatch"
+                },
+                "Size": {
+                    "type": "number"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::SqlInjectionMatchSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "SqlInjectionMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::SqlInjectionMatchSet.SqlInjectionMatchTuple"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::SqlInjectionMatchSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::SqlInjectionMatchSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::SqlInjectionMatchSet.SqlInjectionMatchTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAFRegional::SqlInjectionMatchSet.FieldToMatch"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::WebACL": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultAction": {
+                            "$ref": "#/definitions/AWS::WAFRegional::WebACL.Action"
+                        },
+                        "MetricName": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Rules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::WebACL.Rule"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DefaultAction",
+                        "MetricName",
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::WebACL"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::WebACL.Action": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::WebACL.Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Action": {
+                    "$ref": "#/definitions/AWS::WAFRegional::WebACL.Action"
+                },
+                "Priority": {
+                    "type": "number"
+                },
+                "RuleId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Action",
+                "Priority",
+                "RuleId"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::WebACLAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResourceArn": {
+                            "type": "string"
+                        },
+                        "WebACLId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResourceArn",
+                        "WebACLId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::WebACLAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::XssMatchSet": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        },
+                        "XssMatchTuples": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFRegional::XssMatchSet.XssMatchTuple"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Name"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WAFRegional::XssMatchSet"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::XssMatchSet.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "Data": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFRegional::XssMatchSet.XssMatchTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "FieldToMatch": {
+                    "$ref": "#/definitions/AWS::WAFRegional::XssMatchSet.FieldToMatch"
+                },
+                "TextTransformation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "TextTransformation"
+            ],
+            "type": "object"
+        },
+        "AWS::WorkSpaces::Workspace": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "BundleId": {
+                            "type": "string"
+                        },
+                        "DirectoryId": {
+                            "type": "string"
+                        },
+                        "RootVolumeEncryptionEnabled": {
+                            "type": "boolean"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        },
+                        "UserVolumeEncryptionEnabled": {
+                            "type": "boolean"
+                        },
+                        "VolumeEncryptionKey": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "BundleId",
+                        "DirectoryId",
+                        "UserName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::WorkSpaces::Workspace"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
@@ -481,6 +19162,22 @@
                 "Type"
             ],
             "type": "object"
+        },
+        "Tag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
         }
     },
     "properties": {
@@ -493,7 +19190,7 @@
         "Conditions": {
             "additionalProperties": false,
             "patternProperties": {
-                ".*": {
+                "^[a-zA-Z0-9]+$": {
                     "type": "object"
                 }
             },
@@ -507,7 +19204,21 @@
         "Mappings": {
             "additionalProperties": false,
             "patternProperties": {
-                ".*": {
+                "^[a-zA-Z0-9]+$": {
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Metadata": {
+            "type": "object"
+        },
+        "Outputs": {
+            "additionalProperties": false,
+            "maxProperties": 60,
+            "minProperties": 1,
+            "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
                     "type": "object"
                 }
             },
@@ -524,9 +19235,625 @@
             "type": "object"
         },
         "Resources": {
+            "additionalProperties": false,
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                     "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Account"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::ApiKey"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Authorizer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::BasePathMapping"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::ClientCertificate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Deployment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::DocumentationPart"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::DocumentationVersion"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::DomainName"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::GatewayResponse"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Method"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Model"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::RequestValidator"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Resource"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::RestApi"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::Stage"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::UsagePlan"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApiGateway::UsagePlanKey"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalableTarget"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalingPolicy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::AutoScaling::LifecycleHook"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::AutoScaling::ScalingPolicy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::AutoScaling::ScheduledAction"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Batch::ComputeEnvironment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Batch::JobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Batch::JobQueue"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CertificateManager::Certificate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::CustomResource"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::Stack"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::WaitCondition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::WaitConditionHandle"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFront::Distribution"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudTrail::Trail"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudWatch::Alarm"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudWatch::Dashboard"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodeBuild::Project"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodeCommit::Repository"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodeDeploy::Application"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodeDeploy::DeploymentGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodePipeline::CustomActionType"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CodePipeline::Pipeline"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::IdentityPool"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::IdentityPoolRoleAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::UserPoolClient"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::UserPoolGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::UserPoolUser"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Cognito::UserPoolUserToGroupAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::ConfigRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::ConfigurationRecorder"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::DeliveryChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DAX::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DAX::ParameterGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DAX::SubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DMS::Certificate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DMS::Endpoint"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DMS::EventSubscription"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DMS::ReplicationInstance"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DMS::ReplicationSubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DMS::ReplicationTask"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DataPipeline::Pipeline"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DirectoryService::SimpleAD"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DynamoDB::Table"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::CustomerGateway"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::DHCPOptions"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::EIP"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::EIPAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::EgressOnlyInternetGateway"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::FlowLog"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::Host"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::Instance"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::InternetGateway"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NatGateway"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkAcl"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkAclEntry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInterface"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInterfaceAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInterfacePermission"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::PlacementGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::Route"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::RouteTable"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SecurityGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SecurityGroupEgress"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SecurityGroupIngress"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SpotFleet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::Subnet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SubnetCidrBlock"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SubnetNetworkAclAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::SubnetRouteTableAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::TrunkInterfaceAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPC"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPCCidrBlock"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPCDHCPOptionsAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPCEndpoint"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPCGatewayAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPCPeeringConnection"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPNConnection"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPNConnectionRoute"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPNGateway"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VPNGatewayRoutePropagation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::Volume"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::VolumeAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ECR::Repository"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ECS::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ECS::Service"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ECS::TaskDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EFS::FileSystem"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EFS::MountTarget"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EMR::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EMR::InstanceFleetConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EMR::InstanceGroupConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EMR::SecurityConfiguration"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EMR::Step"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::CacheCluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::ParameterGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::ReplicationGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::SecurityGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::SecurityGroupIngress"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::SubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::Application"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::ApplicationVersion"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::ConfigurationTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticBeanstalk::Environment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancing::LoadBalancer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerCertificate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::LoadBalancer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::TargetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Elasticsearch::Domain"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Events::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::GameLift::Alias"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::GameLift::Build"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::GameLift::Fleet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::AccessKey"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::Group"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::InstanceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::ManagedPolicy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::Policy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::Role"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::User"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IAM::UserToGroupAddition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoT::Certificate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoT::Policy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoT::PolicyPrincipalAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoT::Thing"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoT::ThingPrincipalAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoT::TopicRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::KMS::Alias"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::KMS::Key"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Kinesis::Stream"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::Application"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationOutput"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::KinesisAnalytics::ApplicationReferenceDataSource"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::KinesisFirehose::DeliveryStream"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Lambda::Alias"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Lambda::EventSourceMapping"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Lambda::Function"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Lambda::Permission"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Lambda::Version"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Logs::Destination"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Logs::LogGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Logs::LogStream"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Logs::MetricFilter"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Logs::SubscriptionFilter"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::App"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::ElasticLoadBalancerAttachment"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::Instance"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::Layer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::Stack"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::UserProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::OpsWorks::Volume"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBCluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBClusterParameterGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBInstance"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBParameterGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBSecurityGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBSecurityGroupIngress"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::DBSubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::EventSubscription"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::RDS::OptionGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Redshift::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Redshift::ClusterParameterGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Redshift::ClusterSecurityGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Redshift::ClusterSecurityGroupIngress"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Redshift::ClusterSubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Route53::HealthCheck"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Route53::HostedZone"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Route53::RecordSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Route53::RecordSetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::S3::Bucket"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::S3::BucketPolicy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SDB::Domain"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SNS::Subscription"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SNS::Topic"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SNS::TopicPolicy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SQS::Queue"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SQS::QueuePolicy"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SSM::Association"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SSM::Document"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SSM::Parameter"
+                        },
                         {
                             "$ref": "#/definitions/AWS::Serverless::Api"
                         },
@@ -535,12 +19862,76 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Serverless::SimpleTable"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::StepFunctions::Activity"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::StepFunctions::StateMachine"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::ByteMatchSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::IPSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::SizeConstraintSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::SqlInjectionMatchSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::WebACL"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAF::XssMatchSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::ByteMatchSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::IPSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::SizeConstraintSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::SqlInjectionMatchSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::WebACL"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::WebACLAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WAFRegional::XssMatchSet"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::WorkSpaces::Workspace"
                         }
                     ]
                 }
             },
             "type": "object"
+        },
+        "Transform": {
+            "enum": [
+                "AWS::Serverless-2016-10-31"
+            ],
+            "type": "string"
         }
     },
+    "required": [
+        "Transform",
+        "Resources"
+    ],
     "type": "object"
 }

--- a/test/json/invalid-sam-template-no-transform.json
+++ b/test/json/invalid-sam-template-no-transform.json
@@ -1,0 +1,14 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Template has a Serverless resource, but no transform",
+  "Resources" : {
+    "MyServerlessFunctionLogicalID": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "CodeUri": "s3://testBucket/mySourceCode.zip",
+        "Runtime": "nodejs4.3"
+      }
+    }
+  }
+}

--- a/test/json/invalid-sam-template-wrong-transform.json
+++ b/test/json/invalid-sam-template-wrong-transform.json
@@ -1,0 +1,15 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Template has a Serverless resource, but wrong transform",
+  "Transform" : "HelloWorld",
+  "Resources" : {
+    "MyServerlessFunctionLogicalID": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "CodeUri": "s3://testBucket/mySourceCode.zip",
+        "Runtime": "nodejs4.3"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-additional-property.json
+++ b/test/json/invalid-template-additional-property.json
@@ -1,0 +1,26 @@
+{
+  "Hello" : "World",
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Has invalid root property 'Hello'",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-additional-resource-property.json
+++ b/test/json/invalid-template-additional-resource-property.json
@@ -1,0 +1,26 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Has invalid 'Hello' property for AWS::Route53::HostedZone",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com",
+        "Hello" : "World"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-empty-resource-properties.json
+++ b/test/json/invalid-template-empty-resource-properties.json
@@ -1,0 +1,24 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Has empty properties for AWS::Route53::HostedZone (Name is required)",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-invalid-resource-name.json
+++ b/test/json/invalid-template-invalid-resource-name.json
@@ -1,0 +1,12 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Has non-alphanumeric resource name",
+  "Resources" : {
+    "My_Route_53_Hosted_Zone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-invalid-resource-subproperty.json
+++ b/test/json/invalid-template-invalid-resource-subproperty.json
@@ -1,0 +1,20 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Has wrong type for AWS::SNS::Topic.Subscription",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : "HelloWorld",
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-missing-resource-properties.json
+++ b/test/json/invalid-template-missing-resource-properties.json
@@ -1,0 +1,22 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Missing Properties for AWS::Route53::HostedZone (Name is required)",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone"
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-missing-resource-type.json
+++ b/test/json/invalid-template-missing-resource-type.json
@@ -1,0 +1,24 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Missing Type for resource",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-missing-resources.json
+++ b/test/json/invalid-template-missing-resources.json
@@ -1,0 +1,4 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "No Resources section"
+}

--- a/test/json/invalid-template-subproperty-missing-property.json
+++ b/test/json/invalid-template-subproperty-missing-property.json
@@ -1,0 +1,24 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Missing Protocol property for AWS::SNS::Topic.Subscription",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-unknown-resource-type.json
+++ b/test/json/invalid-template-unknown-resource-type.json
@@ -1,0 +1,25 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Resource with an unrecognized resource type 'NewResourceType'",
+  "Resources" : {
+    "MyNewResource" : {
+      "Type" : "AWS::NewService::NewResourceType",
+      "Properties" : {
+        "Name" :  "HelloWorld"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/invalid-template-unknown-subproperty-property.json
+++ b/test/json/invalid-template-unknown-subproperty-property.json
@@ -1,0 +1,26 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Unrecognized 'Hello' property for AWS::SNS::Topic.Subscription",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol",
+            "Hello"    : "World"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/valid-sam-template.json
+++ b/test/json/valid-sam-template.json
@@ -1,0 +1,28 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Valid Serverless template",
+  "Transform" : "AWS::Serverless-2016-10-31",
+  "Resources" : {
+    "MyServerlessFunctionLogicalID": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "CodeUri": "s3://testBucket/mySourceCode.zip",
+        "Runtime": "nodejs4.3"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/test/json/valid-template-with-fns.json
+++ b/test/json/valid-template-with-fns.json
@@ -1,0 +1,36 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Valid template with an intrinsic function",
+  "Resources" : {
+    "MyServerlessFunctionLogicalID": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "S3Bucket": "testBucket",
+          "S3Key": "mySourceCode.zip"
+        },
+        "Role": {
+          "Fn::GetAtt": ["FunctionNameRole", "Arn"]
+        },
+        "Runtime": "nodejs4.3"
+      }
+    },
+    "FunctionNameRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Action": ["sts:AssumeRole"],
+            "Effect": "Allow",
+            "Principal": {
+              "Service": ["lambda.amazonaws.com"]
+            }
+          }]
+        }
+      }
+    }
+  }
+}

--- a/test/json/valid-template.json
+++ b/test/json/valid-template.json
@@ -1,0 +1,25 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "Valid CloudFormation template",
+  "Resources" : {
+    "MyRoute53HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" :  "example.com"
+      }
+    },
+    "MySNSTopic" : {
+      "Type" : "AWS::SNS::Topic",
+      "Properties" : {
+        "DisplayName" : "test-sns-topic-display-name",
+        "Subscription" : [
+          {
+            "Endpoint" : "test-sns-topic-subscription-endpoint",
+            "Protocol" : "test-sns-topic-subscription-protocol"
+          }
+        ],
+        "TopicName" : "test-sns-topic-name"
+      }
+    }
+  }
+}

--- a/vendor/github.com/johandorland/gojsonschema/LICENSE-APACHE-2.0.txt
+++ b/vendor/github.com/johandorland/gojsonschema/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/johandorland/gojsonschema/README.md
+++ b/vendor/github.com/johandorland/gojsonschema/README.md
@@ -1,0 +1,236 @@
+[![Build Status](https://travis-ci.org/xeipuuv/gojsonschema.svg)](https://travis-ci.org/xeipuuv/gojsonschema)
+
+# gojsonschema
+
+## Description
+
+An implementation of JSON Schema, based on IETF's draft v4 - Go language
+
+References :
+
+* http://json-schema.org
+* http://json-schema.org/latest/json-schema-core.html
+* http://json-schema.org/latest/json-schema-validation.html
+
+## Installation
+
+```
+go get github.com/xeipuuv/gojsonschema
+```
+
+Dependencies :
+* [github.com/xeipuuv/gojsonpointer](https://github.com/xeipuuv/gojsonpointer)
+* [github.com/xeipuuv/gojsonreference](https://github.com/xeipuuv/gojsonreference)
+* [github.com/stretchr/testify/assert](https://github.com/stretchr/testify#assert-package)
+
+## Usage
+
+### Example
+
+```go
+
+package main
+
+import (
+    "fmt"
+    "github.com/xeipuuv/gojsonschema"
+)
+
+func main() {
+
+    schemaLoader := gojsonschema.NewReferenceLoader("file:///home/me/schema.json")
+    documentLoader := gojsonschema.NewReferenceLoader("file:///home/me/document.json")
+
+    result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+    if err != nil {
+        panic(err.Error())
+    }
+
+    if result.Valid() {
+        fmt.Printf("The document is valid\n")
+    } else {
+        fmt.Printf("The document is not valid. see errors :\n")
+        for _, desc := range result.Errors() {
+            fmt.Printf("- %s\n", desc)
+        }
+    }
+
+}
+
+
+```
+
+#### Loaders
+
+There are various ways to load your JSON data.
+In order to load your schemas and documents,
+first declare an appropriate loader :
+
+* Web / HTTP, using a reference :
+
+```go
+loader := gojsonschema.NewReferenceLoader("http://www.some_host.com/schema.json")
+```
+
+* Local file, using a reference :
+
+```go
+loader := gojsonschema.NewReferenceLoader("file:///home/me/schema.json")
+```
+
+References use the URI scheme, the prefix (file://) and a full path to the file are required.
+
+* JSON strings :
+
+```go
+loader := gojsonschema.NewStringLoader(`{"type": "string"}`)
+```
+
+* Custom Go types :
+
+```go
+m := map[string]interface{}{"type": "string"}
+loader := gojsonschema.NewGoLoader(m)
+```
+
+And
+
+```go
+type Root struct {
+	Users []User `json:"users"`
+}
+
+type User struct {
+	Name string `json:"name"`
+}
+
+...
+
+data := Root{}
+data.Users = append(data.Users, User{"John"})
+data.Users = append(data.Users, User{"Sophia"})
+data.Users = append(data.Users, User{"Bill"})
+
+loader := gojsonschema.NewGoLoader(data)
+```
+
+#### Validation
+
+Once the loaders are set, validation is easy :
+
+```go
+result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+```
+
+Alternatively, you might want to load a schema only once and process to multiple validations :
+
+```go
+schema, err := gojsonschema.NewSchema(schemaLoader)
+...
+result1, err := schema.Validate(documentLoader1)
+...
+result2, err := schema.Validate(documentLoader2)
+...
+// etc ...
+```
+
+To check the result :
+
+```go
+    if result.Valid() {
+    	fmt.Printf("The document is valid\n")
+    } else {
+        fmt.Printf("The document is not valid. see errors :\n")
+        for _, err := range result.Errors() {
+        	// Err implements the ResultError interface
+            fmt.Printf("- %s\n", err)
+        }
+    }
+```
+
+## Working with Errors
+
+The library handles string error codes which you can customize by creating your own gojsonschema.locale and setting it
+```go
+gojsonschema.Locale = YourCustomLocale{}
+```
+
+However, each error contains additional contextual information.
+
+**err.Type()**: *string* Returns the "type" of error that occurred. Note you can also type check. See below
+
+Note: An error of RequiredType has an err.Type() return value of "required"
+
+    "required": RequiredError
+    "invalid_type": InvalidTypeError
+    "number_any_of": NumberAnyOfError
+    "number_one_of": NumberOneOfError
+    "number_all_of": NumberAllOfError
+    "number_not": NumberNotError
+    "missing_dependency": MissingDependencyError
+    "internal": InternalError
+    "enum": EnumError
+    "array_no_additional_items": ArrayNoAdditionalItemsError
+    "array_min_items": ArrayMinItemsError
+    "array_max_items": ArrayMaxItemsError
+    "unique": ItemsMustBeUniqueError
+    "array_min_properties": ArrayMinPropertiesError
+    "array_max_properties": ArrayMaxPropertiesError
+    "additional_property_not_allowed": AdditionalPropertyNotAllowedError
+    "invalid_property_pattern": InvalidPropertyPatternError
+    "string_gte": StringLengthGTEError
+    "string_lte": StringLengthLTEError
+    "pattern": DoesNotMatchPatternError
+    "multiple_of": MultipleOfError
+    "number_gte": NumberGTEError
+    "number_gt": NumberGTError
+    "number_lte": NumberLTEError
+    "number_lt": NumberLTError
+
+**err.Value()**: *interface{}* Returns the value given
+
+**err.Context()**: *gojsonschema.jsonContext* Returns the context. This has a String() method that will print something like this: (root).firstName
+
+**err.Field()**: *string* Returns the fieldname in the format firstName, or for embedded properties, person.firstName. This returns the same as the String() method on *err.Context()* but removes the (root). prefix.
+
+**err.Description()**: *string* The error description. This is based on the locale you are using. See the beginning of this section for overwriting the locale with a custom implementation.
+
+**err.Details()**: *gojsonschema.ErrorDetails* Returns a map[string]interface{} of additional error details specific to the error. For example, GTE errors will have a "min" value, LTE will have a "max" value. See errors.go for a full description of all the error details. Every error always contains a "field" key that holds the value of *err.Field()*
+
+Note in most cases, the err.Details() will be used to generate replacement strings in your locales, and not used directly. These strings follow the text/template format i.e.
+```
+{{.field}} must be greater than or equal to {{.min}}
+```
+
+## Formats
+JSON Schema allows for optional "format" property to validate strings against well-known formats. gojsonschema ships with all of the formats defined in the spec that you can use like this:
+````json
+{"type": "string", "format": "email"}
+````
+Available formats: date-time, hostname, email, ipv4, ipv6, uri.
+
+For repetitive or more complex formats, you can create custom format checkers and add them to gojsonschema like this:
+
+```go
+// Define the format checker
+type RoleFormatChecker struct {}
+
+// Ensure it meets the gojsonschema.FormatChecker interface
+func (f RoleFormatChecker) IsFormat(input string) bool {
+    return strings.HasPrefix("ROLE_", input)
+}
+
+// Add it to the library
+gojsonschema.FormatCheckers.Add("role", RoleFormatChecker{})
+````
+
+Now to use in your json schema:
+````json
+{"type": "string", "format": "role"}
+````
+
+## Uses
+
+gojsonschema uses the following test suite :
+
+https://github.com/json-schema/JSON-Schema-Test-Suite

--- a/vendor/github.com/johandorland/gojsonschema/errors.go
+++ b/vendor/github.com/johandorland/gojsonschema/errors.go
@@ -1,0 +1,274 @@
+package gojsonschema
+
+import (
+	"bytes"
+	"sync"
+	"text/template"
+)
+
+var errorTemplates errorTemplate = errorTemplate{template.New("errors-new"), sync.RWMutex{}}
+
+// template.Template is not thread-safe for writing, so some locking is done
+// sync.RWMutex is used for efficiently locking when new templates are created
+type errorTemplate struct {
+	*template.Template
+	sync.RWMutex
+}
+
+type (
+	// RequiredError. ErrorDetails: property string
+	RequiredError struct {
+		ResultErrorFields
+	}
+
+	// InvalidTypeError. ErrorDetails: expected, given
+	InvalidTypeError struct {
+		ResultErrorFields
+	}
+
+	// NumberAnyOfError. ErrorDetails: -
+	NumberAnyOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberOneOfError. ErrorDetails: -
+	NumberOneOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberAllOfError. ErrorDetails: -
+	NumberAllOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberNotError. ErrorDetails: -
+	NumberNotError struct {
+		ResultErrorFields
+	}
+
+	// MissingDependencyError. ErrorDetails: dependency
+	MissingDependencyError struct {
+		ResultErrorFields
+	}
+
+	// InternalError. ErrorDetails: error
+	InternalError struct {
+		ResultErrorFields
+	}
+
+	// EnumError. ErrorDetails: allowed
+	EnumError struct {
+		ResultErrorFields
+	}
+
+	// ArrayNoAdditionalItemsError. ErrorDetails: -
+	ArrayNoAdditionalItemsError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMinItemsError. ErrorDetails: min
+	ArrayMinItemsError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMaxItemsError. ErrorDetails: max
+	ArrayMaxItemsError struct {
+		ResultErrorFields
+	}
+
+	// ItemsMustBeUniqueError. ErrorDetails: type
+	ItemsMustBeUniqueError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMinPropertiesError. ErrorDetails: min
+	ArrayMinPropertiesError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMaxPropertiesError. ErrorDetails: max
+	ArrayMaxPropertiesError struct {
+		ResultErrorFields
+	}
+
+	// AdditionalPropertyNotAllowedError. ErrorDetails: property
+	AdditionalPropertyNotAllowedError struct {
+		ResultErrorFields
+	}
+
+	// InvalidPropertyPatternError. ErrorDetails: property, pattern
+	InvalidPropertyPatternError struct {
+		ResultErrorFields
+	}
+
+	// StringLengthGTEError. ErrorDetails: min
+	StringLengthGTEError struct {
+		ResultErrorFields
+	}
+
+	// StringLengthLTEError. ErrorDetails: max
+	StringLengthLTEError struct {
+		ResultErrorFields
+	}
+
+	// DoesNotMatchPatternError. ErrorDetails: pattern
+	DoesNotMatchPatternError struct {
+		ResultErrorFields
+	}
+
+	// DoesNotMatchFormatError. ErrorDetails: format
+	DoesNotMatchFormatError struct {
+		ResultErrorFields
+	}
+
+	// MultipleOfError. ErrorDetails: multiple
+	MultipleOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberGTEError. ErrorDetails: min
+	NumberGTEError struct {
+		ResultErrorFields
+	}
+
+	// NumberGTError. ErrorDetails: min
+	NumberGTError struct {
+		ResultErrorFields
+	}
+
+	// NumberLTEError. ErrorDetails: max
+	NumberLTEError struct {
+		ResultErrorFields
+	}
+
+	// NumberLTError. ErrorDetails: max
+	NumberLTError struct {
+		ResultErrorFields
+	}
+)
+
+// newError takes a ResultError type and sets the type, context, description, details, value, and field
+func newError(err ResultError, context *jsonContext, value interface{}, locale locale, details ErrorDetails) {
+	var t string
+	var d string
+	switch err.(type) {
+	case *RequiredError:
+		t = "required"
+		d = locale.Required()
+	case *InvalidTypeError:
+		t = "invalid_type"
+		d = locale.InvalidType()
+	case *NumberAnyOfError:
+		t = "number_any_of"
+		d = locale.NumberAnyOf()
+	case *NumberOneOfError:
+		t = "number_one_of"
+		d = locale.NumberOneOf()
+	case *NumberAllOfError:
+		t = "number_all_of"
+		d = locale.NumberAllOf()
+	case *NumberNotError:
+		t = "number_not"
+		d = locale.NumberNot()
+	case *MissingDependencyError:
+		t = "missing_dependency"
+		d = locale.MissingDependency()
+	case *InternalError:
+		t = "internal"
+		d = locale.Internal()
+	case *EnumError:
+		t = "enum"
+		d = locale.Enum()
+	case *ArrayNoAdditionalItemsError:
+		t = "array_no_additional_items"
+		d = locale.ArrayNoAdditionalItems()
+	case *ArrayMinItemsError:
+		t = "array_min_items"
+		d = locale.ArrayMinItems()
+	case *ArrayMaxItemsError:
+		t = "array_max_items"
+		d = locale.ArrayMaxItems()
+	case *ItemsMustBeUniqueError:
+		t = "unique"
+		d = locale.Unique()
+	case *ArrayMinPropertiesError:
+		t = "array_min_properties"
+		d = locale.ArrayMinProperties()
+	case *ArrayMaxPropertiesError:
+		t = "array_max_properties"
+		d = locale.ArrayMaxProperties()
+	case *AdditionalPropertyNotAllowedError:
+		t = "additional_property_not_allowed"
+		d = locale.AdditionalPropertyNotAllowed()
+	case *InvalidPropertyPatternError:
+		t = "invalid_property_pattern"
+		d = locale.InvalidPropertyPattern()
+	case *StringLengthGTEError:
+		t = "string_gte"
+		d = locale.StringGTE()
+	case *StringLengthLTEError:
+		t = "string_lte"
+		d = locale.StringLTE()
+	case *DoesNotMatchPatternError:
+		t = "pattern"
+		d = locale.DoesNotMatchPattern()
+	case *DoesNotMatchFormatError:
+		t = "format"
+		d = locale.DoesNotMatchFormat()
+	case *MultipleOfError:
+		t = "multiple_of"
+		d = locale.MultipleOf()
+	case *NumberGTEError:
+		t = "number_gte"
+		d = locale.NumberGTE()
+	case *NumberGTError:
+		t = "number_gt"
+		d = locale.NumberGT()
+	case *NumberLTEError:
+		t = "number_lte"
+		d = locale.NumberLTE()
+	case *NumberLTError:
+		t = "number_lt"
+		d = locale.NumberLT()
+	}
+
+	err.SetType(t)
+	err.SetContext(context)
+	err.SetValue(value)
+	err.SetDetails(details)
+	details["field"] = err.Field()
+	err.SetDescription(formatErrorDescription(d, details))
+}
+
+// formatErrorDescription takes a string in the default text/template
+// format and converts it to a string with replacements. The fields come
+// from the ErrorDetails struct and vary for each type of error.
+func formatErrorDescription(s string, details ErrorDetails) string {
+
+	var tpl *template.Template
+	var descrAsBuffer bytes.Buffer
+	var err error
+
+	errorTemplates.RLock()
+	tpl = errorTemplates.Lookup(s)
+	errorTemplates.RUnlock()
+
+	if tpl == nil {
+		errorTemplates.Lock()
+		tpl = errorTemplates.New(s)
+
+		tpl, err = tpl.Parse(s)
+		errorTemplates.Unlock()
+
+		if err != nil {
+			return err.Error()
+		}
+	}
+
+	err = tpl.Execute(&descrAsBuffer, details)
+	if err != nil {
+		return err.Error()
+	}
+
+	return descrAsBuffer.String()
+}

--- a/vendor/github.com/johandorland/gojsonschema/format_checkers.go
+++ b/vendor/github.com/johandorland/gojsonschema/format_checkers.go
@@ -1,0 +1,194 @@
+package gojsonschema
+
+import (
+	"net"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type (
+	// FormatChecker is the interface all formatters added to FormatCheckerChain must implement
+	FormatChecker interface {
+		IsFormat(input string) bool
+	}
+
+	// FormatCheckerChain holds the formatters
+	FormatCheckerChain struct {
+		formatters map[string]FormatChecker
+	}
+
+	// EmailFormatter verifies email address formats
+	EmailFormatChecker struct{}
+
+	// IPV4FormatChecker verifies IP addresses in the ipv4 format
+	IPV4FormatChecker struct{}
+
+	// IPV6FormatChecker verifies IP addresses in the ipv6 format
+	IPV6FormatChecker struct{}
+
+	// DateTimeFormatChecker verifies date/time formats per RFC3339 5.6
+	//
+	// Valid formats:
+	// 		Partial Time: HH:MM:SS
+	//		Full Date: YYYY-MM-DD
+	// 		Full Time: HH:MM:SSZ-07:00
+	//		Date Time: YYYY-MM-DDTHH:MM:SSZ-0700
+	//
+	// 	Where
+	//		YYYY = 4DIGIT year
+	//		MM = 2DIGIT month ; 01-12
+	//		DD = 2DIGIT day-month ; 01-28, 01-29, 01-30, 01-31 based on month/year
+	//		HH = 2DIGIT hour ; 00-23
+	//		MM = 2DIGIT ; 00-59
+	//		SS = 2DIGIT ; 00-58, 00-60 based on leap second rules
+	//		T = Literal
+	//		Z = Literal
+	//
+	//	Note: Nanoseconds are also suported in all formats
+	//
+	// http://tools.ietf.org/html/rfc3339#section-5.6
+	DateTimeFormatChecker struct{}
+
+	// URIFormatCheckers validates a URI with a valid Scheme per RFC3986
+	URIFormatChecker struct{}
+
+	// HostnameFormatChecker validates a hostname is in the correct format
+	HostnameFormatChecker struct{}
+
+	// UUIDFormatChecker validates a UUID is in the correct format
+	UUIDFormatChecker struct{}
+
+	// RegexFormatChecker validates a regex is in the correct format
+	RegexFormatChecker struct{}
+)
+
+var (
+	// Formatters holds the valid formatters, and is a public variable
+	// so library users can add custom formatters
+	FormatCheckers = FormatCheckerChain{
+		formatters: map[string]FormatChecker{
+			"date-time": DateTimeFormatChecker{},
+			"hostname":  HostnameFormatChecker{},
+			"email":     EmailFormatChecker{},
+			"ipv4":      IPV4FormatChecker{},
+			"ipv6":      IPV6FormatChecker{},
+			"uri":       URIFormatChecker{},
+			"uuid":      UUIDFormatChecker{},
+			"regex":     RegexFormatChecker{},
+		},
+	}
+
+	// Regex credit: https://github.com/asaskevich/govalidator
+	rxEmail = regexp.MustCompile("^(((([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+(\\.([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+)*)|((\\x22)((((\\x20|\\x09)*(\\x0d\\x0a))?(\\x20|\\x09)+)?(([\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(\\([\\x01-\\x09\\x0b\\x0c\\x0d-\\x7f]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]))))*(((\\x20|\\x09)*(\\x0d\\x0a))?(\\x20|\\x09)+)?(\\x22)))@((([a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(([a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])([a-zA-Z]|\\d|-|\\.|_|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*([a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.)+(([a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(([a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])([a-zA-Z]|\\d|-|\\.|_|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*([a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.?$")
+
+	// Regex credit: https://www.socketloop.com/tutorials/golang-validate-hostname
+	rxHostname = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`)
+
+	rxUUID = regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
+)
+
+// Add adds a FormatChecker to the FormatCheckerChain
+// The name used will be the value used for the format key in your json schema
+func (c *FormatCheckerChain) Add(name string, f FormatChecker) *FormatCheckerChain {
+	c.formatters[name] = f
+
+	return c
+}
+
+// Remove deletes a FormatChecker from the FormatCheckerChain (if it exists)
+func (c *FormatCheckerChain) Remove(name string) *FormatCheckerChain {
+	delete(c.formatters, name)
+
+	return c
+}
+
+// Has checks to see if the FormatCheckerChain holds a FormatChecker with the given name
+func (c *FormatCheckerChain) Has(name string) bool {
+	_, ok := c.formatters[name]
+
+	return ok
+}
+
+// IsFormat will check an input against a FormatChecker with the given name
+// to see if it is the correct format
+func (c *FormatCheckerChain) IsFormat(name string, input interface{}) bool {
+	f, ok := c.formatters[name]
+
+	if !ok {
+		return false
+	}
+
+	if !isKind(input, reflect.String) {
+		return false
+	}
+
+	inputString := input.(string)
+
+	return f.IsFormat(inputString)
+}
+
+func (f EmailFormatChecker) IsFormat(input string) bool {
+	return rxEmail.MatchString(input)
+}
+
+// Credit: https://github.com/asaskevich/govalidator
+func (f IPV4FormatChecker) IsFormat(input string) bool {
+	ip := net.ParseIP(input)
+	return ip != nil && strings.Contains(input, ".")
+}
+
+// Credit: https://github.com/asaskevich/govalidator
+func (f IPV6FormatChecker) IsFormat(input string) bool {
+	ip := net.ParseIP(input)
+	return ip != nil && strings.Contains(input, ":")
+}
+
+func (f DateTimeFormatChecker) IsFormat(input string) bool {
+	formats := []string{
+		"15:04:05",
+		"15:04:05Z07:00",
+		"2006-01-02",
+		time.RFC3339,
+		time.RFC3339Nano,
+	}
+
+	for _, format := range formats {
+		if _, err := time.Parse(format, input); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f URIFormatChecker) IsFormat(input string) bool {
+	u, err := url.Parse(input)
+	if err != nil || u.Scheme == "" {
+		return false
+	}
+
+	return true
+}
+
+func (f HostnameFormatChecker) IsFormat(input string) bool {
+	return rxHostname.MatchString(input) && len(input) < 256
+}
+
+func (f UUIDFormatChecker) IsFormat(input string) bool {
+	return rxUUID.MatchString(input)
+}
+
+// IsFormat implements FormatChecker interface.
+func (f RegexFormatChecker) IsFormat(input string) bool {
+	if input == "" {
+		return true
+	}
+	_, err := regexp.Compile(input)
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/johandorland/gojsonschema/glide.yaml
+++ b/vendor/github.com/johandorland/gojsonschema/glide.yaml
@@ -1,0 +1,12 @@
+package: github.com/xeipuuv/gojsonschema
+license: Apache 2.0
+import:
+- package: github.com/xeipuuv/gojsonschema
+
+- package: github.com/xeipuuv/gojsonpointer
+
+- package: github.com/xeipuuv/gojsonreference
+
+- package: github.com/stretchr/testify/assert
+  version: ^1.1.3
+

--- a/vendor/github.com/johandorland/gojsonschema/internalLog.go
+++ b/vendor/github.com/johandorland/gojsonschema/internalLog.go
@@ -1,0 +1,37 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Very simple log wrapper.
+//					Used for debugging/testing purposes.
+//
+// created          01-01-2015
+
+package gojsonschema
+
+import (
+	"log"
+)
+
+const internalLogEnabled = false
+
+func internalLog(format string, v ...interface{}) {
+	log.Printf(format, v...)
+}

--- a/vendor/github.com/johandorland/gojsonschema/jsonContext.go
+++ b/vendor/github.com/johandorland/gojsonschema/jsonContext.go
@@ -1,0 +1,72 @@
+// Copyright 2013 MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           tolsen
+// author-github    https://github.com/tolsen
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Implements a persistent (immutable w/ shared structure) singly-linked list of strings for the purpose of storing a json context
+//
+// created          04-09-2013
+
+package gojsonschema
+
+import "bytes"
+
+// jsonContext implements a persistent linked-list of strings
+type jsonContext struct {
+	head string
+	tail *jsonContext
+}
+
+func newJsonContext(head string, tail *jsonContext) *jsonContext {
+	return &jsonContext{head, tail}
+}
+
+// String displays the context in reverse.
+// This plays well with the data structure's persistent nature with
+// Cons and a json document's tree structure.
+func (c *jsonContext) String(del ...string) string {
+	byteArr := make([]byte, 0, c.stringLen())
+	buf := bytes.NewBuffer(byteArr)
+	c.writeStringToBuffer(buf, del)
+
+	return buf.String()
+}
+
+func (c *jsonContext) stringLen() int {
+	length := 0
+	if c.tail != nil {
+		length = c.tail.stringLen() + 1 // add 1 for "."
+	}
+
+	length += len(c.head)
+	return length
+}
+
+func (c *jsonContext) writeStringToBuffer(buf *bytes.Buffer, del []string) {
+	if c.tail != nil {
+		c.tail.writeStringToBuffer(buf, del)
+
+		if len(del) > 0 {
+			buf.WriteString(del[0])
+		} else {
+			buf.WriteString(".")
+		}
+	}
+
+	buf.WriteString(c.head)
+}

--- a/vendor/github.com/johandorland/gojsonschema/jsonLoader.go
+++ b/vendor/github.com/johandorland/gojsonschema/jsonLoader.go
@@ -1,0 +1,340 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description		Different strategies to load JSON files.
+// 					Includes References (file and HTTP), JSON strings and Go types.
+//
+// created          01-02-2015
+
+package gojsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+var osFS = osFileSystem(os.Open)
+
+// JSON loader interface
+
+type JSONLoader interface {
+	JsonSource() interface{}
+	LoadJSON() (interface{}, error)
+	JsonReference() (gojsonreference.JsonReference, error)
+	LoaderFactory() JSONLoaderFactory
+}
+
+type JSONLoaderFactory interface {
+	New(source string) JSONLoader
+}
+
+type DefaultJSONLoaderFactory struct {
+}
+
+type FileSystemJSONLoaderFactory struct {
+	fs http.FileSystem
+}
+
+func (d DefaultJSONLoaderFactory) New(source string) JSONLoader {
+	return &jsonReferenceLoader{
+		fs:     osFS,
+		source: source,
+	}
+}
+
+func (f FileSystemJSONLoaderFactory) New(source string) JSONLoader {
+	return &jsonReferenceLoader{
+		fs:     f.fs,
+		source: source,
+	}
+}
+
+// osFileSystem is a functional wrapper for os.Open that implements http.FileSystem.
+type osFileSystem func(string) (*os.File, error)
+
+func (o osFileSystem) Open(name string) (http.File, error) {
+	return o(name)
+}
+
+// JSON Reference loader
+// references are used to load JSONs from files and HTTP
+
+type jsonReferenceLoader struct {
+	fs     http.FileSystem
+	source string
+}
+
+func (l *jsonReferenceLoader) JsonSource() interface{} {
+	return l.source
+}
+
+func (l *jsonReferenceLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference(l.JsonSource().(string))
+}
+
+func (l *jsonReferenceLoader) LoaderFactory() JSONLoaderFactory {
+	return &FileSystemJSONLoaderFactory{
+		fs: l.fs,
+	}
+}
+
+// NewReferenceLoader returns a JSON reference loader using the given source and the local OS file system.
+func NewReferenceLoader(source string) *jsonReferenceLoader {
+	return &jsonReferenceLoader{
+		fs:     osFS,
+		source: source,
+	}
+}
+
+// NewReferenceLoaderFileSystem returns a JSON reference loader using the given source and file system.
+func NewReferenceLoaderFileSystem(source string, fs http.FileSystem) *jsonReferenceLoader {
+	return &jsonReferenceLoader{
+		fs:     fs,
+		source: source,
+	}
+}
+
+func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
+
+	var err error
+
+	reference, err := gojsonreference.NewJsonReference(l.JsonSource().(string))
+	if err != nil {
+		return nil, err
+	}
+
+	refToUrl := reference
+	refToUrl.GetUrl().Fragment = ""
+
+	var document interface{}
+
+	if reference.HasFileScheme {
+
+		filename := strings.Replace(refToUrl.GetUrl().Path, "file://", "", -1)
+		if runtime.GOOS == "windows" {
+			// on Windows, a file URL may have an extra leading slash, use slashes
+			// instead of backslashes, and have spaces escaped
+			if strings.HasPrefix(filename, "/") {
+				filename = filename[1:]
+			}
+			filename = filepath.FromSlash(filename)
+		}
+
+		document, err = l.loadFromFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+
+		document, err = l.loadFromHTTP(refToUrl.String())
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	return document, nil
+
+}
+
+func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) {
+
+	resp, err := http.Get(address)
+	if err != nil {
+		return nil, err
+	}
+
+	// must return HTTP Status 200 OK
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(formatErrorDescription(Locale.HttpBadStatus(), ErrorDetails{"status": resp.Status}))
+	}
+
+	bodyBuff, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
+
+}
+
+func (l *jsonReferenceLoader) loadFromFile(path string) (interface{}, error) {
+	f, err := l.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	bodyBuff, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
+
+}
+
+// JSON string loader
+
+type jsonStringLoader struct {
+	source string
+}
+
+func (l *jsonStringLoader) JsonSource() interface{} {
+	return l.source
+}
+
+func (l *jsonStringLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonStringLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
+}
+
+func NewStringLoader(source string) *jsonStringLoader {
+	return &jsonStringLoader{source: source}
+}
+
+func (l *jsonStringLoader) LoadJSON() (interface{}, error) {
+
+	return decodeJsonUsingNumber(strings.NewReader(l.JsonSource().(string)))
+
+}
+
+// JSON bytes loader
+
+type jsonBytesLoader struct {
+	source []byte
+}
+
+func (l *jsonBytesLoader) JsonSource() interface{} {
+	return l.source
+}
+
+func (l *jsonBytesLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonBytesLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
+}
+
+func NewBytesLoader(source []byte) *jsonBytesLoader {
+	return &jsonBytesLoader{source: source}
+}
+
+func (l *jsonBytesLoader) LoadJSON() (interface{}, error) {
+	return decodeJsonUsingNumber(bytes.NewReader(l.JsonSource().([]byte)))
+}
+
+// JSON Go (types) loader
+// used to load JSONs from the code as maps, interface{}, structs ...
+
+type jsonGoLoader struct {
+	source interface{}
+}
+
+func (l *jsonGoLoader) JsonSource() interface{} {
+	return l.source
+}
+
+func (l *jsonGoLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonGoLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
+}
+
+func NewGoLoader(source interface{}) *jsonGoLoader {
+	return &jsonGoLoader{source: source}
+}
+
+func (l *jsonGoLoader) LoadJSON() (interface{}, error) {
+
+	// convert it to a compliant JSON first to avoid types "mismatches"
+
+	jsonBytes, err := json.Marshal(l.JsonSource())
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(jsonBytes))
+
+}
+
+type jsonIOLoader struct {
+	buf *bytes.Buffer
+}
+
+func NewReaderLoader(source io.Reader) (*jsonIOLoader, io.Reader) {
+	buf := &bytes.Buffer{}
+	return &jsonIOLoader{buf: buf}, io.TeeReader(source, buf)
+}
+
+func NewWriterLoader(source io.Writer) (*jsonIOLoader, io.Writer) {
+	buf := &bytes.Buffer{}
+	return &jsonIOLoader{buf: buf}, io.MultiWriter(source, buf)
+}
+
+func (l *jsonIOLoader) JsonSource() interface{} {
+	return l.buf.String()
+}
+
+func (l *jsonIOLoader) LoadJSON() (interface{}, error) {
+	return decodeJsonUsingNumber(l.buf)
+}
+
+func (l *jsonIOLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonIOLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
+}
+
+func decodeJsonUsingNumber(r io.Reader) (interface{}, error) {
+
+	var document interface{}
+
+	decoder := json.NewDecoder(r)
+	decoder.UseNumber()
+
+	err := decoder.Decode(&document)
+	if err != nil {
+		return nil, err
+	}
+
+	return document, nil
+
+}

--- a/vendor/github.com/johandorland/gojsonschema/locales.go
+++ b/vendor/github.com/johandorland/gojsonschema/locales.go
@@ -1,0 +1,280 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Contains const string and messages.
+//
+// created          01-01-2015
+
+package gojsonschema
+
+type (
+	// locale is an interface for defining custom error strings
+	locale interface {
+		Required() string
+		InvalidType() string
+		NumberAnyOf() string
+		NumberOneOf() string
+		NumberAllOf() string
+		NumberNot() string
+		MissingDependency() string
+		Internal() string
+		Enum() string
+		ArrayNotEnoughItems() string
+		ArrayNoAdditionalItems() string
+		ArrayMinItems() string
+		ArrayMaxItems() string
+		Unique() string
+		ArrayMinProperties() string
+		ArrayMaxProperties() string
+		AdditionalPropertyNotAllowed() string
+		InvalidPropertyPattern() string
+		StringGTE() string
+		StringLTE() string
+		DoesNotMatchPattern() string
+		DoesNotMatchFormat() string
+		MultipleOf() string
+		NumberGTE() string
+		NumberGT() string
+		NumberLTE() string
+		NumberLT() string
+
+		// Schema validations
+		RegexPattern() string
+		GreaterThanZero() string
+		MustBeOfA() string
+		MustBeOfAn() string
+		CannotBeUsedWithout() string
+		CannotBeGT() string
+		MustBeOfType() string
+		MustBeValidRegex() string
+		MustBeValidFormat() string
+		MustBeGTEZero() string
+		KeyCannotBeGreaterThan() string
+		KeyItemsMustBeOfType() string
+		KeyItemsMustBeUnique() string
+		ReferenceMustBeCanonical() string
+		NotAValidType() string
+		Duplicated() string
+		HttpBadStatus() string
+
+		// ErrorFormat
+		ErrorFormat() string
+	}
+
+	// DefaultLocale is the default locale for this package
+	DefaultLocale struct{}
+)
+
+func (l DefaultLocale) Required() string {
+	return `{{.property}} is required`
+}
+
+func (l DefaultLocale) InvalidType() string {
+	return `Invalid type. Expected: {{.expected}}, given: {{.given}}`
+}
+
+func (l DefaultLocale) NumberAnyOf() string {
+	return `Must validate at least one schema (anyOf)`
+}
+
+func (l DefaultLocale) NumberOneOf() string {
+	return `Must validate one and only one schema (oneOf)`
+}
+
+func (l DefaultLocale) NumberAllOf() string {
+	return `Must validate all the schemas (allOf)`
+}
+
+func (l DefaultLocale) NumberNot() string {
+	return `Must not validate the schema (not)`
+}
+
+func (l DefaultLocale) MissingDependency() string {
+	return `Has a dependency on {{.dependency}}`
+}
+
+func (l DefaultLocale) Internal() string {
+	return `Internal Error {{.error}}`
+}
+
+func (l DefaultLocale) Enum() string {
+	return `{{.field}} must be one of the following: {{.allowed}}`
+}
+
+func (l DefaultLocale) ArrayNoAdditionalItems() string {
+	return `No additional items allowed on array`
+}
+
+func (l DefaultLocale) ArrayNotEnoughItems() string {
+	return `Not enough items on array to match positional list of schema`
+}
+
+func (l DefaultLocale) ArrayMinItems() string {
+	return `Array must have at least {{.min}} items`
+}
+
+func (l DefaultLocale) ArrayMaxItems() string {
+	return `Array must have at most {{.max}} items`
+}
+
+func (l DefaultLocale) Unique() string {
+	return `{{.type}} items must be unique`
+}
+
+func (l DefaultLocale) ArrayMinProperties() string {
+	return `Must have at least {{.min}} properties`
+}
+
+func (l DefaultLocale) ArrayMaxProperties() string {
+	return `Must have at most {{.max}} properties`
+}
+
+func (l DefaultLocale) AdditionalPropertyNotAllowed() string {
+	return `Additional property {{.property}} is not allowed`
+}
+
+func (l DefaultLocale) InvalidPropertyPattern() string {
+	return `Property "{{.property}}" does not match pattern {{.pattern}}`
+}
+
+func (l DefaultLocale) StringGTE() string {
+	return `String length must be greater than or equal to {{.min}}`
+}
+
+func (l DefaultLocale) StringLTE() string {
+	return `String length must be less than or equal to {{.max}}`
+}
+
+func (l DefaultLocale) DoesNotMatchPattern() string {
+	return `Does not match pattern '{{.pattern}}'`
+}
+
+func (l DefaultLocale) DoesNotMatchFormat() string {
+	return `Does not match format '{{.format}}'`
+}
+
+func (l DefaultLocale) MultipleOf() string {
+	return `Must be a multiple of {{.multiple}}`
+}
+
+func (l DefaultLocale) NumberGTE() string {
+	return `Must be greater than or equal to {{.min}}`
+}
+
+func (l DefaultLocale) NumberGT() string {
+	return `Must be greater than {{.min}}`
+}
+
+func (l DefaultLocale) NumberLTE() string {
+	return `Must be less than or equal to {{.max}}`
+}
+
+func (l DefaultLocale) NumberLT() string {
+	return `Must be less than {{.max}}`
+}
+
+// Schema validators
+func (l DefaultLocale) RegexPattern() string {
+	return `Invalid regex pattern '{{.pattern}}'`
+}
+
+func (l DefaultLocale) GreaterThanZero() string {
+	return `{{.number}} must be strictly greater than 0`
+}
+
+func (l DefaultLocale) MustBeOfA() string {
+	return `{{.x}} must be of a {{.y}}`
+}
+
+func (l DefaultLocale) MustBeOfAn() string {
+	return `{{.x}} must be of an {{.y}}`
+}
+
+func (l DefaultLocale) CannotBeUsedWithout() string {
+	return `{{.x}} cannot be used without {{.y}}`
+}
+
+func (l DefaultLocale) CannotBeGT() string {
+	return `{{.x}} cannot be greater than {{.y}}`
+}
+
+func (l DefaultLocale) MustBeOfType() string {
+	return `{{.key}} must be of type {{.type}}`
+}
+
+func (l DefaultLocale) MustBeValidRegex() string {
+	return `{{.key}} must be a valid regex`
+}
+
+func (l DefaultLocale) MustBeValidFormat() string {
+	return `{{.key}} must be a valid format {{.given}}`
+}
+
+func (l DefaultLocale) MustBeGTEZero() string {
+	return `{{.key}} must be greater than or equal to 0`
+}
+
+func (l DefaultLocale) KeyCannotBeGreaterThan() string {
+	return `{{.key}} cannot be greater than {{.y}}`
+}
+
+func (l DefaultLocale) KeyItemsMustBeOfType() string {
+	return `{{.key}} items must be {{.type}}`
+}
+
+func (l DefaultLocale) KeyItemsMustBeUnique() string {
+	return `{{.key}} items must be unique`
+}
+
+func (l DefaultLocale) ReferenceMustBeCanonical() string {
+	return `Reference {{.reference}} must be canonical`
+}
+
+func (l DefaultLocale) NotAValidType() string {
+	return `{{.type}} is not a valid type -- `
+}
+
+func (l DefaultLocale) Duplicated() string {
+	return `{{.type}} type is duplicated`
+}
+
+func (l DefaultLocale) HttpBadStatus() string {
+	return `Could not read schema from HTTP, response status is {{.status}}`
+}
+
+// Replacement options: field, description, context, value
+func (l DefaultLocale) ErrorFormat() string {
+	return `{{.field}}: {{.description}}`
+}
+
+const (
+	STRING_NUMBER                     = "number"
+	STRING_ARRAY_OF_STRINGS           = "array of strings"
+	STRING_ARRAY_OF_SCHEMAS           = "array of schemas"
+	STRING_SCHEMA                     = "schema"
+	STRING_SCHEMA_OR_ARRAY_OF_STRINGS = "schema or array of strings"
+	STRING_PROPERTIES                 = "properties"
+	STRING_DEPENDENCY                 = "dependency"
+	STRING_PROPERTY                   = "property"
+	STRING_UNDEFINED                  = "undefined"
+	STRING_CONTEXT_ROOT               = "(root)"
+	STRING_ROOT_SCHEMA_PROPERTY       = "(root)"
+)

--- a/vendor/github.com/johandorland/gojsonschema/result.go
+++ b/vendor/github.com/johandorland/gojsonschema/result.go
@@ -1,0 +1,172 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Result and ResultError implementations.
+//
+// created          01-01-2015
+
+package gojsonschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	// ErrorDetails is a map of details specific to each error.
+	// While the values will vary, every error will contain a "field" value
+	ErrorDetails map[string]interface{}
+
+	// ResultError is the interface that library errors must implement
+	ResultError interface {
+		Field() string
+		SetType(string)
+		Type() string
+		SetContext(*jsonContext)
+		Context() *jsonContext
+		SetDescription(string)
+		Description() string
+		SetValue(interface{})
+		Value() interface{}
+		SetDetails(ErrorDetails)
+		Details() ErrorDetails
+		String() string
+	}
+
+	// ResultErrorFields holds the fields for each ResultError implementation.
+	// ResultErrorFields implements the ResultError interface, so custom errors
+	// can be defined by just embedding this type
+	ResultErrorFields struct {
+		errorType   string       // A string with the type of error (i.e. invalid_type)
+		context     *jsonContext // Tree like notation of the part that failed the validation. ex (root).a.b ...
+		description string       // A human readable error message
+		value       interface{}  // Value given by the JSON file that is the source of the error
+		details     ErrorDetails
+	}
+
+	Result struct {
+		errors []ResultError
+		// Scores how well the validation matched. Useful in generating
+		// better error messages for anyOf and oneOf.
+		score int
+	}
+)
+
+// Field outputs the field name without the root context
+// i.e. firstName or person.firstName instead of (root).firstName or (root).person.firstName
+func (v *ResultErrorFields) Field() string {
+	if p, ok := v.Details()["property"]; ok {
+		if str, isString := p.(string); isString {
+			return str
+		}
+	}
+
+	return strings.TrimPrefix(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
+}
+
+func (v *ResultErrorFields) SetType(errorType string) {
+	v.errorType = errorType
+}
+
+func (v *ResultErrorFields) Type() string {
+	return v.errorType
+}
+
+func (v *ResultErrorFields) SetContext(context *jsonContext) {
+	v.context = context
+}
+
+func (v *ResultErrorFields) Context() *jsonContext {
+	return v.context
+}
+
+func (v *ResultErrorFields) SetDescription(description string) {
+	v.description = description
+}
+
+func (v *ResultErrorFields) Description() string {
+	return v.description
+}
+
+func (v *ResultErrorFields) SetValue(value interface{}) {
+	v.value = value
+}
+
+func (v *ResultErrorFields) Value() interface{} {
+	return v.value
+}
+
+func (v *ResultErrorFields) SetDetails(details ErrorDetails) {
+	v.details = details
+}
+
+func (v *ResultErrorFields) Details() ErrorDetails {
+	return v.details
+}
+
+func (v ResultErrorFields) String() string {
+	// as a fallback, the value is displayed go style
+	valueString := fmt.Sprintf("%v", v.value)
+
+	// marshal the go value value to json
+	if v.value == nil {
+		valueString = TYPE_NULL
+	} else {
+		if vs, err := marshalToJsonString(v.value); err == nil {
+			if vs == nil {
+				valueString = TYPE_NULL
+			} else {
+				valueString = *vs
+			}
+		}
+	}
+
+	return formatErrorDescription(Locale.ErrorFormat(), ErrorDetails{
+		"context":     v.context.String(),
+		"description": v.description,
+		"value":       valueString,
+		"field":       v.Field(),
+	})
+}
+
+func (v *Result) Valid() bool {
+	return len(v.errors) == 0
+}
+
+func (v *Result) Errors() []ResultError {
+	return v.errors
+}
+
+func (v *Result) addError(err ResultError, context *jsonContext, value interface{}, details ErrorDetails) {
+	newError(err, context, value, Locale, details)
+	v.errors = append(v.errors, err)
+	v.score -= 2 // results in a net -1 when added to the +1 we get at the end of the validation function
+}
+
+// Used to copy errors from a sub-schema to the main one
+func (v *Result) mergeErrors(otherResult *Result) {
+	v.errors = append(v.errors, otherResult.Errors()...)
+	v.score += otherResult.score
+}
+
+func (v *Result) incrementScore() {
+	v.score++
+}

--- a/vendor/github.com/johandorland/gojsonschema/schema.go
+++ b/vendor/github.com/johandorland/gojsonschema/schema.go
@@ -1,0 +1,932 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Defines Schema, the main entry to every subSchema.
+//                  Contains the parsing logic and error checking.
+//
+// created          26-02-2013
+
+package gojsonschema
+
+import (
+	//	"encoding/json"
+	"errors"
+	"reflect"
+	"regexp"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+var (
+	// Locale is the default locale to use
+	// Library users can overwrite with their own implementation
+	Locale locale = DefaultLocale{}
+)
+
+func NewSchema(l JSONLoader) (*Schema, error) {
+	ref, err := l.JsonReference()
+	if err != nil {
+		return nil, err
+	}
+
+	d := Schema{}
+	d.pool = newSchemaPool(l.LoaderFactory())
+	d.documentReference = ref
+	d.referencePool = newSchemaReferencePool()
+
+	var doc interface{}
+	if ref.String() != "" {
+		// Get document from schema pool
+		spd, err := d.pool.GetDocument(d.documentReference)
+		if err != nil {
+			return nil, err
+		}
+		doc = spd.Document
+	} else {
+		// Load JSON directly
+		doc, err = l.LoadJSON()
+		if err != nil {
+			return nil, err
+		}
+		d.pool.SetStandaloneDocument(doc)
+	}
+
+	err = d.parse(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &d, nil
+}
+
+type Schema struct {
+	documentReference gojsonreference.JsonReference
+	rootSchema        *subSchema
+	pool              *schemaPool
+	referencePool     *schemaReferencePool
+}
+
+func (d *Schema) parse(document interface{}) error {
+	d.rootSchema = &subSchema{property: STRING_ROOT_SCHEMA_PROPERTY}
+	return d.parseSchema(document, d.rootSchema)
+}
+
+func (d *Schema) SetRootSchemaName(name string) {
+	d.rootSchema.property = name
+}
+
+// Parses a subSchema
+//
+// Pretty long function ( sorry :) )... but pretty straight forward, repetitive and boring
+// Not much magic involved here, most of the job is to validate the key names and their values,
+// then the values are copied into subSchema struct
+//
+func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema) error {
+
+	if !isKind(documentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_OBJECT,
+				"given":    STRING_SCHEMA,
+			},
+		))
+	}
+
+	m := documentNode.(map[string]interface{})
+
+	if currentSchema == d.rootSchema {
+		currentSchema.ref = &d.documentReference
+	}
+
+	// $subSchema
+	if existsMapKey(m, KEY_SCHEMA) {
+		if !isKind(m[KEY_SCHEMA], reflect.String) {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": TYPE_STRING,
+					"given":    KEY_SCHEMA,
+				},
+			))
+		}
+		schemaRef := m[KEY_SCHEMA].(string)
+		schemaReference, err := gojsonreference.NewJsonReference(schemaRef)
+		currentSchema.subSchema = &schemaReference
+		if err != nil {
+			return err
+		}
+	}
+
+	// $ref
+	if existsMapKey(m, KEY_REF) && !isKind(m[KEY_REF], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_REF,
+			},
+		))
+	}
+	if k, ok := m[KEY_REF].(string); ok {
+
+		jsonReference, err := gojsonreference.NewJsonReference(k)
+		if err != nil {
+			return err
+		}
+
+		if jsonReference.HasFullUrl {
+			currentSchema.ref = &jsonReference
+		} else {
+			inheritedReference, err := currentSchema.ref.Inherits(jsonReference)
+			if err != nil {
+				return err
+			}
+
+			currentSchema.ref = inheritedReference
+		}
+
+		currentSchema.ref.GetUrl().Fragment = ""
+
+		if sch, ok := d.referencePool.Get(currentSchema.ref.String() + k); ok {
+			currentSchema.refSchema = sch
+
+		} else {
+			err := d.parseReference(documentNode, currentSchema, k)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+
+	// definitions
+	if existsMapKey(m, KEY_DEFINITIONS) {
+		if isKind(m[KEY_DEFINITIONS], reflect.Map) {
+			currentSchema.definitions = make(map[string]*subSchema)
+			for dk, dv := range m[KEY_DEFINITIONS].(map[string]interface{}) {
+				if isKind(dv, reflect.Map) {
+					newSchema := &subSchema{property: KEY_DEFINITIONS, parent: currentSchema, ref: currentSchema.ref}
+					currentSchema.definitions[dk] = newSchema
+					err := d.parseSchema(dv, newSchema)
+					if err != nil {
+						return errors.New(err.Error())
+					}
+				} else {
+					return errors.New(formatErrorDescription(
+						Locale.InvalidType(),
+						ErrorDetails{
+							"expected": STRING_ARRAY_OF_SCHEMAS,
+							"given":    KEY_DEFINITIONS,
+						},
+					))
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_ARRAY_OF_SCHEMAS,
+					"given":    KEY_DEFINITIONS,
+				},
+			))
+		}
+
+	}
+
+	// id
+	if existsMapKey(m, KEY_ID) && !isKind(m[KEY_ID], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_ID,
+			},
+		))
+	}
+	if k, ok := m[KEY_ID].(string); ok {
+		currentSchema.id = &k
+	}
+
+	// title
+	if existsMapKey(m, KEY_TITLE) && !isKind(m[KEY_TITLE], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_TITLE,
+			},
+		))
+	}
+	if k, ok := m[KEY_TITLE].(string); ok {
+		currentSchema.title = &k
+	}
+
+	// description
+	if existsMapKey(m, KEY_DESCRIPTION) && !isKind(m[KEY_DESCRIPTION], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_DESCRIPTION,
+			},
+		))
+	}
+	if k, ok := m[KEY_DESCRIPTION].(string); ok {
+		currentSchema.description = &k
+	}
+
+	// type
+	if existsMapKey(m, KEY_TYPE) {
+		if isKind(m[KEY_TYPE], reflect.String) {
+			if k, ok := m[KEY_TYPE].(string); ok {
+				err := currentSchema.types.Add(k)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			if isKind(m[KEY_TYPE], reflect.Slice) {
+				arrayOfTypes := m[KEY_TYPE].([]interface{})
+				for _, typeInArray := range arrayOfTypes {
+					if reflect.ValueOf(typeInArray).Kind() != reflect.String {
+						return errors.New(formatErrorDescription(
+							Locale.InvalidType(),
+							ErrorDetails{
+								"expected": TYPE_STRING + "/" + STRING_ARRAY_OF_STRINGS,
+								"given":    KEY_TYPE,
+							},
+						))
+					} else {
+						currentSchema.types.Add(typeInArray.(string))
+					}
+				}
+
+			} else {
+				return errors.New(formatErrorDescription(
+					Locale.InvalidType(),
+					ErrorDetails{
+						"expected": TYPE_STRING + "/" + STRING_ARRAY_OF_STRINGS,
+						"given":    KEY_TYPE,
+					},
+				))
+			}
+		}
+	}
+
+	// properties
+	if existsMapKey(m, KEY_PROPERTIES) {
+		err := d.parseProperties(m[KEY_PROPERTIES], currentSchema)
+		if err != nil {
+			return err
+		}
+	}
+
+	// additionalProperties
+	if existsMapKey(m, KEY_ADDITIONAL_PROPERTIES) {
+		if isKind(m[KEY_ADDITIONAL_PROPERTIES], reflect.Bool) {
+			currentSchema.additionalProperties = m[KEY_ADDITIONAL_PROPERTIES].(bool)
+		} else if isKind(m[KEY_ADDITIONAL_PROPERTIES], reflect.Map) {
+			newSchema := &subSchema{property: KEY_ADDITIONAL_PROPERTIES, parent: currentSchema, ref: currentSchema.ref}
+			currentSchema.additionalProperties = newSchema
+			err := d.parseSchema(m[KEY_ADDITIONAL_PROPERTIES], newSchema)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": TYPE_BOOLEAN + "/" + STRING_SCHEMA,
+					"given":    KEY_ADDITIONAL_PROPERTIES,
+				},
+			))
+		}
+	}
+
+	// patternProperties
+	if existsMapKey(m, KEY_PATTERN_PROPERTIES) {
+		if isKind(m[KEY_PATTERN_PROPERTIES], reflect.Map) {
+			patternPropertiesMap := m[KEY_PATTERN_PROPERTIES].(map[string]interface{})
+			if len(patternPropertiesMap) > 0 {
+				currentSchema.patternProperties = make(map[string]*subSchema)
+				for k, v := range patternPropertiesMap {
+					_, err := regexp.MatchString(k, "")
+					if err != nil {
+						return errors.New(formatErrorDescription(
+							Locale.RegexPattern(),
+							ErrorDetails{"pattern": k},
+						))
+					}
+					newSchema := &subSchema{property: k, parent: currentSchema, ref: currentSchema.ref}
+					err = d.parseSchema(v, newSchema)
+					if err != nil {
+						return errors.New(err.Error())
+					}
+					currentSchema.patternProperties[k] = newSchema
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_SCHEMA,
+					"given":    KEY_PATTERN_PROPERTIES,
+				},
+			))
+		}
+	}
+
+	// dependencies
+	if existsMapKey(m, KEY_DEPENDENCIES) {
+		err := d.parseDependencies(m[KEY_DEPENDENCIES], currentSchema)
+		if err != nil {
+			return err
+		}
+	}
+
+	// items
+	if existsMapKey(m, KEY_ITEMS) {
+		if isKind(m[KEY_ITEMS], reflect.Slice) {
+			for _, itemElement := range m[KEY_ITEMS].([]interface{}) {
+				if isKind(itemElement, reflect.Map) {
+					newSchema := &subSchema{parent: currentSchema, property: KEY_ITEMS}
+					newSchema.ref = currentSchema.ref
+					currentSchema.AddItemsChild(newSchema)
+					err := d.parseSchema(itemElement, newSchema)
+					if err != nil {
+						return err
+					}
+				} else {
+					return errors.New(formatErrorDescription(
+						Locale.InvalidType(),
+						ErrorDetails{
+							"expected": STRING_SCHEMA + "/" + STRING_ARRAY_OF_SCHEMAS,
+							"given":    KEY_ITEMS,
+						},
+					))
+				}
+				currentSchema.itemsChildrenIsSingleSchema = false
+			}
+		} else if isKind(m[KEY_ITEMS], reflect.Map) {
+			newSchema := &subSchema{parent: currentSchema, property: KEY_ITEMS}
+			newSchema.ref = currentSchema.ref
+			currentSchema.AddItemsChild(newSchema)
+			err := d.parseSchema(m[KEY_ITEMS], newSchema)
+			if err != nil {
+				return err
+			}
+			currentSchema.itemsChildrenIsSingleSchema = true
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_SCHEMA + "/" + STRING_ARRAY_OF_SCHEMAS,
+					"given":    KEY_ITEMS,
+				},
+			))
+		}
+	}
+
+	// additionalItems
+	if existsMapKey(m, KEY_ADDITIONAL_ITEMS) {
+		if isKind(m[KEY_ADDITIONAL_ITEMS], reflect.Bool) {
+			currentSchema.additionalItems = m[KEY_ADDITIONAL_ITEMS].(bool)
+		} else if isKind(m[KEY_ADDITIONAL_ITEMS], reflect.Map) {
+			newSchema := &subSchema{property: KEY_ADDITIONAL_ITEMS, parent: currentSchema, ref: currentSchema.ref}
+			currentSchema.additionalItems = newSchema
+			err := d.parseSchema(m[KEY_ADDITIONAL_ITEMS], newSchema)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": TYPE_BOOLEAN + "/" + STRING_SCHEMA,
+					"given":    KEY_ADDITIONAL_ITEMS,
+				},
+			))
+		}
+	}
+
+	// validation : number / integer
+
+	if existsMapKey(m, KEY_MULTIPLE_OF) {
+		multipleOfValue := mustBeNumber(m[KEY_MULTIPLE_OF])
+		if multipleOfValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_NUMBER,
+					"given":    KEY_MULTIPLE_OF,
+				},
+			))
+		}
+		if *multipleOfValue <= 0 {
+			return errors.New(formatErrorDescription(
+				Locale.GreaterThanZero(),
+				ErrorDetails{"number": KEY_MULTIPLE_OF},
+			))
+		}
+		currentSchema.multipleOf = multipleOfValue
+	}
+
+	if existsMapKey(m, KEY_MINIMUM) {
+		minimumValue := mustBeNumber(m[KEY_MINIMUM])
+		if minimumValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_MINIMUM, "y": STRING_NUMBER},
+			))
+		}
+		currentSchema.minimum = minimumValue
+	}
+
+	if existsMapKey(m, KEY_EXCLUSIVE_MINIMUM) {
+		if isKind(m[KEY_EXCLUSIVE_MINIMUM], reflect.Bool) {
+			if currentSchema.minimum == nil {
+				return errors.New(formatErrorDescription(
+					Locale.CannotBeUsedWithout(),
+					ErrorDetails{"x": KEY_EXCLUSIVE_MINIMUM, "y": KEY_MINIMUM},
+				))
+			}
+			exclusiveMinimumValue := m[KEY_EXCLUSIVE_MINIMUM].(bool)
+			currentSchema.exclusiveMinimum = exclusiveMinimumValue
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_EXCLUSIVE_MINIMUM, "y": TYPE_BOOLEAN},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_MAXIMUM) {
+		maximumValue := mustBeNumber(m[KEY_MAXIMUM])
+		if maximumValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_MAXIMUM, "y": STRING_NUMBER},
+			))
+		}
+		currentSchema.maximum = maximumValue
+	}
+
+	if existsMapKey(m, KEY_EXCLUSIVE_MAXIMUM) {
+		if isKind(m[KEY_EXCLUSIVE_MAXIMUM], reflect.Bool) {
+			if currentSchema.maximum == nil {
+				return errors.New(formatErrorDescription(
+					Locale.CannotBeUsedWithout(),
+					ErrorDetails{"x": KEY_EXCLUSIVE_MAXIMUM, "y": KEY_MAXIMUM},
+				))
+			}
+			exclusiveMaximumValue := m[KEY_EXCLUSIVE_MAXIMUM].(bool)
+			currentSchema.exclusiveMaximum = exclusiveMaximumValue
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_EXCLUSIVE_MAXIMUM, "y": STRING_NUMBER},
+			))
+		}
+	}
+
+	if currentSchema.minimum != nil && currentSchema.maximum != nil {
+		if *currentSchema.minimum > *currentSchema.maximum {
+			return errors.New(formatErrorDescription(
+				Locale.CannotBeGT(),
+				ErrorDetails{"x": KEY_MINIMUM, "y": KEY_MAXIMUM},
+			))
+		}
+	}
+
+	// validation : string
+
+	if existsMapKey(m, KEY_MIN_LENGTH) {
+		minLengthIntegerValue := mustBeInteger(m[KEY_MIN_LENGTH])
+		if minLengthIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MIN_LENGTH, "y": TYPE_INTEGER},
+			))
+		}
+		if *minLengthIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MIN_LENGTH},
+			))
+		}
+		currentSchema.minLength = minLengthIntegerValue
+	}
+
+	if existsMapKey(m, KEY_MAX_LENGTH) {
+		maxLengthIntegerValue := mustBeInteger(m[KEY_MAX_LENGTH])
+		if maxLengthIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MAX_LENGTH, "y": TYPE_INTEGER},
+			))
+		}
+		if *maxLengthIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MAX_LENGTH},
+			))
+		}
+		currentSchema.maxLength = maxLengthIntegerValue
+	}
+
+	if currentSchema.minLength != nil && currentSchema.maxLength != nil {
+		if *currentSchema.minLength > *currentSchema.maxLength {
+			return errors.New(formatErrorDescription(
+				Locale.CannotBeGT(),
+				ErrorDetails{"x": KEY_MIN_LENGTH, "y": KEY_MAX_LENGTH},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_PATTERN) {
+		if isKind(m[KEY_PATTERN], reflect.String) {
+			regexpObject, err := regexp.Compile(m[KEY_PATTERN].(string))
+			if err != nil {
+				return errors.New(formatErrorDescription(
+					Locale.MustBeValidRegex(),
+					ErrorDetails{"key": KEY_PATTERN},
+				))
+			}
+			currentSchema.pattern = regexpObject
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_PATTERN, "y": TYPE_STRING},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_FORMAT) {
+		formatString, ok := m[KEY_FORMAT].(string)
+		if ok && FormatCheckers.Has(formatString) {
+			currentSchema.format = formatString
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeValidFormat(),
+				ErrorDetails{"key": KEY_FORMAT, "given": m[KEY_FORMAT]},
+			))
+		}
+	}
+
+	// validation : object
+
+	if existsMapKey(m, KEY_MIN_PROPERTIES) {
+		minPropertiesIntegerValue := mustBeInteger(m[KEY_MIN_PROPERTIES])
+		if minPropertiesIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MIN_PROPERTIES, "y": TYPE_INTEGER},
+			))
+		}
+		if *minPropertiesIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MIN_PROPERTIES},
+			))
+		}
+		currentSchema.minProperties = minPropertiesIntegerValue
+	}
+
+	if existsMapKey(m, KEY_MAX_PROPERTIES) {
+		maxPropertiesIntegerValue := mustBeInteger(m[KEY_MAX_PROPERTIES])
+		if maxPropertiesIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MAX_PROPERTIES, "y": TYPE_INTEGER},
+			))
+		}
+		if *maxPropertiesIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MAX_PROPERTIES},
+			))
+		}
+		currentSchema.maxProperties = maxPropertiesIntegerValue
+	}
+
+	if currentSchema.minProperties != nil && currentSchema.maxProperties != nil {
+		if *currentSchema.minProperties > *currentSchema.maxProperties {
+			return errors.New(formatErrorDescription(
+				Locale.KeyCannotBeGreaterThan(),
+				ErrorDetails{"key": KEY_MIN_PROPERTIES, "y": KEY_MAX_PROPERTIES},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_REQUIRED) {
+		if isKind(m[KEY_REQUIRED], reflect.Slice) {
+			requiredValues := m[KEY_REQUIRED].([]interface{})
+			for _, requiredValue := range requiredValues {
+				if isKind(requiredValue, reflect.String) {
+					err := currentSchema.AddRequired(requiredValue.(string))
+					if err != nil {
+						return err
+					}
+				} else {
+					return errors.New(formatErrorDescription(
+						Locale.KeyItemsMustBeOfType(),
+						ErrorDetails{"key": KEY_REQUIRED, "type": TYPE_STRING},
+					))
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_REQUIRED, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	// validation : array
+
+	if existsMapKey(m, KEY_MIN_ITEMS) {
+		minItemsIntegerValue := mustBeInteger(m[KEY_MIN_ITEMS])
+		if minItemsIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MIN_ITEMS, "y": TYPE_INTEGER},
+			))
+		}
+		if *minItemsIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MIN_ITEMS},
+			))
+		}
+		currentSchema.minItems = minItemsIntegerValue
+	}
+
+	if existsMapKey(m, KEY_MAX_ITEMS) {
+		maxItemsIntegerValue := mustBeInteger(m[KEY_MAX_ITEMS])
+		if maxItemsIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MAX_ITEMS, "y": TYPE_INTEGER},
+			))
+		}
+		if *maxItemsIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MAX_ITEMS},
+			))
+		}
+		currentSchema.maxItems = maxItemsIntegerValue
+	}
+
+	if existsMapKey(m, KEY_UNIQUE_ITEMS) {
+		if isKind(m[KEY_UNIQUE_ITEMS], reflect.Bool) {
+			currentSchema.uniqueItems = m[KEY_UNIQUE_ITEMS].(bool)
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_UNIQUE_ITEMS, "y": TYPE_BOOLEAN},
+			))
+		}
+	}
+
+	// validation : all
+
+	if existsMapKey(m, KEY_ENUM) {
+		if isKind(m[KEY_ENUM], reflect.Slice) {
+			for _, v := range m[KEY_ENUM].([]interface{}) {
+				err := currentSchema.AddEnum(v)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ENUM, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	// validation : subSchema
+
+	if existsMapKey(m, KEY_ONE_OF) {
+		if isKind(m[KEY_ONE_OF], reflect.Slice) {
+			for _, v := range m[KEY_ONE_OF].([]interface{}) {
+				newSchema := &subSchema{property: KEY_ONE_OF, parent: currentSchema, ref: currentSchema.ref}
+				currentSchema.AddOneOf(newSchema)
+				err := d.parseSchema(v, newSchema)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ONE_OF, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_ANY_OF) {
+		if isKind(m[KEY_ANY_OF], reflect.Slice) {
+			for _, v := range m[KEY_ANY_OF].([]interface{}) {
+				newSchema := &subSchema{property: KEY_ANY_OF, parent: currentSchema, ref: currentSchema.ref}
+				currentSchema.AddAnyOf(newSchema)
+				err := d.parseSchema(v, newSchema)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ANY_OF, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_ALL_OF) {
+		if isKind(m[KEY_ALL_OF], reflect.Slice) {
+			for _, v := range m[KEY_ALL_OF].([]interface{}) {
+				newSchema := &subSchema{property: KEY_ALL_OF, parent: currentSchema, ref: currentSchema.ref}
+				currentSchema.AddAllOf(newSchema)
+				err := d.parseSchema(v, newSchema)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ANY_OF, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_NOT) {
+		if isKind(m[KEY_NOT], reflect.Map) {
+			newSchema := &subSchema{property: KEY_NOT, parent: currentSchema, ref: currentSchema.ref}
+			currentSchema.SetNot(newSchema)
+			err := d.parseSchema(m[KEY_NOT], newSchema)
+			if err != nil {
+				return err
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_NOT, "y": TYPE_OBJECT},
+			))
+		}
+	}
+
+	return nil
+}
+
+func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSchema, reference string) error {
+	var refdDocumentNode interface{}
+	jsonPointer := currentSchema.ref.GetPointer()
+	standaloneDocument := d.pool.GetStandaloneDocument()
+
+	if standaloneDocument != nil {
+
+		var err error
+		refdDocumentNode, _, err = jsonPointer.Get(standaloneDocument)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		dsp, err := d.pool.GetDocument(*currentSchema.ref)
+		if err != nil {
+			return err
+		}
+
+		refdDocumentNode, _, err = jsonPointer.Get(dsp.Document)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	if !isKind(refdDocumentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.MustBeOfType(),
+			ErrorDetails{"key": STRING_SCHEMA, "type": TYPE_OBJECT},
+		))
+	}
+
+	// returns the loaded referenced subSchema for the caller to update its current subSchema
+	newSchemaDocument := refdDocumentNode.(map[string]interface{})
+	newSchema := &subSchema{property: KEY_REF, parent: currentSchema, ref: currentSchema.ref}
+	d.referencePool.Add(currentSchema.ref.String()+reference, newSchema)
+
+	err := d.parseSchema(newSchemaDocument, newSchema)
+	if err != nil {
+		return err
+	}
+
+	currentSchema.refSchema = newSchema
+
+	return nil
+
+}
+
+func (d *Schema) parseProperties(documentNode interface{}, currentSchema *subSchema) error {
+
+	if !isKind(documentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.MustBeOfType(),
+			ErrorDetails{"key": STRING_PROPERTIES, "type": TYPE_OBJECT},
+		))
+	}
+
+	m := documentNode.(map[string]interface{})
+	for k := range m {
+		schemaProperty := k
+		newSchema := &subSchema{property: schemaProperty, parent: currentSchema, ref: currentSchema.ref}
+		currentSchema.AddPropertiesChild(newSchema)
+		err := d.parseSchema(m[k], newSchema)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Schema) parseDependencies(documentNode interface{}, currentSchema *subSchema) error {
+
+	if !isKind(documentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.MustBeOfType(),
+			ErrorDetails{"key": KEY_DEPENDENCIES, "type": TYPE_OBJECT},
+		))
+	}
+
+	m := documentNode.(map[string]interface{})
+	currentSchema.dependencies = make(map[string]interface{})
+
+	for k := range m {
+		switch reflect.ValueOf(m[k]).Kind() {
+
+		case reflect.Slice:
+			values := m[k].([]interface{})
+			var valuesToRegister []string
+
+			for _, value := range values {
+				if !isKind(value, reflect.String) {
+					return errors.New(formatErrorDescription(
+						Locale.MustBeOfType(),
+						ErrorDetails{
+							"key":  STRING_DEPENDENCY,
+							"type": STRING_SCHEMA_OR_ARRAY_OF_STRINGS,
+						},
+					))
+				} else {
+					valuesToRegister = append(valuesToRegister, value.(string))
+				}
+				currentSchema.dependencies[k] = valuesToRegister
+			}
+
+		case reflect.Map:
+			depSchema := &subSchema{property: k, parent: currentSchema, ref: currentSchema.ref}
+			err := d.parseSchema(m[k], depSchema)
+			if err != nil {
+				return err
+			}
+			currentSchema.dependencies[k] = depSchema
+
+		default:
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfType(),
+				ErrorDetails{
+					"key":  STRING_DEPENDENCY,
+					"type": STRING_SCHEMA_OR_ARRAY_OF_STRINGS,
+				},
+			))
+		}
+
+	}
+
+	return nil
+}

--- a/vendor/github.com/johandorland/gojsonschema/schemaPool.go
+++ b/vendor/github.com/johandorland/gojsonschema/schemaPool.go
@@ -1,0 +1,109 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description		Defines resources pooling.
+//                  Eases referencing and avoids downloading the same resource twice.
+//
+// created          26-02-2013
+
+package gojsonschema
+
+import (
+	"errors"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+type schemaPoolDocument struct {
+	Document interface{}
+}
+
+type schemaPool struct {
+	schemaPoolDocuments map[string]*schemaPoolDocument
+	standaloneDocument  interface{}
+	jsonLoaderFactory   JSONLoaderFactory
+}
+
+func newSchemaPool(f JSONLoaderFactory) *schemaPool {
+
+	p := &schemaPool{}
+	p.schemaPoolDocuments = make(map[string]*schemaPoolDocument)
+	p.standaloneDocument = nil
+	p.jsonLoaderFactory = f
+
+	return p
+}
+
+func (p *schemaPool) SetStandaloneDocument(document interface{}) {
+	p.standaloneDocument = document
+}
+
+func (p *schemaPool) GetStandaloneDocument() (document interface{}) {
+	return p.standaloneDocument
+}
+
+func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*schemaPoolDocument, error) {
+
+	if internalLogEnabled {
+		internalLog("Get Document ( %s )", reference.String())
+	}
+
+	var err error
+
+	// It is not possible to load anything that is not canonical...
+	if !reference.IsCanonical() {
+		return nil, errors.New(formatErrorDescription(
+			Locale.ReferenceMustBeCanonical(),
+			ErrorDetails{"reference": reference},
+		))
+	}
+
+	refToUrl := reference
+	refToUrl.GetUrl().Fragment = ""
+
+	var spd *schemaPoolDocument
+
+	// Try to find the requested document in the pool
+	for k := range p.schemaPoolDocuments {
+		if k == refToUrl.String() {
+			spd = p.schemaPoolDocuments[k]
+		}
+	}
+
+	if spd != nil {
+		if internalLogEnabled {
+			internalLog(" From pool")
+		}
+		return spd, nil
+	}
+
+	jsonReferenceLoader := p.jsonLoaderFactory.New(reference.String())
+	document, err := jsonReferenceLoader.LoadJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	spd = &schemaPoolDocument{Document: document}
+	// add the document to the pool for potential later use
+	p.schemaPoolDocuments[refToUrl.String()] = spd
+
+	return spd, nil
+}

--- a/vendor/github.com/johandorland/gojsonschema/schemaReferencePool.go
+++ b/vendor/github.com/johandorland/gojsonschema/schemaReferencePool.go
@@ -1,0 +1,67 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Pool of referenced schemas.
+//
+// created          25-06-2013
+
+package gojsonschema
+
+import (
+	"fmt"
+)
+
+type schemaReferencePool struct {
+	documents map[string]*subSchema
+}
+
+func newSchemaReferencePool() *schemaReferencePool {
+
+	p := &schemaReferencePool{}
+	p.documents = make(map[string]*subSchema)
+
+	return p
+}
+
+func (p *schemaReferencePool) Get(ref string) (r *subSchema, o bool) {
+
+	if internalLogEnabled {
+		internalLog(fmt.Sprintf("Schema Reference ( %s )", ref))
+	}
+
+	if sch, ok := p.documents[ref]; ok {
+		if internalLogEnabled {
+			internalLog(fmt.Sprintf(" From pool"))
+		}
+		return sch, true
+	}
+
+	return nil, false
+}
+
+func (p *schemaReferencePool) Add(ref string, sch *subSchema) {
+
+	if internalLogEnabled {
+		internalLog(fmt.Sprintf("Add Schema Reference %s to pool", ref))
+	}
+
+	p.documents[ref] = sch
+}

--- a/vendor/github.com/johandorland/gojsonschema/schemaType.go
+++ b/vendor/github.com/johandorland/gojsonschema/schemaType.go
@@ -1,0 +1,83 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Helper structure to handle schema types, and the combination of them.
+//
+// created          28-02-2013
+
+package gojsonschema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type jsonSchemaType struct {
+	types []string
+}
+
+// Is the schema typed ? that is containing at least one type
+// When not typed, the schema does not need any type validation
+func (t *jsonSchemaType) IsTyped() bool {
+	return len(t.types) > 0
+}
+
+func (t *jsonSchemaType) Add(etype string) error {
+
+	if !isStringInSlice(JSON_TYPES, etype) {
+		return errors.New(formatErrorDescription(Locale.NotAValidType(), ErrorDetails{"type": etype}))
+	}
+
+	if t.Contains(etype) {
+		return errors.New(formatErrorDescription(Locale.Duplicated(), ErrorDetails{"type": etype}))
+	}
+
+	t.types = append(t.types, etype)
+
+	return nil
+}
+
+func (t *jsonSchemaType) Contains(etype string) bool {
+
+	for _, v := range t.types {
+		if v == etype {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *jsonSchemaType) String() string {
+
+	if len(t.types) == 0 {
+		return STRING_UNDEFINED // should never happen
+	}
+
+	// Displayed as a list [type1,type2,...]
+	if len(t.types) > 1 {
+		return fmt.Sprintf("[%s]", strings.Join(t.types, ","))
+	}
+
+	// Only one type: name only
+	return t.types[0]
+}

--- a/vendor/github.com/johandorland/gojsonschema/subSchema.go
+++ b/vendor/github.com/johandorland/gojsonschema/subSchema.go
@@ -1,0 +1,227 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Defines the structure of a sub-subSchema.
+//                  A sub-subSchema can contain other sub-schemas.
+//
+// created          27-02-2013
+
+package gojsonschema
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+const (
+	KEY_SCHEMA                = "$subSchema"
+	KEY_ID                    = "$id"
+	KEY_REF                   = "$ref"
+	KEY_TITLE                 = "title"
+	KEY_DESCRIPTION           = "description"
+	KEY_TYPE                  = "type"
+	KEY_ITEMS                 = "items"
+	KEY_ADDITIONAL_ITEMS      = "additionalItems"
+	KEY_PROPERTIES            = "properties"
+	KEY_PATTERN_PROPERTIES    = "patternProperties"
+	KEY_ADDITIONAL_PROPERTIES = "additionalProperties"
+	KEY_DEFINITIONS           = "definitions"
+	KEY_MULTIPLE_OF           = "multipleOf"
+	KEY_MINIMUM               = "minimum"
+	KEY_MAXIMUM               = "maximum"
+	KEY_EXCLUSIVE_MINIMUM     = "exclusiveMinimum"
+	KEY_EXCLUSIVE_MAXIMUM     = "exclusiveMaximum"
+	KEY_MIN_LENGTH            = "minLength"
+	KEY_MAX_LENGTH            = "maxLength"
+	KEY_PATTERN               = "pattern"
+	KEY_FORMAT                = "format"
+	KEY_MIN_PROPERTIES        = "minProperties"
+	KEY_MAX_PROPERTIES        = "maxProperties"
+	KEY_DEPENDENCIES          = "dependencies"
+	KEY_REQUIRED              = "required"
+	KEY_MIN_ITEMS             = "minItems"
+	KEY_MAX_ITEMS             = "maxItems"
+	KEY_UNIQUE_ITEMS          = "uniqueItems"
+	KEY_ENUM                  = "enum"
+	KEY_ONE_OF                = "oneOf"
+	KEY_ANY_OF                = "anyOf"
+	KEY_ALL_OF                = "allOf"
+	KEY_NOT                   = "not"
+)
+
+type subSchema struct {
+
+	// basic subSchema meta properties
+	id          *string
+	title       *string
+	description *string
+
+	property string
+
+	// Types associated with the subSchema
+	types jsonSchemaType
+
+	// Reference url
+	ref *gojsonreference.JsonReference
+	// Schema referenced
+	refSchema *subSchema
+	// Json reference
+	subSchema *gojsonreference.JsonReference
+
+	// hierarchy
+	parent                      *subSchema
+	definitions                 map[string]*subSchema
+	definitionsChildren         []*subSchema
+	itemsChildren               []*subSchema
+	itemsChildrenIsSingleSchema bool
+	propertiesChildren          []*subSchema
+
+	// validation : number / integer
+	multipleOf       *float64
+	maximum          *float64
+	exclusiveMaximum bool
+	minimum          *float64
+	exclusiveMinimum bool
+
+	// validation : string
+	minLength *int
+	maxLength *int
+	pattern   *regexp.Regexp
+	format    string
+
+	// validation : object
+	minProperties *int
+	maxProperties *int
+	required      []string
+
+	dependencies         map[string]interface{}
+	additionalProperties interface{}
+	patternProperties    map[string]*subSchema
+
+	// validation : array
+	minItems    *int
+	maxItems    *int
+	uniqueItems bool
+
+	additionalItems interface{}
+
+	// validation : all
+	enum []string
+
+	// validation : subSchema
+	oneOf []*subSchema
+	anyOf []*subSchema
+	allOf []*subSchema
+	not   *subSchema
+}
+
+func (s *subSchema) AddEnum(i interface{}) error {
+
+	is, err := marshalToJsonString(i)
+	if err != nil {
+		return err
+	}
+
+	if isStringInSlice(s.enum, *is) {
+		return errors.New(formatErrorDescription(
+			Locale.KeyItemsMustBeUnique(),
+			ErrorDetails{"key": KEY_ENUM},
+		))
+	}
+
+	s.enum = append(s.enum, *is)
+
+	return nil
+}
+
+func (s *subSchema) ContainsEnum(i interface{}) (bool, error) {
+
+	is, err := marshalToJsonString(i)
+	if err != nil {
+		return false, err
+	}
+
+	return isStringInSlice(s.enum, *is), nil
+}
+
+func (s *subSchema) AddOneOf(subSchema *subSchema) {
+	s.oneOf = append(s.oneOf, subSchema)
+}
+
+func (s *subSchema) AddAllOf(subSchema *subSchema) {
+	s.allOf = append(s.allOf, subSchema)
+}
+
+func (s *subSchema) AddAnyOf(subSchema *subSchema) {
+	s.anyOf = append(s.anyOf, subSchema)
+}
+
+func (s *subSchema) SetNot(subSchema *subSchema) {
+	s.not = subSchema
+}
+
+func (s *subSchema) AddRequired(value string) error {
+
+	if isStringInSlice(s.required, value) {
+		return errors.New(formatErrorDescription(
+			Locale.KeyItemsMustBeUnique(),
+			ErrorDetails{"key": KEY_REQUIRED},
+		))
+	}
+
+	s.required = append(s.required, value)
+
+	return nil
+}
+
+func (s *subSchema) AddDefinitionChild(child *subSchema) {
+	s.definitionsChildren = append(s.definitionsChildren, child)
+}
+
+func (s *subSchema) AddItemsChild(child *subSchema) {
+	s.itemsChildren = append(s.itemsChildren, child)
+}
+
+func (s *subSchema) AddPropertiesChild(child *subSchema) {
+	s.propertiesChildren = append(s.propertiesChildren, child)
+}
+
+func (s *subSchema) PatternPropertiesString() string {
+
+	if s.patternProperties == nil || len(s.patternProperties) == 0 {
+		return STRING_UNDEFINED // should never happen
+	}
+
+	patternPropertiesKeySlice := []string{}
+	for pk := range s.patternProperties {
+		patternPropertiesKeySlice = append(patternPropertiesKeySlice, `"`+pk+`"`)
+	}
+
+	if len(patternPropertiesKeySlice) == 1 {
+		return patternPropertiesKeySlice[0]
+	}
+
+	return "[" + strings.Join(patternPropertiesKeySlice, ",") + "]"
+
+}

--- a/vendor/github.com/johandorland/gojsonschema/types.go
+++ b/vendor/github.com/johandorland/gojsonschema/types.go
@@ -1,0 +1,58 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Contains const types for schema and JSON.
+//
+// created          28-02-2013
+
+package gojsonschema
+
+const (
+	TYPE_ARRAY   = `array`
+	TYPE_BOOLEAN = `boolean`
+	TYPE_INTEGER = `integer`
+	TYPE_NUMBER  = `number`
+	TYPE_NULL    = `null`
+	TYPE_OBJECT  = `object`
+	TYPE_STRING  = `string`
+)
+
+var JSON_TYPES []string
+var SCHEMA_TYPES []string
+
+func init() {
+	JSON_TYPES = []string{
+		TYPE_ARRAY,
+		TYPE_BOOLEAN,
+		TYPE_INTEGER,
+		TYPE_NUMBER,
+		TYPE_NULL,
+		TYPE_OBJECT,
+		TYPE_STRING}
+
+	SCHEMA_TYPES = []string{
+		TYPE_ARRAY,
+		TYPE_BOOLEAN,
+		TYPE_INTEGER,
+		TYPE_NUMBER,
+		TYPE_OBJECT,
+		TYPE_STRING}
+}

--- a/vendor/github.com/johandorland/gojsonschema/utils.go
+++ b/vendor/github.com/johandorland/gojsonschema/utils.go
@@ -1,0 +1,208 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Various utility functions.
+//
+// created          26-02-2013
+
+package gojsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+)
+
+func isKind(what interface{}, kind reflect.Kind) bool {
+	target := what
+	if isJsonNumber(what) {
+		// JSON Numbers are strings!
+		target = *mustBeNumber(what)
+	}
+	return reflect.ValueOf(target).Kind() == kind
+}
+
+func existsMapKey(m map[string]interface{}, k string) bool {
+	_, ok := m[k]
+	return ok
+}
+
+func isStringInSlice(s []string, what string) bool {
+	for i := range s {
+		if s[i] == what {
+			return true
+		}
+	}
+	return false
+}
+
+func marshalToJsonString(value interface{}) (*string, error) {
+
+	mBytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	sBytes := string(mBytes)
+	return &sBytes, nil
+}
+
+func isJsonNumber(what interface{}) bool {
+
+	switch what.(type) {
+
+	case json.Number:
+		return true
+	}
+
+	return false
+}
+
+func checkJsonNumber(what interface{}) (isValidFloat64 bool, isValidInt64 bool, isValidInt32 bool) {
+
+	jsonNumber := what.(json.Number)
+
+	f64, errFloat64 := jsonNumber.Float64()
+	s64 := strconv.FormatFloat(f64, 'f', -1, 64)
+	_, errInt64 := strconv.ParseInt(s64, 10, 64)
+
+	isValidFloat64 = errFloat64 == nil
+	isValidInt64 = errInt64 == nil
+
+	_, errInt32 := strconv.ParseInt(s64, 10, 32)
+	isValidInt32 = isValidInt64 && errInt32 == nil
+
+	return
+
+}
+
+// same as ECMA Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+const (
+	max_json_float = float64(1<<53 - 1)  // 9007199254740991.0 	 2^53 - 1
+	min_json_float = -float64(1<<53 - 1) //-9007199254740991.0	-2^53 - 1
+)
+
+func isFloat64AnInteger(f float64) bool {
+
+	if math.IsNaN(f) || math.IsInf(f, 0) || f < min_json_float || f > max_json_float {
+		return false
+	}
+
+	return f == float64(int64(f)) || f == float64(uint64(f))
+}
+
+func mustBeInteger(what interface{}) *int {
+
+	if isJsonNumber(what) {
+
+		number := what.(json.Number)
+
+		_, _, isValidInt32 := checkJsonNumber(number)
+
+		if isValidInt32 {
+
+			int64Value, err := number.Int64()
+			if err != nil {
+				return nil
+			}
+
+			int32Value := int(int64Value)
+			return &int32Value
+
+		} else {
+			return nil
+		}
+
+	}
+
+	return nil
+}
+
+func mustBeNumber(what interface{}) *float64 {
+
+	if isJsonNumber(what) {
+
+		number := what.(json.Number)
+		float64Value, err := number.Float64()
+
+		if err == nil {
+			return &float64Value
+		} else {
+			return nil
+		}
+
+	}
+
+	return nil
+
+}
+
+// formats a number so that it is displayed as the smallest string possible
+func resultErrorFormatJsonNumber(n json.Number) string {
+
+	if int64Value, err := n.Int64(); err == nil {
+		return fmt.Sprintf("%d", int64Value)
+	}
+
+	float64Value, _ := n.Float64()
+
+	return fmt.Sprintf("%g", float64Value)
+}
+
+// formats a number so that it is displayed as the smallest string possible
+func resultErrorFormatNumber(n float64) string {
+
+	if isFloat64AnInteger(n) {
+		return fmt.Sprintf("%d", int64(n))
+	}
+
+	return fmt.Sprintf("%g", n)
+}
+
+func convertDocumentNode(val interface{}) interface{} {
+
+	if lval, ok := val.([]interface{}); ok {
+
+		res := []interface{}{}
+		for _, v := range lval {
+			res = append(res, convertDocumentNode(v))
+		}
+
+		return res
+
+	}
+
+	if mval, ok := val.(map[interface{}]interface{}); ok {
+
+		res := map[string]interface{}{}
+
+		for k, v := range mval {
+			res[k.(string)] = convertDocumentNode(v)
+		}
+
+		return res
+
+	}
+
+	return val
+}

--- a/vendor/github.com/johandorland/gojsonschema/validation.go
+++ b/vendor/github.com/johandorland/gojsonschema/validation.go
@@ -1,0 +1,832 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Extends Schema and subSchema, implements the validation phase.
+//
+// created          28-02-2013
+
+package gojsonschema
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+func Validate(ls JSONLoader, ld JSONLoader) (*Result, error) {
+
+	var err error
+
+	// load schema
+
+	schema, err := NewSchema(ls)
+	if err != nil {
+		return nil, err
+	}
+
+	// begine validation
+
+	return schema.Validate(ld)
+
+}
+
+func (v *Schema) Validate(l JSONLoader) (*Result, error) {
+
+	// load document
+
+	root, err := l.LoadJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	// begin validation
+
+	result := &Result{}
+	context := newJsonContext(STRING_CONTEXT_ROOT, nil)
+	v.rootSchema.validateRecursive(v.rootSchema, root, result, context)
+
+	return result, nil
+
+}
+
+func (v *subSchema) subValidateWithContext(document interface{}, context *jsonContext) *Result {
+	result := &Result{}
+	v.validateRecursive(v, document, result, context)
+	return result
+}
+
+// Walker function to validate the json recursively against the subSchema
+func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateRecursive %s", context.String())
+		internalLog(" %v", currentNode)
+	}
+
+	// Handle referenced schemas, returns directly when a $ref is found
+	if currentSubSchema.refSchema != nil {
+		v.validateRecursive(currentSubSchema.refSchema, currentNode, result, context)
+		return
+	}
+
+	// Check for null value
+	if currentNode == nil {
+		if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_NULL) {
+			result.addError(
+				new(InvalidTypeError),
+				context,
+				currentNode,
+				ErrorDetails{
+					"expected": currentSubSchema.types.String(),
+					"given":    TYPE_NULL,
+				},
+			)
+			return
+		}
+
+		currentSubSchema.validateSchema(currentSubSchema, currentNode, result, context)
+		v.validateCommon(currentSubSchema, currentNode, result, context)
+
+	} else { // Not a null value
+
+		if isJsonNumber(currentNode) {
+
+			value := currentNode.(json.Number)
+
+			_, isValidInt64, _ := checkJsonNumber(value)
+
+			validType := currentSubSchema.types.Contains(TYPE_NUMBER) || (isValidInt64 && currentSubSchema.types.Contains(TYPE_INTEGER))
+
+			if currentSubSchema.types.IsTyped() && !validType {
+
+				givenType := TYPE_INTEGER
+				if !isValidInt64 {
+					givenType = TYPE_NUMBER
+				}
+
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    givenType,
+					},
+				)
+				return
+			}
+
+			currentSubSchema.validateSchema(currentSubSchema, value, result, context)
+			v.validateNumber(currentSubSchema, value, result, context)
+			v.validateCommon(currentSubSchema, value, result, context)
+			v.validateString(currentSubSchema, value, result, context)
+
+		} else {
+
+			rValue := reflect.ValueOf(currentNode)
+			rKind := rValue.Kind()
+
+			switch rKind {
+
+			// Slice => JSON array
+
+			case reflect.Slice:
+
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_ARRAY) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_ARRAY,
+						},
+					)
+					return
+				}
+
+				castCurrentNode := currentNode.([]interface{})
+
+				currentSubSchema.validateSchema(currentSubSchema, castCurrentNode, result, context)
+
+				v.validateArray(currentSubSchema, castCurrentNode, result, context)
+				v.validateCommon(currentSubSchema, castCurrentNode, result, context)
+
+			// Map => JSON object
+
+			case reflect.Map:
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_OBJECT) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_OBJECT,
+						},
+					)
+					return
+				}
+
+				castCurrentNode, ok := currentNode.(map[string]interface{})
+				if !ok {
+					castCurrentNode = convertDocumentNode(currentNode).(map[string]interface{})
+				}
+
+				currentSubSchema.validateSchema(currentSubSchema, castCurrentNode, result, context)
+
+				v.validateObject(currentSubSchema, castCurrentNode, result, context)
+				v.validateCommon(currentSubSchema, castCurrentNode, result, context)
+
+				for _, pSchema := range currentSubSchema.propertiesChildren {
+					nextNode, ok := castCurrentNode[pSchema.property]
+					if ok {
+						subContext := newJsonContext(pSchema.property, context)
+						v.validateRecursive(pSchema, nextNode, result, subContext)
+					}
+				}
+
+			// Simple JSON values : string, number, boolean
+
+			case reflect.Bool:
+
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_BOOLEAN) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_BOOLEAN,
+						},
+					)
+					return
+				}
+
+				value := currentNode.(bool)
+
+				currentSubSchema.validateSchema(currentSubSchema, value, result, context)
+				v.validateNumber(currentSubSchema, value, result, context)
+				v.validateCommon(currentSubSchema, value, result, context)
+				v.validateString(currentSubSchema, value, result, context)
+
+			case reflect.String:
+
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_STRING) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_STRING,
+						},
+					)
+					return
+				}
+
+				value := currentNode.(string)
+
+				currentSubSchema.validateSchema(currentSubSchema, value, result, context)
+				v.validateNumber(currentSubSchema, value, result, context)
+				v.validateCommon(currentSubSchema, value, result, context)
+				v.validateString(currentSubSchema, value, result, context)
+
+			}
+
+		}
+
+	}
+
+	result.incrementScore()
+}
+
+// Different kinds of validation there, subSchema / common / array / object / string...
+func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateSchema %s", context.String())
+		internalLog(" %v", currentNode)
+	}
+
+	if len(currentSubSchema.anyOf) > 0 {
+
+		validatedAnyOf := false
+		var bestValidationResult *Result
+
+		for _, anyOfSchema := range currentSubSchema.anyOf {
+			if !validatedAnyOf {
+				validationResult := anyOfSchema.subValidateWithContext(currentNode, context)
+				validatedAnyOf = validationResult.Valid()
+
+				if !validatedAnyOf && (bestValidationResult == nil || validationResult.score > bestValidationResult.score) {
+					bestValidationResult = validationResult
+				}
+			}
+		}
+		if !validatedAnyOf {
+
+			result.addError(new(NumberAnyOfError), context, currentNode, ErrorDetails{})
+
+			if bestValidationResult != nil {
+				// add error messages of closest matching subSchema as
+				// that's probably the one the user was trying to match
+				result.mergeErrors(bestValidationResult)
+			}
+		}
+	}
+
+	if len(currentSubSchema.oneOf) > 0 {
+
+		nbValidated := 0
+		var bestValidationResult *Result
+
+		for _, oneOfSchema := range currentSubSchema.oneOf {
+			validationResult := oneOfSchema.subValidateWithContext(currentNode, context)
+			if validationResult.Valid() {
+				nbValidated++
+			} else if nbValidated == 0 && (bestValidationResult == nil || validationResult.score > bestValidationResult.score) {
+				bestValidationResult = validationResult
+			}
+		}
+
+		if nbValidated != 1 {
+
+			result.addError(new(NumberOneOfError), context, currentNode, ErrorDetails{})
+
+			if nbValidated == 0 {
+				// add error messages of closest matching subSchema as
+				// that's probably the one the user was trying to match
+				result.mergeErrors(bestValidationResult)
+			}
+		}
+
+	}
+
+	if len(currentSubSchema.allOf) > 0 {
+		nbValidated := 0
+
+		for _, allOfSchema := range currentSubSchema.allOf {
+			validationResult := allOfSchema.subValidateWithContext(currentNode, context)
+			if validationResult.Valid() {
+				nbValidated++
+			}
+			result.mergeErrors(validationResult)
+		}
+
+		if nbValidated != len(currentSubSchema.allOf) {
+			result.addError(new(NumberAllOfError), context, currentNode, ErrorDetails{})
+		}
+	}
+
+	if currentSubSchema.not != nil {
+		validationResult := currentSubSchema.not.subValidateWithContext(currentNode, context)
+		if validationResult.Valid() {
+			result.addError(new(NumberNotError), context, currentNode, ErrorDetails{})
+		}
+	}
+
+	if currentSubSchema.dependencies != nil && len(currentSubSchema.dependencies) > 0 {
+		if isKind(currentNode, reflect.Map) {
+			for elementKey := range currentNode.(map[string]interface{}) {
+				if dependency, ok := currentSubSchema.dependencies[elementKey]; ok {
+					switch dependency := dependency.(type) {
+
+					case []string:
+						for _, dependOnKey := range dependency {
+							if _, dependencyResolved := currentNode.(map[string]interface{})[dependOnKey]; !dependencyResolved {
+								result.addError(
+									new(MissingDependencyError),
+									context,
+									currentNode,
+									ErrorDetails{"dependency": dependOnKey},
+								)
+							}
+						}
+
+					case *subSchema:
+						dependency.validateRecursive(dependency, currentNode, result, context)
+
+					}
+				}
+			}
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateCommon(currentSubSchema *subSchema, value interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateCommon %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	// enum:
+	if len(currentSubSchema.enum) > 0 {
+		has, err := currentSubSchema.ContainsEnum(value)
+		if err != nil {
+			result.addError(new(InternalError), context, value, ErrorDetails{"error": err})
+		}
+		if !has {
+			result.addError(
+				new(EnumError),
+				context,
+				value,
+				ErrorDetails{
+					"allowed": strings.Join(currentSubSchema.enum, ", "),
+				},
+			)
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateArray %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	nbValues := len(value)
+
+	// TODO explain
+	if currentSubSchema.itemsChildrenIsSingleSchema {
+		for i := range value {
+			subContext := newJsonContext(strconv.Itoa(i), context)
+			validationResult := currentSubSchema.itemsChildren[0].subValidateWithContext(value[i], subContext)
+			result.mergeErrors(validationResult)
+		}
+	} else {
+		if currentSubSchema.itemsChildren != nil && len(currentSubSchema.itemsChildren) > 0 {
+
+			nbItems := len(currentSubSchema.itemsChildren)
+
+			// while we have both schemas and values, check them against each other
+			for i := 0; i != nbItems && i != nbValues; i++ {
+				subContext := newJsonContext(strconv.Itoa(i), context)
+				validationResult := currentSubSchema.itemsChildren[i].subValidateWithContext(value[i], subContext)
+				result.mergeErrors(validationResult)
+			}
+
+			if nbItems < nbValues {
+				// we have less schemas than elements in the instance array,
+				// but that might be ok if "additionalItems" is specified.
+
+				switch currentSubSchema.additionalItems.(type) {
+				case bool:
+					if !currentSubSchema.additionalItems.(bool) {
+						result.addError(new(ArrayNoAdditionalItemsError), context, value, ErrorDetails{})
+					}
+				case *subSchema:
+					additionalItemSchema := currentSubSchema.additionalItems.(*subSchema)
+					for i := nbItems; i != nbValues; i++ {
+						subContext := newJsonContext(strconv.Itoa(i), context)
+						validationResult := additionalItemSchema.subValidateWithContext(value[i], subContext)
+						result.mergeErrors(validationResult)
+					}
+				}
+			}
+		}
+	}
+
+	// minItems & maxItems
+	if currentSubSchema.minItems != nil {
+		if nbValues < int(*currentSubSchema.minItems) {
+			result.addError(
+				new(ArrayMinItemsError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minItems},
+			)
+		}
+	}
+	if currentSubSchema.maxItems != nil {
+		if nbValues > int(*currentSubSchema.maxItems) {
+			result.addError(
+				new(ArrayMaxItemsError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxItems},
+			)
+		}
+	}
+
+	// uniqueItems:
+	if currentSubSchema.uniqueItems {
+		var stringifiedItems []string
+		for _, v := range value {
+			vString, err := marshalToJsonString(v)
+			if err != nil {
+				result.addError(new(InternalError), context, value, ErrorDetails{"err": err})
+			}
+			if isStringInSlice(stringifiedItems, *vString) {
+				result.addError(
+					new(ItemsMustBeUniqueError),
+					context,
+					value,
+					ErrorDetails{"type": TYPE_ARRAY},
+				)
+			}
+			stringifiedItems = append(stringifiedItems, *vString)
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string]interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateObject %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	// minProperties & maxProperties:
+	if currentSubSchema.minProperties != nil {
+		if len(value) < int(*currentSubSchema.minProperties) {
+			result.addError(
+				new(ArrayMinPropertiesError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minProperties},
+			)
+		}
+	}
+	if currentSubSchema.maxProperties != nil {
+		if len(value) > int(*currentSubSchema.maxProperties) {
+			result.addError(
+				new(ArrayMaxPropertiesError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxProperties},
+			)
+		}
+	}
+
+	// required:
+	for _, requiredProperty := range currentSubSchema.required {
+		_, ok := value[requiredProperty]
+		if ok {
+			result.incrementScore()
+		} else {
+			result.addError(
+				new(RequiredError),
+				context,
+				value,
+				ErrorDetails{"property": requiredProperty},
+			)
+		}
+	}
+
+	// additionalProperty & patternProperty:
+	if currentSubSchema.additionalProperties != nil {
+
+		switch currentSubSchema.additionalProperties.(type) {
+		case bool:
+
+			if !currentSubSchema.additionalProperties.(bool) {
+
+				for pk := range value {
+
+					found := false
+					for _, spValue := range currentSubSchema.propertiesChildren {
+						if pk == spValue.property {
+							found = true
+						}
+					}
+
+					pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
+
+					if found {
+
+						if pp_has && !pp_match {
+							result.addError(
+								new(AdditionalPropertyNotAllowedError),
+								context,
+								value[pk],
+								ErrorDetails{"property": pk},
+							)
+						}
+
+					} else {
+
+						if !pp_has || !pp_match {
+							result.addError(
+								new(AdditionalPropertyNotAllowedError),
+								context,
+								value[pk],
+								ErrorDetails{"property": pk},
+							)
+						}
+
+					}
+				}
+			}
+
+		case *subSchema:
+
+			additionalPropertiesSchema := currentSubSchema.additionalProperties.(*subSchema)
+			for pk := range value {
+
+				found := false
+				for _, spValue := range currentSubSchema.propertiesChildren {
+					if pk == spValue.property {
+						found = true
+					}
+				}
+
+				pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
+
+				if found {
+
+					if pp_has && !pp_match {
+						validationResult := additionalPropertiesSchema.subValidateWithContext(value[pk], context)
+						result.mergeErrors(validationResult)
+					}
+
+				} else {
+
+					if !pp_has || !pp_match {
+						validationResult := additionalPropertiesSchema.subValidateWithContext(value[pk], context)
+						result.mergeErrors(validationResult)
+					}
+
+				}
+
+			}
+		}
+	} else {
+
+		for pk := range value {
+
+			pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
+
+			if pp_has && !pp_match {
+
+				result.addError(
+					new(InvalidPropertyPatternError),
+					context,
+					value[pk],
+					ErrorDetails{
+						"property": pk,
+						"pattern":  currentSubSchema.PatternPropertiesString(),
+					},
+				)
+			}
+
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validatePatternProperty(currentSubSchema *subSchema, key string, value interface{}, result *Result, context *jsonContext) (has bool, matched bool) {
+
+	if internalLogEnabled {
+		internalLog("validatePatternProperty %s", context.String())
+		internalLog(" %s %v", key, value)
+	}
+
+	has = false
+
+	validatedkey := false
+
+	for pk, pv := range currentSubSchema.patternProperties {
+		if matches, _ := regexp.MatchString(pk, key); matches {
+			has = true
+			subContext := newJsonContext(key, context)
+			validationResult := pv.subValidateWithContext(value, subContext)
+			result.mergeErrors(validationResult)
+			if validationResult.Valid() {
+				validatedkey = true
+			}
+		}
+	}
+
+	if !validatedkey {
+		return has, false
+	}
+
+	result.incrementScore()
+
+	return has, true
+}
+
+func (v *subSchema) validateString(currentSubSchema *subSchema, value interface{}, result *Result, context *jsonContext) {
+
+	// Ignore JSON numbers
+	if isJsonNumber(value) {
+		return
+	}
+
+	// Ignore non strings
+	if !isKind(value, reflect.String) {
+		return
+	}
+
+	if internalLogEnabled {
+		internalLog("validateString %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	stringValue := value.(string)
+
+	// minLength & maxLength:
+	if currentSubSchema.minLength != nil {
+		if utf8.RuneCount([]byte(stringValue)) < int(*currentSubSchema.minLength) {
+			result.addError(
+				new(StringLengthGTEError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minLength},
+			)
+		}
+	}
+	if currentSubSchema.maxLength != nil {
+		if utf8.RuneCount([]byte(stringValue)) > int(*currentSubSchema.maxLength) {
+			result.addError(
+				new(StringLengthLTEError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxLength},
+			)
+		}
+	}
+
+	// pattern:
+	if currentSubSchema.pattern != nil {
+		if !currentSubSchema.pattern.MatchString(stringValue) {
+			result.addError(
+				new(DoesNotMatchPatternError),
+				context,
+				value,
+				ErrorDetails{"pattern": currentSubSchema.pattern},
+			)
+
+		}
+	}
+
+	// format
+	if currentSubSchema.format != "" {
+		if !FormatCheckers.IsFormat(currentSubSchema.format, stringValue) {
+			result.addError(
+				new(DoesNotMatchFormatError),
+				context,
+				value,
+				ErrorDetails{"format": currentSubSchema.format},
+			)
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{}, result *Result, context *jsonContext) {
+
+	// Ignore non numbers
+	if !isJsonNumber(value) {
+		return
+	}
+
+	if internalLogEnabled {
+		internalLog("validateNumber %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	number := value.(json.Number)
+	float64Value, _ := number.Float64()
+
+	// multipleOf:
+	if currentSubSchema.multipleOf != nil {
+
+		if !isFloat64AnInteger(float64Value / *currentSubSchema.multipleOf) {
+			result.addError(
+				new(MultipleOfError),
+				context,
+				resultErrorFormatJsonNumber(number),
+				ErrorDetails{"multiple": *currentSubSchema.multipleOf},
+			)
+		}
+	}
+
+	//maximum & exclusiveMaximum:
+	if currentSubSchema.maximum != nil {
+		if currentSubSchema.exclusiveMaximum {
+			if float64Value >= *currentSubSchema.maximum {
+				result.addError(
+					new(NumberLTError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"max": resultErrorFormatNumber(*currentSubSchema.maximum),
+					},
+				)
+			}
+		} else {
+			if float64Value > *currentSubSchema.maximum {
+				result.addError(
+					new(NumberLTEError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"max": resultErrorFormatNumber(*currentSubSchema.maximum),
+					},
+				)
+			}
+		}
+	}
+
+	//minimum & exclusiveMinimum:
+	if currentSubSchema.minimum != nil {
+		if currentSubSchema.exclusiveMinimum {
+			if float64Value <= *currentSubSchema.minimum {
+				result.addError(
+					new(NumberGTError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"min": resultErrorFormatNumber(*currentSubSchema.minimum),
+					},
+				)
+			}
+		} else {
+			if float64Value < *currentSubSchema.minimum {
+				result.addError(
+					new(NumberGTEError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"min": resultErrorFormatNumber(*currentSubSchema.minimum),
+					},
+				)
+			}
+		}
+	}
+
+	result.incrementScore()
+}

--- a/vendor/github.com/xeipuuv/gojsonpointer/LICENSE-APACHE-2.0.txt
+++ b/vendor/github.com/xeipuuv/gojsonpointer/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xeipuuv/gojsonpointer/README.md
+++ b/vendor/github.com/xeipuuv/gojsonpointer/README.md
@@ -1,0 +1,8 @@
+# gojsonpointer
+An implementation of JSON Pointer - Go language
+
+## References
+http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
+
+### Note
+The 4.Evaluation part of the previous reference, starting with 'If the currently referenced value is a JSON array, the reference token MUST contain either...' is not implemented.

--- a/vendor/github.com/xeipuuv/gojsonpointer/pointer.go
+++ b/vendor/github.com/xeipuuv/gojsonpointer/pointer.go
@@ -1,0 +1,190 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author  			xeipuuv
+// author-github 	https://github.com/xeipuuv
+// author-mail		xeipuuv@gmail.com
+//
+// repository-name	gojsonpointer
+// repository-desc	An implementation of JSON Pointer - Go language
+//
+// description		Main and unique file.
+//
+// created      	25-02-2013
+
+package gojsonpointer
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+const (
+	const_empty_pointer     = ``
+	const_pointer_separator = `/`
+
+	const_invalid_start = `JSON pointer must be empty or start with a "` + const_pointer_separator + `"`
+)
+
+type implStruct struct {
+	mode string // "SET" or "GET"
+
+	inDocument interface{}
+
+	setInValue interface{}
+
+	getOutNode interface{}
+	getOutKind reflect.Kind
+	outError   error
+}
+
+type JsonPointer struct {
+	referenceTokens []string
+}
+
+// NewJsonPointer parses the given string JSON pointer and returns an object
+func NewJsonPointer(jsonPointerString string) (p JsonPointer, err error) {
+
+	// Pointer to the root of the document
+	if len(jsonPointerString) == 0 {
+		// Keep referenceTokens nil
+		return
+	}
+	if jsonPointerString[0] != '/' {
+		return p, errors.New(const_invalid_start)
+	}
+
+	p.referenceTokens = strings.Split(jsonPointerString[1:], const_pointer_separator)
+	return
+}
+
+// Uses the pointer to retrieve a value from a JSON document
+func (p *JsonPointer) Get(document interface{}) (interface{}, reflect.Kind, error) {
+
+	is := &implStruct{mode: "GET", inDocument: document}
+	p.implementation(is)
+	return is.getOutNode, is.getOutKind, is.outError
+
+}
+
+// Uses the pointer to update a value from a JSON document
+func (p *JsonPointer) Set(document interface{}, value interface{}) (interface{}, error) {
+
+	is := &implStruct{mode: "SET", inDocument: document, setInValue: value}
+	p.implementation(is)
+	return document, is.outError
+
+}
+
+// Both Get and Set functions use the same implementation to avoid code duplication
+func (p *JsonPointer) implementation(i *implStruct) {
+
+	kind := reflect.Invalid
+
+	// Full document when empty
+	if len(p.referenceTokens) == 0 {
+		i.getOutNode = i.inDocument
+		i.outError = nil
+		i.getOutKind = kind
+		i.outError = nil
+		return
+	}
+
+	node := i.inDocument
+
+	for ti, token := range p.referenceTokens {
+
+		isLastToken := ti == len(p.referenceTokens)-1
+
+		switch v := node.(type) {
+
+		case map[string]interface{}:
+			decodedToken := decodeReferenceToken(token)
+			if _, ok := v[decodedToken]; ok {
+				node = v[decodedToken]
+				if isLastToken && i.mode == "SET" {
+					v[decodedToken] = i.setInValue
+				}
+			} else {
+				i.outError = fmt.Errorf("Object has no key '%s'", decodedToken)
+				i.getOutKind = reflect.Map
+				i.getOutNode = nil
+				return
+			}
+
+		case []interface{}:
+			tokenIndex, err := strconv.Atoi(token)
+			if err != nil {
+				i.outError = fmt.Errorf("Invalid array index '%s'", token)
+				i.getOutKind = reflect.Slice
+				i.getOutNode = nil
+				return
+			}
+			if tokenIndex < 0 || tokenIndex >= len(v) {
+				i.outError = fmt.Errorf("Out of bound array[0,%d] index '%d'", len(v), tokenIndex)
+				i.getOutKind = reflect.Slice
+				i.getOutNode = nil
+				return
+			}
+
+			node = v[tokenIndex]
+			if isLastToken && i.mode == "SET" {
+				v[tokenIndex] = i.setInValue
+			}
+
+		default:
+			i.outError = fmt.Errorf("Invalid token reference '%s'", token)
+			i.getOutKind = reflect.ValueOf(node).Kind()
+			i.getOutNode = nil
+			return
+		}
+
+	}
+
+	i.getOutNode = node
+	i.getOutKind = reflect.ValueOf(node).Kind()
+	i.outError = nil
+}
+
+// Pointer to string representation function
+func (p *JsonPointer) String() string {
+
+	if len(p.referenceTokens) == 0 {
+		return const_empty_pointer
+	}
+
+	pointerString := const_pointer_separator + strings.Join(p.referenceTokens, const_pointer_separator)
+
+	return pointerString
+}
+
+// Specific JSON pointer encoding here
+// ~0 => ~
+// ~1 => /
+// ... and vice versa
+
+func decodeReferenceToken(token string) string {
+	step1 := strings.Replace(token, `~1`, `/`, -1)
+	step2 := strings.Replace(step1, `~0`, `~`, -1)
+	return step2
+}
+
+func encodeReferenceToken(token string) string {
+	step1 := strings.Replace(token, `~`, `~0`, -1)
+	step2 := strings.Replace(step1, `/`, `~1`, -1)
+	return step2
+}

--- a/vendor/github.com/xeipuuv/gojsonreference/LICENSE-APACHE-2.0.txt
+++ b/vendor/github.com/xeipuuv/gojsonreference/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xeipuuv/gojsonreference/README.md
+++ b/vendor/github.com/xeipuuv/gojsonreference/README.md
@@ -1,0 +1,10 @@
+# gojsonreference
+An implementation of JSON Reference - Go language
+
+## Dependencies
+https://github.com/xeipuuv/gojsonpointer
+
+## References
+http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
+
+http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03

--- a/vendor/github.com/xeipuuv/gojsonreference/reference.go
+++ b/vendor/github.com/xeipuuv/gojsonreference/reference.go
@@ -1,0 +1,141 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author  			xeipuuv
+// author-github 	https://github.com/xeipuuv
+// author-mail		xeipuuv@gmail.com
+//
+// repository-name	gojsonreference
+// repository-desc	An implementation of JSON Reference - Go language
+//
+// description		Main and unique file.
+//
+// created      	26-02-2013
+
+package gojsonreference
+
+import (
+	"errors"
+	"github.com/xeipuuv/gojsonpointer"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	const_fragment_char = `#`
+)
+
+func NewJsonReference(jsonReferenceString string) (JsonReference, error) {
+
+	var r JsonReference
+	err := r.parse(jsonReferenceString)
+	return r, err
+
+}
+
+type JsonReference struct {
+	referenceUrl     *url.URL
+	referencePointer gojsonpointer.JsonPointer
+
+	HasFullUrl      bool
+	HasUrlPathOnly  bool
+	HasFragmentOnly bool
+	HasFileScheme   bool
+	HasFullFilePath bool
+}
+
+func (r *JsonReference) GetUrl() *url.URL {
+	return r.referenceUrl
+}
+
+func (r *JsonReference) GetPointer() *gojsonpointer.JsonPointer {
+	return &r.referencePointer
+}
+
+func (r *JsonReference) String() string {
+
+	if r.referenceUrl != nil {
+		return r.referenceUrl.String()
+	}
+
+	if r.HasFragmentOnly {
+		return const_fragment_char + r.referencePointer.String()
+	}
+
+	return r.referencePointer.String()
+}
+
+func (r *JsonReference) IsCanonical() bool {
+	return (r.HasFileScheme && r.HasFullFilePath) || (!r.HasFileScheme && r.HasFullUrl)
+}
+
+// "Constructor", parses the given string JSON reference
+func (r *JsonReference) parse(jsonReferenceString string) (err error) {
+
+	r.referenceUrl, err = url.Parse(jsonReferenceString)
+	if err != nil {
+		return
+	}
+	refUrl := r.referenceUrl
+
+	if refUrl.Scheme != "" && refUrl.Host != "" {
+		r.HasFullUrl = true
+	} else {
+		if refUrl.Path != "" {
+			r.HasUrlPathOnly = true
+		} else if refUrl.RawQuery == "" && refUrl.Fragment != "" {
+			r.HasFragmentOnly = true
+		}
+	}
+
+	r.HasFileScheme = refUrl.Scheme == "file"
+	if runtime.GOOS == "windows" {
+		// on Windows, a file URL may have an extra leading slash, and if it
+		// doesn't then its first component will be treated as the host by the
+		// Go runtime
+		if refUrl.Host == "" && strings.HasPrefix(refUrl.Path, "/") {
+			r.HasFullFilePath = filepath.IsAbs(refUrl.Path[1:])
+		} else {
+			r.HasFullFilePath = filepath.IsAbs(refUrl.Host + refUrl.Path)
+		}
+	} else {
+		r.HasFullFilePath = filepath.IsAbs(refUrl.Path)
+	}
+
+	// invalid json-pointer error means url has no json-pointer fragment. simply ignore error
+	r.referencePointer, _ = gojsonpointer.NewJsonPointer(refUrl.Fragment)
+
+	return
+}
+
+// Creates a new reference from a parent and a child
+// If the child cannot inherit from the parent, an error is returned
+func (r *JsonReference) Inherits(child JsonReference) (*JsonReference, error) {
+	childUrl := child.GetUrl()
+	parentUrl := r.GetUrl()
+	if childUrl == nil {
+		return nil, errors.New("childUrl is nil!")
+	}
+	if parentUrl == nil {
+		return nil, errors.New("parentUrl is nil!")
+	}
+
+	ref, err := NewJsonReference(parentUrl.ResolveReference(childUrl).String())
+	if err != nil {
+		return nil, err
+	}
+	return &ref, err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "lDmYYWGAAJtqnpOtF7lUKYPrzYg=",
+			"path": "github.com/johandorland/gojsonschema",
+			"revision": "6ee4c4d90b0d29163ea7792af726cf88e62a8f17",
+			"revisionTime": "2017-04-20T16:18:40Z"
+		},
+		{
 			"checksumSHA1": "EHjhpHipgm+XGccrRAms9AW3Ewk=",
 			"path": "github.com/mitchellh/mapstructure",
 			"revision": "d0303fe809921458f417bcf828397a65db30a7e4",
@@ -213,6 +219,18 @@
 			"path": "github.com/sanathkr/yaml",
 			"revision": "0056894fa522748ca336761ffeeeb6bbae654d07",
 			"revisionTime": "2017-08-19T20:10:35Z"
+		},
+		{
+			"checksumSHA1": "B9K+5clCq0PU8n8/utbKT0QjQyU=",
+			"path": "github.com/xeipuuv/gojsonpointer",
+			"revision": "6fe8760cad3569743d51ddbb243b26f8456742dc",
+			"revisionTime": "2017-02-25T23:34:18Z"
+		},
+		{
+			"checksumSHA1": "pSoUW+qY6LwIJ5lFwGohPU5HUpg=",
+			"path": "github.com/xeipuuv/gojsonreference",
+			"revision": "e02fc20de94c78484cd5ffb007f8af96be030a45",
+			"revisionTime": "2015-08-08T06:50:54Z"
 		},
 		{
 			"checksumSHA1": "vqc3a+oTUGX8PmD0TS+qQ7gmN8I=",


### PR DESCRIPTION
I'm attempting to use the generated schemas to validate some JSON templates.  I could not get the  current schemas to invalidate my invalid CloudFormation templates, which meant they also weren't really validating my valid templates.

After this change, the schemas support:
- Strict validation using additionalProperties = false. This has the unfortunate effect of causing validation errors against valid template features that are not included in the template yet (for example, intrinsic functions).  But there should be enough here for most basic templates, and I included some lenient definitions for things like the Outputs and Metadata sections.
- Correct definitions for resource types vs subproperty types
- Polymorphic types in the schema using anyOf
- Mixing "classic" CloudFormation resources with SAM resources in the same template: the resource types from the CloudFormation spec are included in the SAM schema
- Enforcing a specific Transform value for SAM-based templates

The test JSON templates were all validated with `aws cloudformation validate-template`, though that API does not seem to be very strict when it comes to missing resource properties that are marked as Required in the spec.  Hence, some templates will succeed against  `aws cloudformation validate-template`, but fail against the generated schemas.