### PR TITLE
fix property name in CreationPolicy

### DIFF
--- a/cloudformation/policies.go
+++ b/cloudformation/policies.go
@@ -6,8 +6,8 @@ type CreationPolicy struct {
 	// AutoScalingCreationPolicy specifies how many instances must signal success for the update to succeed.
 	AutoScalingCreationPolicy *AutoScalingCreationPolicy `json:"AutoScalingCreationPolicy,omitempty"`
 
-	// ResourcesSignal configures the number of required success signals and the length of time that AWS CloudFormation waits for those signals.
-	ResourcesSignal *ResourcesSignal `json:"ResourcesSignal,omitempty"`
+	// ResourceSignal configures the number of required success signals and the length of time that AWS CloudFormation waits for those signals.
+	ResourceSignal *ResourceSignal `json:"ResourceSignal,omitempty"`
 }
 
 // AutoScalingCreationPolicy specifies how many instances must signal success for the update to succeed.
@@ -17,8 +17,8 @@ type AutoScalingCreationPolicy struct {
 	MinSuccessfulInstancesPercent float64 `json:"MinSuccessfulInstancesPercent,omitempty"`
 }
 
-// ResourcesSignal configures the number of required success signals and the length of time that AWS CloudFormation waits for those signals.
-type ResourcesSignal struct {
+// ResourceSignal configures the number of required success signals and the length of time that AWS CloudFormation waits for those signals.
+type ResourceSignal struct {
 
 	// Count is the number of success signals AWS CloudFormation must receive before it sets the resource status as CREATE_COMPLETE. If the resource receives a failure signal or doesn't receive the specified number of signals before the timeout period expires, the resource creation fails and AWS CloudFormation rolls the stack back.
 	Count float64 `json:"Count,omitempty"`

--- a/cloudformation/policies_test.go
+++ b/cloudformation/policies_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Goformation", func() {
 					AutoScalingCreationPolicy: &cloudformation.AutoScalingCreationPolicy{
 						MinSuccessfulInstancesPercent: 10,
 					},
-					ResourcesSignal: &cloudformation.ResourcesSignal{
+					ResourceSignal: &cloudformation.ResourceSignal{
 						Count:   11,
 						Timeout: "test-timeout",
 					},
@@ -146,7 +146,7 @@ var _ = Describe("Goformation", func() {
 					"AutoScalingCreationPolicy": map[string]interface{}{
 						"MinSuccessfulInstancesPercent": float64(10),
 					},
-					"ResourcesSignal": map[string]interface{}{
+					"ResourceSignal": map[string]interface{}{
 						"Count":   float64(11),
 						"Timeout": "test-timeout",
 					},


### PR DESCRIPTION
As mentioned in issue [#130](https://github.com/awslabs/goformation/issues/130) there was a typo on the name of a property of the CloudFormation's attribue "CreationPolicy".
You can check the official [doc](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html).