### PR TITLE
Support MethodSettings on Serverless::API

### DIFF
--- a/cloudformation/aws-serverless-api.go
+++ b/cloudformation/aws-serverless-api.go
@@ -30,6 +30,11 @@ type AWSServerlessApi struct {
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi
 	DefinitionUri *AWSServerlessApi_DefinitionUri `json:"DefinitionUri,omitempty"`
 
+	// MethodSettings AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi
+	MethodSettings interface{} `json:"MethodSettings,omitempty"`
+
 	// Name AWS CloudFormation Property
 	// Required: false
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -20,8 +20,12 @@
                 "CodeUri": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
                     "Required": true,
-                    "PrimitiveTypes": [ "String" ],
-                    "Types": [ "S3Location" ],
+                    "PrimitiveTypes": [
+                        "String"
+                    ],
+                    "Types": [
+                        "S3Location"
+                    ],
                     "UpdateType": "Immutable"
                 },
                 "FunctionName": {
@@ -57,10 +61,18 @@
                 "Policies": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
                     "Required": false,
-                    "PrimitiveTypes": [ "String" ],
-                    "PrimitiveItemTypes": [ "String" ],
-                    "Types": [ "IAMPolicyDocument" ] ,
-                    "ItemTypes": [ "IAMPolicyDocument" ],
+                    "PrimitiveTypes": [
+                        "String"
+                    ],
+                    "PrimitiveItemTypes": [
+                        "String"
+                    ],
+                    "Types": [
+                        "IAMPolicyDocument"
+                    ],
+                    "ItemTypes": [
+                        "IAMPolicyDocument"
+                    ],
                     "UpdateType": "Immutable"
                 },
                 "Environment": {
@@ -127,8 +139,12 @@
                 "DefinitionUri": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi",
                     "Required": false,
-                    "PrimitiveTypes": [ "String" ],
-                    "Types": [ "S3Location" ],
+                    "PrimitiveTypes": [
+                        "String"
+                    ],
+                    "Types": [
+                        "S3Location"
+                    ],
                     "UpdateType": "Immutable"
                 },
                 "DefinitionBody": {
@@ -149,11 +165,17 @@
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 },
-                "Variables" :{
+                "Variables": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi",
                     "Required": false,
                     "Type": "Map",
                     "PrimitiveItemType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "MethodSettings": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi",
+                    "Required": false,
+                    "PrimitiveType": "Json",
                     "UpdateType": "Immutable"
                 }
             }
@@ -212,7 +234,18 @@
                 "Properties": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-types",
                     "Required": true,
-                    "Types": [ "S3Event", "SNSEvent", "SQSEvent", "KinesisEvent", "DynamoDBEvent", "ApiEvent", "ScheduleEvent", "CloudWatchEventEvent", "IoTRuleEvent", "AlexaSkillEvent" ],
+                    "Types": [
+                        "S3Event",
+                        "SNSEvent",
+                        "SQSEvent",
+                        "KinesisEvent",
+                        "DynamoDBEvent",
+                        "ApiEvent",
+                        "ScheduleEvent",
+                        "CloudWatchEventEvent",
+                        "IoTRuleEvent",
+                        "AlexaSkillEvent"
+                    ],
                     "UpdateType": "Immutable"
                 }
             }
@@ -229,8 +262,12 @@
                 "Events": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3",
                     "Required": true,
-                    "PrimitiveTypes": [ "String" ],
-                    "PrimitiveItemTypes": [ "String" ]
+                    "PrimitiveTypes": [
+                        "String"
+                    ],
+                    "PrimitiveItemTypes": [
+                        "String"
+                    ]
                 },
                 "Filter": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3",

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -30017,6 +30017,9 @@ var samSchema = `{
                                 }
                             ]
                         },
+                        "MethodSettings": {
+                            "type": "object"
+                        },
                         "Name": {
                             "type": "string"
                         },

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -30014,6 +30014,9 @@
                                 }
                             ]
                         },
+                        "MethodSettings": {
+                            "type": "object"
+                        },
                         "Name": {
                             "type": "string"
                         },

--- a/test/yaml/aws-serverless-api.yaml
+++ b/test/yaml/aws-serverless-api.yaml
@@ -53,3 +53,16 @@ Resources:
       CacheClusterSize: test-cache-cluster-size
       Variables:
         NAME: VALUE 
+
+  ServerlessApiWithMethodSettingsAsYAML:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: test-name
+      StageName: test-stage-name
+      MethodSettings:
+        LoggingLevel: ERROR
+        MetricsEnabled: true
+      CacheClusterEnabled: true
+      CacheClusterSize: test-cache-cluster-size
+      Variables:
+        NAME: VALUE


### PR DESCRIPTION
Serverless::API allows MethodSettings to pass through to control things like LoggingLevel. This fixes Goformation to allow those settings through rather than dropping them when processing a Serverless::API resource.

https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi