### PR TITLE
add ability to replace intrinsics for condition functions.

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -142,6 +142,11 @@ func replaceIntrinsicsRecursive(input interface{}) interface{} {
 			"Fn::Split",
 			"Fn::Sub",
 			"Fn::Transform",
+			"Fn::And",
+			"Fn::Equals",
+			"Fn::If",
+			"Fn::Not",
+			"Fn::Or",
 		}
 
 		for name, v := range intrinsic {


### PR DESCRIPTION
This will allow for vanilla no-op intrinsic processor:

```go
func noOpHandler(name string, input interface{}, template interface{}) interface{} {
	intrinsicFunc := map[string]interface{}{
		name: input,
	}

	b, err := json.Marshal(intrinsicFunc)
	if err != nil {
		panic(err)
	}

	return base64.StdEncoding.EncodeToString(b)
}
```