### PR TITLE
Add option to disable intrinsics processing

### DIFF
--- a/goformation_test.go
+++ b/goformation_test.go
@@ -526,6 +526,18 @@ var _ = Describe("Goformation", func() {
 		})
 	})
 
+	Context("with a YAML template with processing disabled", func() {
+
+		template, err := goformation.OpenWithOptions("test/yaml/aws-serverless-function-env-vars.yaml", &intrinsics.ProcessorOptions{
+			NoProcess: true,
+		})
+
+		It("should successfully validate the SAM template", func() {
+			Expect(err).To(BeNil())
+			Expect(template).ShouldNot(BeNil())
+		})
+	})
+
 	Context("with a SNS event source", func() {
 		event := cloudformation.AWSServerlessFunction_Properties{
 			SNSEvent: &cloudformation.AWSServerlessFunction_SNSEvent{

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -37,11 +37,13 @@ var defaultIntrinsicHandlers = map[string]IntrinsicHandler{
 }
 
 // ProcessorOptions allows customisation of the intrinsic function processor behaviour.
-// Initially, this only allows overriding of the handlers for each intrinsic function type
-// and overriding template paramters.
+// This allows disabling the processing of intrinsics,
+// overriding of the handlers for each intrinsic function type,
+// and overriding template parameters.
 type ProcessorOptions struct {
 	IntrinsicHandlerOverrides map[string]IntrinsicHandler
 	ParameterOverrides        map[string]interface{}
+	NoProcess                 bool
 }
 
 // nonResolvingHandler is a simple example of an intrinsic function handler function
@@ -78,14 +80,20 @@ func ProcessJSON(input []byte, options *ProcessorOptions) ([]byte, error) {
 		return nil, fmt.Errorf("invalid JSON: %s", err)
 	}
 
-	applyGlobals(unmarshalled, options)
+	var processed interface{}
 
-	overrideParameters(unmarshalled, options)
+	if options != nil && options.NoProcess {
+		processed = unmarshalled
+	} else {
+		applyGlobals(unmarshalled, options)
 
-	evaluateConditions(unmarshalled, options)
+		overrideParameters(unmarshalled, options)
 
-	// Process all of the intrinsic functions
-	processed := search(unmarshalled, unmarshalled, options)
+		evaluateConditions(unmarshalled, options)
+
+		// Process all of the intrinsic functions
+		processed = search(unmarshalled, unmarshalled, options)
+	}
 
 	// And return the result back as a []byte of JSON
 	result, err := json.MarshalIndent(processed, "", "  ")

--- a/intrinsics/intrinsics_test.go
+++ b/intrinsics/intrinsics_test.go
@@ -494,6 +494,38 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 	})
 
+	Context("with a processor options that has NoProcess set", func() {
+
+		input := `{"Resources":{"MyBucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":{"Ref":"BucketNameParameter"}}}}}`
+
+		opts := &ProcessorOptions{
+			NoProcess: true,
+		}
+		processed, err := ProcessJSON([]byte(input), opts)
+		It("should successfully process the template", func() {
+			Expect(processed).ShouldNot(BeNil())
+			Expect(err).Should(BeNil())
+		})
+
+		var result interface{}
+		err = json.Unmarshal(processed, &result)
+		It("should be valid JSON, and marshal to a Go type", func() {
+			Expect(processed).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		template := result.(map[string]interface{})
+		resources := template["Resources"].(map[string]interface{})
+		resource := resources["MyBucket"].(map[string]interface{})
+		properties := resource["Properties"].(map[string]interface{})
+		bucketName := properties["BucketName"].(map[string]interface{})
+
+		It("should have an unprocessed Ref", func() {
+			Expect(bucketName["Ref"]).To(Equal("BucketNameParameter"))
+		})
+
+	})
+
 	Context("with a template that contains intrinsics and conditions", func() {
 
 		const template = `{


### PR DESCRIPTION
I needed this for something I'm writing. Beats copying the custom tag unmarshaller code out of `intrinsics/intrinsics.go`.

This basically allows someone to use `OpenWithOptions` to get a template object that represents the unresolved original (`Ref`s intact, etc.)