### PR TITLE
Don't omit required numberic/boolean properties

### DIFF
--- a/cloudformation/aws-amazonmq-broker.go
+++ b/cloudformation/aws-amazonmq-broker.go
@@ -13,7 +13,7 @@ type AWSAmazonMQBroker struct {
 	// AutoMinorVersionUpgrade AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-autominorversionupgrade
-	AutoMinorVersionUpgrade bool `json:"AutoMinorVersionUpgrade,omitempty"`
+	AutoMinorVersionUpgrade bool `json:"AutoMinorVersionUpgrade"`
 
 	// BrokerName AWS CloudFormation Property
 	// Required: true
@@ -58,7 +58,7 @@ type AWSAmazonMQBroker struct {
 	// PubliclyAccessible AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-publiclyaccessible
-	PubliclyAccessible bool `json:"PubliclyAccessible,omitempty"`
+	PubliclyAccessible bool `json:"PubliclyAccessible"`
 
 	// SecurityGroups AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-amazonmq-broker_configurationid.go
+++ b/cloudformation/aws-amazonmq-broker_configurationid.go
@@ -12,7 +12,7 @@ type AWSAmazonMQBroker_ConfigurationId struct {
 	// Revision AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-configurationid.html#cfn-amazonmq-broker-configurationid-revision
-	Revision int `json:"Revision,omitempty"`
+	Revision int `json:"Revision"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-applicationautoscaling-scalabletarget.go
+++ b/cloudformation/aws-applicationautoscaling-scalabletarget.go
@@ -13,12 +13,12 @@ type AWSApplicationAutoScalingScalableTarget struct {
 	// MaxCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalabletarget.html#cfn-applicationautoscaling-scalabletarget-maxcapacity
-	MaxCapacity int `json:"MaxCapacity,omitempty"`
+	MaxCapacity int `json:"MaxCapacity"`
 
 	// MinCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalabletarget.html#cfn-applicationautoscaling-scalabletarget-mincapacity
-	MinCapacity int `json:"MinCapacity,omitempty"`
+	MinCapacity int `json:"MinCapacity"`
 
 	// ResourceId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-applicationautoscaling-scalingpolicy_stepadjustment.go
+++ b/cloudformation/aws-applicationautoscaling-scalingpolicy_stepadjustment.go
@@ -17,7 +17,7 @@ type AWSApplicationAutoScalingScalingPolicy_StepAdjustment struct {
 	// ScalingAdjustment AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-stepscalingpolicyconfiguration-stepadjustment.html#cfn-applicationautoscaling-scalingpolicy-stepscalingpolicyconfiguration-stepadjustment-scalingadjustment
-	ScalingAdjustment int `json:"ScalingAdjustment,omitempty"`
+	ScalingAdjustment int `json:"ScalingAdjustment"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-applicationautoscaling-scalingpolicy_targettrackingscalingpolicyconfiguration.go
+++ b/cloudformation/aws-applicationautoscaling-scalingpolicy_targettrackingscalingpolicyconfiguration.go
@@ -32,7 +32,7 @@ type AWSApplicationAutoScalingScalingPolicy_TargetTrackingScalingPolicyConfigura
 	// TargetValue AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-targettrackingscalingpolicyconfiguration.html#cfn-applicationautoscaling-scalingpolicy-targettrackingscalingpolicyconfiguration-targetvalue
-	TargetValue float64 `json:"TargetValue,omitempty"`
+	TargetValue float64 `json:"TargetValue"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-autoscaling-autoscalinggroup_tagproperty.go
+++ b/cloudformation/aws-autoscaling-autoscalinggroup_tagproperty.go
@@ -12,7 +12,7 @@ type AWSAutoScalingAutoScalingGroup_TagProperty struct {
 	// PropagateAtLaunch AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-tags.html#cfn-as-tags-PropagateAtLaunch
-	PropagateAtLaunch bool `json:"PropagateAtLaunch,omitempty"`
+	PropagateAtLaunch bool `json:"PropagateAtLaunch"`
 
 	// Value AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-autoscaling-scalingpolicy_stepadjustment.go
+++ b/cloudformation/aws-autoscaling-scalingpolicy_stepadjustment.go
@@ -17,7 +17,7 @@ type AWSAutoScalingScalingPolicy_StepAdjustment struct {
 	// ScalingAdjustment AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-stepadjustments.html#cfn-autoscaling-scalingpolicy-stepadjustment-scalingadjustment
-	ScalingAdjustment int `json:"ScalingAdjustment,omitempty"`
+	ScalingAdjustment int `json:"ScalingAdjustment"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-autoscaling-scalingpolicy_targettrackingconfiguration.go
+++ b/cloudformation/aws-autoscaling-scalingpolicy_targettrackingconfiguration.go
@@ -22,7 +22,7 @@ type AWSAutoScalingScalingPolicy_TargetTrackingConfiguration struct {
 	// TargetValue AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-targettrackingconfiguration.html#cfn-autoscaling-scalingpolicy-targettrackingconfiguration-targetvalue
-	TargetValue float64 `json:"TargetValue,omitempty"`
+	TargetValue float64 `json:"TargetValue"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-autoscalingplans-scalingplan_scalinginstruction.go
+++ b/cloudformation/aws-autoscalingplans-scalingplan_scalinginstruction.go
@@ -7,12 +7,12 @@ type AWSAutoScalingPlansScalingPlan_ScalingInstruction struct {
 	// MaxCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-maxcapacity
-	MaxCapacity int `json:"MaxCapacity,omitempty"`
+	MaxCapacity int `json:"MaxCapacity"`
 
 	// MinCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-mincapacity
-	MinCapacity int `json:"MinCapacity,omitempty"`
+	MinCapacity int `json:"MinCapacity"`
 
 	// ResourceId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-autoscalingplans-scalingplan_targettrackingconfiguration.go
+++ b/cloudformation/aws-autoscalingplans-scalingplan_targettrackingconfiguration.go
@@ -37,7 +37,7 @@ type AWSAutoScalingPlansScalingPlan_TargetTrackingConfiguration struct {
 	// TargetValue AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-targettrackingconfiguration.html#cfn-autoscalingplans-scalingplan-targettrackingconfiguration-targetvalue
-	TargetValue float64 `json:"TargetValue,omitempty"`
+	TargetValue float64 `json:"TargetValue"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-batch-computeenvironment_computeresources.go
+++ b/cloudformation/aws-batch-computeenvironment_computeresources.go
@@ -37,12 +37,12 @@ type AWSBatchComputeEnvironment_ComputeResources struct {
 	// MaxvCpus AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-maxvcpus
-	MaxvCpus int `json:"MaxvCpus,omitempty"`
+	MaxvCpus int `json:"MaxvCpus"`
 
 	// MinvCpus AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-minvcpus
-	MinvCpus int `json:"MinvCpus,omitempty"`
+	MinvCpus int `json:"MinvCpus"`
 
 	// SecurityGroupIds AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-batch-jobdefinition_containerproperties.go
+++ b/cloudformation/aws-batch-jobdefinition_containerproperties.go
@@ -27,7 +27,7 @@ type AWSBatchJobDefinition_ContainerProperties struct {
 	// Memory AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-memory
-	Memory int `json:"Memory,omitempty"`
+	Memory int `json:"Memory"`
 
 	// MountPoints AWS CloudFormation Property
 	// Required: false
@@ -57,7 +57,7 @@ type AWSBatchJobDefinition_ContainerProperties struct {
 	// Vcpus AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-vcpus
-	Vcpus int `json:"Vcpus,omitempty"`
+	Vcpus int `json:"Vcpus"`
 
 	// Volumes AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-batch-jobdefinition_ulimit.go
+++ b/cloudformation/aws-batch-jobdefinition_ulimit.go
@@ -7,7 +7,7 @@ type AWSBatchJobDefinition_Ulimit struct {
 	// HardLimit AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-ulimit.html#cfn-batch-jobdefinition-ulimit-hardlimit
-	HardLimit int `json:"HardLimit,omitempty"`
+	HardLimit int `json:"HardLimit"`
 
 	// Name AWS CloudFormation Property
 	// Required: true
@@ -17,7 +17,7 @@ type AWSBatchJobDefinition_Ulimit struct {
 	// SoftLimit AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-ulimit.html#cfn-batch-jobdefinition-ulimit-softlimit
-	SoftLimit int `json:"SoftLimit,omitempty"`
+	SoftLimit int `json:"SoftLimit"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-batch-jobqueue.go
+++ b/cloudformation/aws-batch-jobqueue.go
@@ -23,7 +23,7 @@ type AWSBatchJobQueue struct {
 	// Priority AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobqueue.html#cfn-batch-jobqueue-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// State AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-batch-jobqueue_computeenvironmentorder.go
+++ b/cloudformation/aws-batch-jobqueue_computeenvironmentorder.go
@@ -12,7 +12,7 @@ type AWSBatchJobQueue_ComputeEnvironmentOrder struct {
 	// Order AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobqueue-computeenvironmentorder.html#cfn-batch-jobqueue-computeenvironmentorder-order
-	Order int `json:"Order,omitempty"`
+	Order int `json:"Order"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-budgets-budget_notification.go
+++ b/cloudformation/aws-budgets-budget_notification.go
@@ -17,7 +17,7 @@ type AWSBudgetsBudget_Notification struct {
 	// Threshold AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold
-	Threshold float64 `json:"Threshold,omitempty"`
+	Threshold float64 `json:"Threshold"`
 
 	// ThresholdType AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-budgets-budget_spend.go
+++ b/cloudformation/aws-budgets-budget_spend.go
@@ -7,7 +7,7 @@ type AWSBudgetsBudget_Spend struct {
 	// Amount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-spend.html#cfn-budgets-budget-spend-amount
-	Amount float64 `json:"Amount,omitempty"`
+	Amount float64 `json:"Amount"`
 
 	// Unit AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-cloudfront-distribution_customerrorresponse.go
+++ b/cloudformation/aws-cloudfront-distribution_customerrorresponse.go
@@ -12,7 +12,7 @@ type AWSCloudFrontDistribution_CustomErrorResponse struct {
 	// ErrorCode AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-customerrorresponse.html#cfn-cloudfront-distribution-customerrorresponse-errorcode
-	ErrorCode int `json:"ErrorCode,omitempty"`
+	ErrorCode int `json:"ErrorCode"`
 
 	// ResponseCode AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-cloudfront-distribution_distributionconfig.go
+++ b/cloudformation/aws-cloudfront-distribution_distributionconfig.go
@@ -37,7 +37,7 @@ type AWSCloudFrontDistribution_DistributionConfig struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html#cfn-cloudfront-distribution-distributionconfig-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// HttpVersion AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-cloudfront-distribution_forwardedvalues.go
+++ b/cloudformation/aws-cloudfront-distribution_forwardedvalues.go
@@ -17,7 +17,7 @@ type AWSCloudFrontDistribution_ForwardedValues struct {
 	// QueryString AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-forwardedvalues.html#cfn-cloudfront-distribution-forwardedvalues-querystring
-	QueryString bool `json:"QueryString,omitempty"`
+	QueryString bool `json:"QueryString"`
 
 	// QueryStringCacheKeys AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-cloudfront-streamingdistribution_logging.go
+++ b/cloudformation/aws-cloudfront-streamingdistribution_logging.go
@@ -12,7 +12,7 @@ type AWSCloudFrontStreamingDistribution_Logging struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-streamingdistribution-logging.html#cfn-cloudfront-streamingdistribution-logging-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// Prefix AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-cloudfront-streamingdistribution_streamingdistributionconfig.go
+++ b/cloudformation/aws-cloudfront-streamingdistribution_streamingdistributionconfig.go
@@ -17,7 +17,7 @@ type AWSCloudFrontStreamingDistribution_StreamingDistributionConfig struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-streamingdistribution-streamingdistributionconfig.html#cfn-cloudfront-streamingdistribution-streamingdistributionconfig-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// Logging AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-cloudfront-streamingdistribution_trustedsigners.go
+++ b/cloudformation/aws-cloudfront-streamingdistribution_trustedsigners.go
@@ -12,7 +12,7 @@ type AWSCloudFrontStreamingDistribution_TrustedSigners struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-streamingdistribution-trustedsigners.html#cfn-cloudfront-streamingdistribution-trustedsigners-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-cloudtrail-trail.go
+++ b/cloudformation/aws-cloudtrail-trail.go
@@ -38,7 +38,7 @@ type AWSCloudTrailTrail struct {
 	// IsLogging AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html#cfn-cloudtrail-trail-islogging
-	IsLogging bool `json:"IsLogging,omitempty"`
+	IsLogging bool `json:"IsLogging"`
 
 	// IsMultiRegionTrail AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-cloudwatch-alarm.go
+++ b/cloudformation/aws-cloudwatch-alarm.go
@@ -48,7 +48,7 @@ type AWSCloudWatchAlarm struct {
 	// EvaluationPeriods AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-evaluationperiods
-	EvaluationPeriods int `json:"EvaluationPeriods,omitempty"`
+	EvaluationPeriods int `json:"EvaluationPeriods"`
 
 	// ExtendedStatistic AWS CloudFormation Property
 	// Required: false
@@ -78,7 +78,7 @@ type AWSCloudWatchAlarm struct {
 	// Period AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-period
-	Period int `json:"Period,omitempty"`
+	Period int `json:"Period"`
 
 	// Statistic AWS CloudFormation Property
 	// Required: false
@@ -88,7 +88,7 @@ type AWSCloudWatchAlarm struct {
 	// Threshold AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold
-	Threshold float64 `json:"Threshold,omitempty"`
+	Threshold float64 `json:"Threshold"`
 
 	// TreatMissingData AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-codedeploy-deploymentconfig_minimumhealthyhosts.go
+++ b/cloudformation/aws-codedeploy-deploymentconfig_minimumhealthyhosts.go
@@ -12,7 +12,7 @@ type AWSCodeDeployDeploymentConfig_MinimumHealthyHosts struct {
 	// Value AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codedeploy-deploymentconfig-minimumhealthyhosts.html#cfn-codedeploy-deploymentconfig-minimumhealthyhosts-value
-	Value int `json:"Value,omitempty"`
+	Value int `json:"Value"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-codepipeline-customactiontype_artifactdetails.go
+++ b/cloudformation/aws-codepipeline-customactiontype_artifactdetails.go
@@ -7,12 +7,12 @@ type AWSCodePipelineCustomActionType_ArtifactDetails struct {
 	// MaximumCount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-artifactdetails.html#cfn-codepipeline-customactiontype-artifactdetails-maximumcount
-	MaximumCount int `json:"MaximumCount,omitempty"`
+	MaximumCount int `json:"MaximumCount"`
 
 	// MinimumCount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-artifactdetails.html#cfn-codepipeline-customactiontype-artifactdetails-minimumcount
-	MinimumCount int `json:"MinimumCount,omitempty"`
+	MinimumCount int `json:"MinimumCount"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-codepipeline-customactiontype_configurationproperties.go
+++ b/cloudformation/aws-codepipeline-customactiontype_configurationproperties.go
@@ -12,7 +12,7 @@ type AWSCodePipelineCustomActionType_ConfigurationProperties struct {
 	// Key AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-key
-	Key bool `json:"Key,omitempty"`
+	Key bool `json:"Key"`
 
 	// Name AWS CloudFormation Property
 	// Required: true
@@ -27,12 +27,12 @@ type AWSCodePipelineCustomActionType_ConfigurationProperties struct {
 	// Required AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-required
-	Required bool `json:"Required,omitempty"`
+	Required bool `json:"Required"`
 
 	// Secret AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-configurationproperties.html#cfn-codepipeline-customactiontype-configurationproperties-secret
-	Secret bool `json:"Secret,omitempty"`
+	Secret bool `json:"Secret"`
 
 	// Type AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-codepipeline-webhook.go
+++ b/cloudformation/aws-codepipeline-webhook.go
@@ -48,7 +48,7 @@ type AWSCodePipelineWebhook struct {
 	// TargetPipelineVersion AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-webhook.html#cfn-codepipeline-webhook-targetpipelineversion
-	TargetPipelineVersion int `json:"TargetPipelineVersion,omitempty"`
+	TargetPipelineVersion int `json:"TargetPipelineVersion"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-cognito-identitypool.go
+++ b/cloudformation/aws-cognito-identitypool.go
@@ -13,7 +13,7 @@ type AWSCognitoIdentityPool struct {
 	// AllowUnauthenticatedIdentities AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html#cfn-cognito-identitypool-allowunauthenticatedidentities
-	AllowUnauthenticatedIdentities bool `json:"AllowUnauthenticatedIdentities,omitempty"`
+	AllowUnauthenticatedIdentities bool `json:"AllowUnauthenticatedIdentities"`
 
 	// CognitoEvents AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-dax-cluster.go
+++ b/cloudformation/aws-dax-cluster.go
@@ -53,7 +53,7 @@ type AWSDAXCluster struct {
 	// ReplicationFactor AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dax-cluster.html#cfn-dax-cluster-replicationfactor
-	ReplicationFactor int `json:"ReplicationFactor,omitempty"`
+	ReplicationFactor int `json:"ReplicationFactor"`
 
 	// SSESpecification AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-dynamodb-table_provisionedthroughput.go
+++ b/cloudformation/aws-dynamodb-table_provisionedthroughput.go
@@ -7,12 +7,12 @@ type AWSDynamoDBTable_ProvisionedThroughput struct {
 	// ReadCapacityUnits AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html#cfn-dynamodb-provisionedthroughput-readcapacityunits
-	ReadCapacityUnits int64 `json:"ReadCapacityUnits,omitempty"`
+	ReadCapacityUnits int64 `json:"ReadCapacityUnits"`
 
 	// WriteCapacityUnits AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html#cfn-dynamodb-provisionedthroughput-writecapacityunits
-	WriteCapacityUnits int64 `json:"WriteCapacityUnits,omitempty"`
+	WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-dynamodb-table_ssespecification.go
+++ b/cloudformation/aws-dynamodb-table_ssespecification.go
@@ -7,7 +7,7 @@ type AWSDynamoDBTable_SSESpecification struct {
 	// SSEEnabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html#cfn-dynamodb-table-ssespecification-sseenabled
-	SSEEnabled bool `json:"SSEEnabled,omitempty"`
+	SSEEnabled bool `json:"SSEEnabled"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-dynamodb-table_timetolivespecification.go
+++ b/cloudformation/aws-dynamodb-table_timetolivespecification.go
@@ -12,7 +12,7 @@ type AWSDynamoDBTable_TimeToLiveSpecification struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-timetolivespecification.html#cfn-dynamodb-timetolivespecification-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-ec2-customergateway.go
+++ b/cloudformation/aws-ec2-customergateway.go
@@ -13,7 +13,7 @@ type AWSEC2CustomerGateway struct {
 	// BgpAsn AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-bgpasn
-	BgpAsn int `json:"BgpAsn,omitempty"`
+	BgpAsn int `json:"BgpAsn"`
 
 	// IpAddress AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-ec2-instance_privateipaddressspecification.go
+++ b/cloudformation/aws-ec2-instance_privateipaddressspecification.go
@@ -7,7 +7,7 @@ type AWSEC2Instance_PrivateIpAddressSpecification struct {
 	// Primary AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html#cfn-ec2-networkinterface-privateipspecification-primary
-	Primary bool `json:"Primary,omitempty"`
+	Primary bool `json:"Primary"`
 
 	// PrivateIpAddress AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-ec2-networkaclentry.go
+++ b/cloudformation/aws-ec2-networkaclentry.go
@@ -43,7 +43,7 @@ type AWSEC2NetworkAclEntry struct {
 	// Protocol AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-protocol
-	Protocol int `json:"Protocol,omitempty"`
+	Protocol int `json:"Protocol"`
 
 	// RuleAction AWS CloudFormation Property
 	// Required: true
@@ -53,7 +53,7 @@ type AWSEC2NetworkAclEntry struct {
 	// RuleNumber AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber
-	RuleNumber int `json:"RuleNumber,omitempty"`
+	RuleNumber int `json:"RuleNumber"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-ec2-networkinterface_privateipaddressspecification.go
+++ b/cloudformation/aws-ec2-networkinterface_privateipaddressspecification.go
@@ -7,7 +7,7 @@ type AWSEC2NetworkInterface_PrivateIpAddressSpecification struct {
 	// Primary AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html#cfn-ec2-networkinterface-privateipspecification-primary
-	Primary bool `json:"Primary,omitempty"`
+	Primary bool `json:"Primary"`
 
 	// PrivateIpAddress AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-ec2-spotfleet_spotfleetrequestconfigdata.go
+++ b/cloudformation/aws-ec2-spotfleet_spotfleetrequestconfigdata.go
@@ -52,7 +52,7 @@ type AWSEC2SpotFleet_SpotFleetRequestConfigData struct {
 	// TargetCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-targetcapacity
-	TargetCapacity int `json:"TargetCapacity,omitempty"`
+	TargetCapacity int `json:"TargetCapacity"`
 
 	// TerminateInstancesWithExpiration AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-ecs-service_loadbalancer.go
+++ b/cloudformation/aws-ecs-service_loadbalancer.go
@@ -12,7 +12,7 @@ type AWSECSService_LoadBalancer struct {
 	// ContainerPort AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-loadbalancers.html#cfn-ecs-service-loadbalancers-containerport
-	ContainerPort int `json:"ContainerPort,omitempty"`
+	ContainerPort int `json:"ContainerPort"`
 
 	// LoadBalancerName AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-ecs-taskdefinition_ulimit.go
+++ b/cloudformation/aws-ecs-taskdefinition_ulimit.go
@@ -7,7 +7,7 @@ type AWSECSTaskDefinition_Ulimit struct {
 	// HardLimit AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-ulimit.html#cfn-ecs-taskdefinition-containerdefinition-ulimit-hardlimit
-	HardLimit int `json:"HardLimit,omitempty"`
+	HardLimit int `json:"HardLimit"`
 
 	// Name AWS CloudFormation Property
 	// Required: true
@@ -17,7 +17,7 @@ type AWSECSTaskDefinition_Ulimit struct {
 	// SoftLimit AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-ulimit.html#cfn-ecs-taskdefinition-containerdefinition-ulimit-softlimit
-	SoftLimit int `json:"SoftLimit,omitempty"`
+	SoftLimit int `json:"SoftLimit"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-elasticache-cachecluster.go
+++ b/cloudformation/aws-elasticache-cachecluster.go
@@ -63,7 +63,7 @@ type AWSElastiCacheCacheCluster struct {
 	// NumCacheNodes AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-numcachenodes
-	NumCacheNodes int `json:"NumCacheNodes,omitempty"`
+	NumCacheNodes int `json:"NumCacheNodes"`
 
 	// Port AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-elasticloadbalancing-loadbalancer_accessloggingpolicy.go
+++ b/cloudformation/aws-elasticloadbalancing-loadbalancer_accessloggingpolicy.go
@@ -12,7 +12,7 @@ type AWSElasticLoadBalancingLoadBalancer_AccessLoggingPolicy struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-accessloggingpolicy.html#cfn-elb-accessloggingpolicy-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// S3BucketName AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-elasticloadbalancing-loadbalancer_connectiondrainingpolicy.go
+++ b/cloudformation/aws-elasticloadbalancing-loadbalancer_connectiondrainingpolicy.go
@@ -7,7 +7,7 @@ type AWSElasticLoadBalancingLoadBalancer_ConnectionDrainingPolicy struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-connectiondrainingpolicy.html#cfn-elb-connectiondrainingpolicy-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// Timeout AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-elasticloadbalancing-loadbalancer_connectionsettings.go
+++ b/cloudformation/aws-elasticloadbalancing-loadbalancer_connectionsettings.go
@@ -7,7 +7,7 @@ type AWSElasticLoadBalancingLoadBalancer_ConnectionSettings struct {
 	// IdleTimeout AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-connectionsettings.html#cfn-elb-connectionsettings-idletimeout
-	IdleTimeout int `json:"IdleTimeout,omitempty"`
+	IdleTimeout int `json:"IdleTimeout"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-elasticloadbalancingv2-listener.go
+++ b/cloudformation/aws-elasticloadbalancingv2-listener.go
@@ -28,7 +28,7 @@ type AWSElasticLoadBalancingV2Listener struct {
 	// Port AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html#cfn-elasticloadbalancingv2-listener-port
-	Port int `json:"Port,omitempty"`
+	Port int `json:"Port"`
 
 	// Protocol AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-elasticloadbalancingv2-listenerrule.go
+++ b/cloudformation/aws-elasticloadbalancingv2-listenerrule.go
@@ -28,7 +28,7 @@ type AWSElasticLoadBalancingV2ListenerRule struct {
 	// Priority AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html#cfn-elasticloadbalancingv2-listenerrule-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-elasticloadbalancingv2-targetgroup.go
+++ b/cloudformation/aws-elasticloadbalancingv2-targetgroup.go
@@ -53,7 +53,7 @@ type AWSElasticLoadBalancingV2TargetGroup struct {
 	// Port AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-port
-	Port int `json:"Port,omitempty"`
+	Port int `json:"Port"`
 
 	// Protocol AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-emr-cluster_cloudwatchalarmdefinition.go
+++ b/cloudformation/aws-emr-cluster_cloudwatchalarmdefinition.go
@@ -32,7 +32,7 @@ type AWSEMRCluster_CloudWatchAlarmDefinition struct {
 	// Period AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-cloudwatchalarmdefinition.html#cfn-elasticmapreduce-cluster-cloudwatchalarmdefinition-period
-	Period int `json:"Period,omitempty"`
+	Period int `json:"Period"`
 
 	// Statistic AWS CloudFormation Property
 	// Required: false
@@ -42,7 +42,7 @@ type AWSEMRCluster_CloudWatchAlarmDefinition struct {
 	// Threshold AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-cloudwatchalarmdefinition.html#cfn-elasticmapreduce-cluster-cloudwatchalarmdefinition-threshold
-	Threshold float64 `json:"Threshold,omitempty"`
+	Threshold float64 `json:"Threshold"`
 
 	// Unit AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-emr-cluster_instancegroupconfig.go
+++ b/cloudformation/aws-emr-cluster_instancegroupconfig.go
@@ -27,7 +27,7 @@ type AWSEMRCluster_InstanceGroupConfig struct {
 	// InstanceCount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-instancegroupconfig.html#cfn-elasticmapreduce-cluster-instancegroupconfig-instancecount
-	InstanceCount int `json:"InstanceCount,omitempty"`
+	InstanceCount int `json:"InstanceCount"`
 
 	// InstanceType AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-emr-cluster_scalingconstraints.go
+++ b/cloudformation/aws-emr-cluster_scalingconstraints.go
@@ -7,12 +7,12 @@ type AWSEMRCluster_ScalingConstraints struct {
 	// MaxCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-scalingconstraints.html#cfn-elasticmapreduce-cluster-scalingconstraints-maxcapacity
-	MaxCapacity int `json:"MaxCapacity,omitempty"`
+	MaxCapacity int `json:"MaxCapacity"`
 
 	// MinCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-scalingconstraints.html#cfn-elasticmapreduce-cluster-scalingconstraints-mincapacity
-	MinCapacity int `json:"MinCapacity,omitempty"`
+	MinCapacity int `json:"MinCapacity"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-emr-cluster_simplescalingpolicyconfiguration.go
+++ b/cloudformation/aws-emr-cluster_simplescalingpolicyconfiguration.go
@@ -17,7 +17,7 @@ type AWSEMRCluster_SimpleScalingPolicyConfiguration struct {
 	// ScalingAdjustment AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-simplescalingpolicyconfiguration.html#cfn-elasticmapreduce-cluster-simplescalingpolicyconfiguration-scalingadjustment
-	ScalingAdjustment int `json:"ScalingAdjustment,omitempty"`
+	ScalingAdjustment int `json:"ScalingAdjustment"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-emr-cluster_spotprovisioningspecification.go
+++ b/cloudformation/aws-emr-cluster_spotprovisioningspecification.go
@@ -17,7 +17,7 @@ type AWSEMRCluster_SpotProvisioningSpecification struct {
 	// TimeoutDurationMinutes AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-spotprovisioningspecification.html#cfn-elasticmapreduce-cluster-spotprovisioningspecification-timeoutdurationminutes
-	TimeoutDurationMinutes int `json:"TimeoutDurationMinutes,omitempty"`
+	TimeoutDurationMinutes int `json:"TimeoutDurationMinutes"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-emr-cluster_volumespecification.go
+++ b/cloudformation/aws-emr-cluster_volumespecification.go
@@ -12,7 +12,7 @@ type AWSEMRCluster_VolumeSpecification struct {
 	// SizeInGB AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-volumespecification.html#cfn-elasticmapreduce-cluster-volumespecification-sizeingb
-	SizeInGB int `json:"SizeInGB,omitempty"`
+	SizeInGB int `json:"SizeInGB"`
 
 	// VolumeType AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-emr-instancefleetconfig_spotprovisioningspecification.go
+++ b/cloudformation/aws-emr-instancefleetconfig_spotprovisioningspecification.go
@@ -17,7 +17,7 @@ type AWSEMRInstanceFleetConfig_SpotProvisioningSpecification struct {
 	// TimeoutDurationMinutes AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancefleetconfig-spotprovisioningspecification.html#cfn-elasticmapreduce-instancefleetconfig-spotprovisioningspecification-timeoutdurationminutes
-	TimeoutDurationMinutes int `json:"TimeoutDurationMinutes,omitempty"`
+	TimeoutDurationMinutes int `json:"TimeoutDurationMinutes"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-emr-instancefleetconfig_volumespecification.go
+++ b/cloudformation/aws-emr-instancefleetconfig_volumespecification.go
@@ -12,7 +12,7 @@ type AWSEMRInstanceFleetConfig_VolumeSpecification struct {
 	// SizeInGB AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancefleetconfig-volumespecification.html#cfn-elasticmapreduce-instancefleetconfig-volumespecification-sizeingb
-	SizeInGB int `json:"SizeInGB,omitempty"`
+	SizeInGB int `json:"SizeInGB"`
 
 	// VolumeType AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-emr-instancegroupconfig.go
+++ b/cloudformation/aws-emr-instancegroupconfig.go
@@ -33,7 +33,7 @@ type AWSEMRInstanceGroupConfig struct {
 	// InstanceCount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-instancegroupconfig.html#cfn-emr-instancegroupconfiginstancecount-
-	InstanceCount int `json:"InstanceCount,omitempty"`
+	InstanceCount int `json:"InstanceCount"`
 
 	// InstanceRole AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-emr-instancegroupconfig_cloudwatchalarmdefinition.go
+++ b/cloudformation/aws-emr-instancegroupconfig_cloudwatchalarmdefinition.go
@@ -32,7 +32,7 @@ type AWSEMRInstanceGroupConfig_CloudWatchAlarmDefinition struct {
 	// Period AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancegroupconfig-cloudwatchalarmdefinition.html#cfn-elasticmapreduce-instancegroupconfig-cloudwatchalarmdefinition-period
-	Period int `json:"Period,omitempty"`
+	Period int `json:"Period"`
 
 	// Statistic AWS CloudFormation Property
 	// Required: false
@@ -42,7 +42,7 @@ type AWSEMRInstanceGroupConfig_CloudWatchAlarmDefinition struct {
 	// Threshold AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancegroupconfig-cloudwatchalarmdefinition.html#cfn-elasticmapreduce-instancegroupconfig-cloudwatchalarmdefinition-threshold
-	Threshold float64 `json:"Threshold,omitempty"`
+	Threshold float64 `json:"Threshold"`
 
 	// Unit AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-emr-instancegroupconfig_scalingconstraints.go
+++ b/cloudformation/aws-emr-instancegroupconfig_scalingconstraints.go
@@ -7,12 +7,12 @@ type AWSEMRInstanceGroupConfig_ScalingConstraints struct {
 	// MaxCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancegroupconfig-scalingconstraints.html#cfn-elasticmapreduce-instancegroupconfig-scalingconstraints-maxcapacity
-	MaxCapacity int `json:"MaxCapacity,omitempty"`
+	MaxCapacity int `json:"MaxCapacity"`
 
 	// MinCapacity AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancegroupconfig-scalingconstraints.html#cfn-elasticmapreduce-instancegroupconfig-scalingconstraints-mincapacity
-	MinCapacity int `json:"MinCapacity,omitempty"`
+	MinCapacity int `json:"MinCapacity"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-emr-instancegroupconfig_simplescalingpolicyconfiguration.go
+++ b/cloudformation/aws-emr-instancegroupconfig_simplescalingpolicyconfiguration.go
@@ -17,7 +17,7 @@ type AWSEMRInstanceGroupConfig_SimpleScalingPolicyConfiguration struct {
 	// ScalingAdjustment AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancegroupconfig-simplescalingpolicyconfiguration.html#cfn-elasticmapreduce-instancegroupconfig-simplescalingpolicyconfiguration-scalingadjustment
-	ScalingAdjustment int `json:"ScalingAdjustment,omitempty"`
+	ScalingAdjustment int `json:"ScalingAdjustment"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-emr-instancegroupconfig_volumespecification.go
+++ b/cloudformation/aws-emr-instancegroupconfig_volumespecification.go
@@ -12,7 +12,7 @@ type AWSEMRInstanceGroupConfig_VolumeSpecification struct {
 	// SizeInGB AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-ebsconfiguration-ebsblockdeviceconfig-volumespecification.html#cfn-emr-ebsconfiguration-ebsblockdeviceconfig-volumespecification-sizeingb
-	SizeInGB int `json:"SizeInGB,omitempty"`
+	SizeInGB int `json:"SizeInGB"`
 
 	// VolumeType AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-gamelift-fleet.go
+++ b/cloudformation/aws-gamelift-fleet.go
@@ -23,7 +23,7 @@ type AWSGameLiftFleet struct {
 	// DesiredEC2Instances AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-gamelift-fleet.html#cfn-gamelift-fleet-desiredec2instances
-	DesiredEC2Instances int `json:"DesiredEC2Instances,omitempty"`
+	DesiredEC2Instances int `json:"DesiredEC2Instances"`
 
 	// EC2InboundPermissions AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-gamelift-fleet_ippermission.go
+++ b/cloudformation/aws-gamelift-fleet_ippermission.go
@@ -7,7 +7,7 @@ type AWSGameLiftFleet_IpPermission struct {
 	// FromPort AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-gamelift-fleet-ec2inboundpermission.html#cfn-gamelift-fleet-ec2inboundpermissions-fromport
-	FromPort int `json:"FromPort,omitempty"`
+	FromPort int `json:"FromPort"`
 
 	// IpRange AWS CloudFormation Property
 	// Required: true
@@ -22,7 +22,7 @@ type AWSGameLiftFleet_IpPermission struct {
 	// ToPort AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-gamelift-fleet-ec2inboundpermission.html#cfn-gamelift-fleet-ec2inboundpermissions-toport
-	ToPort int `json:"ToPort,omitempty"`
+	ToPort int `json:"ToPort"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-glue-table_order.go
+++ b/cloudformation/aws-glue-table_order.go
@@ -12,7 +12,7 @@ type AWSGlueTable_Order struct {
 	// SortOrder AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-order.html#cfn-glue-table-order-sortorder
-	SortOrder int `json:"SortOrder,omitempty"`
+	SortOrder int `json:"SortOrder"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-guardduty-detector.go
+++ b/cloudformation/aws-guardduty-detector.go
@@ -13,7 +13,7 @@ type AWSGuardDutyDetector struct {
 	// Enable AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-enable
-	Enable bool `json:"Enable,omitempty"`
+	Enable bool `json:"Enable"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-guardduty-filter.go
+++ b/cloudformation/aws-guardduty-filter.go
@@ -38,7 +38,7 @@ type AWSGuardDutyFilter struct {
 	// Rank AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-rank
-	Rank int `json:"Rank,omitempty"`
+	Rank int `json:"Rank"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-guardduty-ipset.go
+++ b/cloudformation/aws-guardduty-ipset.go
@@ -13,7 +13,7 @@ type AWSGuardDutyIPSet struct {
 	// Activate AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-activate
-	Activate bool `json:"Activate,omitempty"`
+	Activate bool `json:"Activate"`
 
 	// DetectorId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-guardduty-threatintelset.go
+++ b/cloudformation/aws-guardduty-threatintelset.go
@@ -13,7 +13,7 @@ type AWSGuardDutyThreatIntelSet struct {
 	// Activate AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-activate
-	Activate bool `json:"Activate,omitempty"`
+	Activate bool `json:"Activate"`
 
 	// DetectorId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-inspector-assessmenttemplate.go
+++ b/cloudformation/aws-inspector-assessmenttemplate.go
@@ -23,7 +23,7 @@ type AWSInspectorAssessmentTemplate struct {
 	// DurationInSeconds AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-inspector-assessmenttemplate.html#cfn-inspector-assessmenttemplate-durationinseconds
-	DurationInSeconds int `json:"DurationInSeconds,omitempty"`
+	DurationInSeconds int `json:"DurationInSeconds"`
 
 	// RulesPackageArns AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-iot-topicrule_topicrulepayload.go
+++ b/cloudformation/aws-iot-topicrule_topicrulepayload.go
@@ -22,7 +22,7 @@ type AWSIoTTopicRule_TopicRulePayload struct {
 	// RuleDisabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-topicrule-topicrulepayload.html#cfn-iot-topicrule-topicrulepayload-ruledisabled
-	RuleDisabled bool `json:"RuleDisabled,omitempty"`
+	RuleDisabled bool `json:"RuleDisabled"`
 
 	// Sql AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-iot1click-device.go
+++ b/cloudformation/aws-iot1click-device.go
@@ -18,7 +18,7 @@ type AWSIoT1ClickDevice struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot1click-device.html#cfn-iot1click-device-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-kinesis-stream.go
+++ b/cloudformation/aws-kinesis-stream.go
@@ -23,7 +23,7 @@ type AWSKinesisStream struct {
 	// ShardCount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html#cfn-kinesis-stream-shardcount
-	ShardCount int `json:"ShardCount,omitempty"`
+	ShardCount int `json:"ShardCount"`
 
 	// StreamEncryption AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-kinesisfirehose-deliverystream_bufferinghints.go
+++ b/cloudformation/aws-kinesisfirehose-deliverystream_bufferinghints.go
@@ -7,12 +7,12 @@ type AWSKinesisFirehoseDeliveryStream_BufferingHints struct {
 	// IntervalInSeconds AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-bufferinghints.html#cfn-kinesisfirehose-deliverystream-bufferinghints-intervalinseconds
-	IntervalInSeconds int `json:"IntervalInSeconds,omitempty"`
+	IntervalInSeconds int `json:"IntervalInSeconds"`
 
 	// SizeInMBs AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-bufferinghints.html#cfn-kinesisfirehose-deliverystream-bufferinghints-sizeinmbs
-	SizeInMBs int `json:"SizeInMBs,omitempty"`
+	SizeInMBs int `json:"SizeInMBs"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-kinesisfirehose-deliverystream_elasticsearchbufferinghints.go
+++ b/cloudformation/aws-kinesisfirehose-deliverystream_elasticsearchbufferinghints.go
@@ -7,12 +7,12 @@ type AWSKinesisFirehoseDeliveryStream_ElasticsearchBufferingHints struct {
 	// IntervalInSeconds AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-elasticsearchbufferinghints.html#cfn-kinesisfirehose-deliverystream-elasticsearchbufferinghints-intervalinseconds
-	IntervalInSeconds int `json:"IntervalInSeconds,omitempty"`
+	IntervalInSeconds int `json:"IntervalInSeconds"`
 
 	// SizeInMBs AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-elasticsearchbufferinghints.html#cfn-kinesisfirehose-deliverystream-elasticsearchbufferinghints-sizeinmbs
-	SizeInMBs int `json:"SizeInMBs,omitempty"`
+	SizeInMBs int `json:"SizeInMBs"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-kinesisfirehose-deliverystream_elasticsearchretryoptions.go
+++ b/cloudformation/aws-kinesisfirehose-deliverystream_elasticsearchretryoptions.go
@@ -7,7 +7,7 @@ type AWSKinesisFirehoseDeliveryStream_ElasticsearchRetryOptions struct {
 	// DurationInSeconds AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-elasticsearchretryoptions.html#cfn-kinesisfirehose-deliverystream-elasticsearchretryoptions-durationinseconds
-	DurationInSeconds int `json:"DurationInSeconds,omitempty"`
+	DurationInSeconds int `json:"DurationInSeconds"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-kinesisfirehose-deliverystream_splunkretryoptions.go
+++ b/cloudformation/aws-kinesisfirehose-deliverystream_splunkretryoptions.go
@@ -7,7 +7,7 @@ type AWSKinesisFirehoseDeliveryStream_SplunkRetryOptions struct {
 	// DurationInSeconds AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-splunkretryoptions.html#cfn-kinesisfirehose-deliverystream-splunkretryoptions-durationinseconds
-	DurationInSeconds int `json:"DurationInSeconds,omitempty"`
+	DurationInSeconds int `json:"DurationInSeconds"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-lambda-alias_versionweight.go
+++ b/cloudformation/aws-lambda-alias_versionweight.go
@@ -12,7 +12,7 @@ type AWSLambdaAlias_VersionWeight struct {
 	// FunctionWeight AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-alias-versionweight.html#cfn-lambda-alias-versionweight-functionweight
-	FunctionWeight float64 `json:"FunctionWeight,omitempty"`
+	FunctionWeight float64 `json:"FunctionWeight"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-opsworks-layer.go
+++ b/cloudformation/aws-opsworks-layer.go
@@ -18,12 +18,12 @@ type AWSOpsWorksLayer struct {
 	// AutoAssignElasticIps AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-autoassignelasticips
-	AutoAssignElasticIps bool `json:"AutoAssignElasticIps,omitempty"`
+	AutoAssignElasticIps bool `json:"AutoAssignElasticIps"`
 
 	// AutoAssignPublicIps AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-autoassignpublicips
-	AutoAssignPublicIps bool `json:"AutoAssignPublicIps,omitempty"`
+	AutoAssignPublicIps bool `json:"AutoAssignPublicIps"`
 
 	// CustomInstanceProfileArn AWS CloudFormation Property
 	// Required: false
@@ -48,7 +48,7 @@ type AWSOpsWorksLayer struct {
 	// EnableAutoHealing AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworks-layer.html#cfn-opsworks-layer-enableautohealing
-	EnableAutoHealing bool `json:"EnableAutoHealing,omitempty"`
+	EnableAutoHealing bool `json:"EnableAutoHealing"`
 
 	// InstallUpdatesOnBoot AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/aws-s3-bucket_abortincompletemultipartupload.go
+++ b/cloudformation/aws-s3-bucket_abortincompletemultipartupload.go
@@ -7,7 +7,7 @@ type AWSS3Bucket_AbortIncompleteMultipartUpload struct {
 	// DaysAfterInitiation AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-abortincompletemultipartupload.html#cfn-s3-bucket-abortincompletemultipartupload-daysafterinitiation
-	DaysAfterInitiation int `json:"DaysAfterInitiation,omitempty"`
+	DaysAfterInitiation int `json:"DaysAfterInitiation"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-s3-bucket_inventoryconfiguration.go
+++ b/cloudformation/aws-s3-bucket_inventoryconfiguration.go
@@ -12,7 +12,7 @@ type AWSS3Bucket_InventoryConfiguration struct {
 	// Enabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-inventoryconfiguration.html#cfn-s3-bucket-inventoryconfiguration-enabled
-	Enabled bool `json:"Enabled,omitempty"`
+	Enabled bool `json:"Enabled"`
 
 	// Id AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-s3-bucket_noncurrentversiontransition.go
+++ b/cloudformation/aws-s3-bucket_noncurrentversiontransition.go
@@ -12,7 +12,7 @@ type AWSS3Bucket_NoncurrentVersionTransition struct {
 	// TransitionInDays AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule-noncurrentversiontransition.html#cfn-s3-bucket-lifecycleconfig-rule-noncurrentversiontransition-transitionindays
-	TransitionInDays int `json:"TransitionInDays,omitempty"`
+	TransitionInDays int `json:"TransitionInDays"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-sagemaker-endpointconfig_productionvariant.go
+++ b/cloudformation/aws-sagemaker-endpointconfig_productionvariant.go
@@ -7,12 +7,12 @@ type AWSSageMakerEndpointConfig_ProductionVariant struct {
 	// InitialInstanceCount AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpointconfig-productionvariant.html#cfn-sagemaker-endpointconfig-productionvariant-initialinstancecount
-	InitialInstanceCount int `json:"InitialInstanceCount,omitempty"`
+	InitialInstanceCount int `json:"InitialInstanceCount"`
 
 	// InitialVariantWeight AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpointconfig-productionvariant.html#cfn-sagemaker-endpointconfig-productionvariant-initialvariantweight
-	InitialVariantWeight float64 `json:"InitialVariantWeight,omitempty"`
+	InitialVariantWeight float64 `json:"InitialVariantWeight"`
 
 	// InstanceType AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-serverless-api_s3location.go
+++ b/cloudformation/aws-serverless-api_s3location.go
@@ -17,7 +17,7 @@ type AWSServerlessApi_S3Location struct {
 	// Version AWS CloudFormation Property
 	// Required: true
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-	Version int `json:"Version,omitempty"`
+	Version int `json:"Version"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-serverless-function_dynamodbevent.go
+++ b/cloudformation/aws-serverless-function_dynamodbevent.go
@@ -7,7 +7,7 @@ type AWSServerlessFunction_DynamoDBEvent struct {
 	// BatchSize AWS CloudFormation Property
 	// Required: true
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#dynamodb
-	BatchSize int `json:"BatchSize,omitempty"`
+	BatchSize int `json:"BatchSize"`
 
 	// StartingPosition AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-serverless-function_s3location.go
+++ b/cloudformation/aws-serverless-function_s3location.go
@@ -17,7 +17,7 @@ type AWSServerlessFunction_S3Location struct {
 	// Version AWS CloudFormation Property
 	// Required: true
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-	Version int `json:"Version,omitempty"`
+	Version int `json:"Version"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-serverless-simpletable_provisionedthroughput.go
+++ b/cloudformation/aws-serverless-simpletable_provisionedthroughput.go
@@ -12,7 +12,7 @@ type AWSServerlessSimpleTable_ProvisionedThroughput struct {
 	// WriteCapacityUnits AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html
-	WriteCapacityUnits int `json:"WriteCapacityUnits,omitempty"`
+	WriteCapacityUnits int `json:"WriteCapacityUnits"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy DeletionPolicy

--- a/cloudformation/aws-ssm-maintenancewindowtask.go
+++ b/cloudformation/aws-ssm-maintenancewindowtask.go
@@ -38,7 +38,7 @@ type AWSSSMMaintenanceWindowTask struct {
 	// Priority AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html#cfn-ssm-maintenancewindowtask-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// ServiceRoleArn AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-waf-rule_predicate.go
+++ b/cloudformation/aws-waf-rule_predicate.go
@@ -12,7 +12,7 @@ type AWSWAFRule_Predicate struct {
 	// Negated AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waf-rule-predicates.html#cfn-waf-rule-predicates-negated
-	Negated bool `json:"Negated,omitempty"`
+	Negated bool `json:"Negated"`
 
 	// Type AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-waf-sizeconstraintset_sizeconstraint.go
+++ b/cloudformation/aws-waf-sizeconstraintset_sizeconstraint.go
@@ -17,7 +17,7 @@ type AWSWAFSizeConstraintSet_SizeConstraint struct {
 	// Size AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waf-sizeconstraintset-sizeconstraint.html#cfn-waf-sizeconstraintset-sizeconstraint-size
-	Size int `json:"Size,omitempty"`
+	Size int `json:"Size"`
 
 	// TextTransformation AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-waf-webacl_activatedrule.go
+++ b/cloudformation/aws-waf-webacl_activatedrule.go
@@ -12,7 +12,7 @@ type AWSWAFWebACL_ActivatedRule struct {
 	// Priority AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waf-webacl-rules.html#cfn-waf-webacl-rules-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// RuleId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-wafregional-rule_predicate.go
+++ b/cloudformation/aws-wafregional-rule_predicate.go
@@ -12,7 +12,7 @@ type AWSWAFRegionalRule_Predicate struct {
 	// Negated AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafregional-rule-predicate.html#cfn-wafregional-rule-predicate-negated
-	Negated bool `json:"Negated,omitempty"`
+	Negated bool `json:"Negated"`
 
 	// Type AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-wafregional-sizeconstraintset_sizeconstraint.go
+++ b/cloudformation/aws-wafregional-sizeconstraintset_sizeconstraint.go
@@ -17,7 +17,7 @@ type AWSWAFRegionalSizeConstraintSet_SizeConstraint struct {
 	// Size AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafregional-sizeconstraintset-sizeconstraint.html#cfn-wafregional-sizeconstraintset-sizeconstraint-size
-	Size int `json:"Size,omitempty"`
+	Size int `json:"Size"`
 
 	// TextTransformation AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/aws-wafregional-webacl_rule.go
+++ b/cloudformation/aws-wafregional-webacl_rule.go
@@ -12,7 +12,7 @@ type AWSWAFRegionalWebACL_Rule struct {
 	// Priority AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafregional-webacl-rule.html#cfn-wafregional-webacl-rule-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// RuleId AWS CloudFormation Property
 	// Required: true

--- a/generate/property.go
+++ b/generate/property.go
@@ -111,6 +111,14 @@ func (p Property) IsPrimitive() bool {
 	return p.PrimitiveType != ""
 }
 
+func (p Property) IsNumeric() bool {
+	return p.IsPrimitive() &&
+		(p.PrimitiveType == "Long" ||
+			p.PrimitiveType == "Integer" ||
+			p.PrimitiveType == "Double" ||
+			p.PrimitiveType == "Boolean")
+}
+
 // IsMap checks whether a property should be a map (map[string]...)
 func (p Property) IsMap() bool {
 	return p.Type == "Map"

--- a/generate/templates/resource.template
+++ b/generate/templates/resource.template
@@ -14,7 +14,7 @@ type {{.StructName}} struct {
     // {{$name}} AWS CloudFormation Property
     // Required: {{$property.Required}}
     // See: {{$property.Documentation}}
-    {{$name}} {{if (or ($property.IsPolymorphic) ($property.IsCustomType) )}}*{{end}}{{$property.GoType $.Basename $name}} `json:"{{$name}},omitempty"`
+    {{$name}} {{if (or ($property.IsPolymorphic) ($property.IsCustomType) )}}*{{end}}{{$property.GoType $.Basename $name}} `json:"{{$name}}{{if (not (and ($property.IsNumeric) ($property.Required)))}},omitempty{{end}}"`
     {{end}}
 	{{if .HasUpdatePolicy }}// _updatePolicy represents a CloudFormation UpdatePolicy
 	_updatePolicy *UpdatePolicy{{ end }}


### PR DESCRIPTION
Relevant for https://github.com/awslabs/goformation/issues/61

I was trying to generate an AWSCloudWatchAlarm explicitly setting Threshold to 0. But the Threshold property was not written when saving the template. Deployment of the template failed with an error saying the property is required.
It seems this would apply to all required primitive properties. But maybe it never makes sense to include an empty string property, so limited this to numbers and booleans.
Not sure whether this might be a problem for some other use case, or whether this is the best way to solve the problem, but thought I should submit it so that the result can be inspected.