### PR TITLE
A bit more type-safe Parameter

### DIFF
--- a/cloudformation/parameter.go
+++ b/cloudformation/parameter.go
@@ -1,0 +1,33 @@
+package cloudformation
+
+// Parameter enables you to input custom values to your template each time you create or update a stack
+type Parameter struct {
+	AllowedPattern string `json:"AllowedPattern,omitempty"`
+	AllowedValues []interface{} `json:"AllowedValues,omitempty"`
+	ConstraintDescription string `json:"ConstraintDescription,omitempty"`
+	Default interface{} `json:"Default,omitempty"`
+	Description string `json:"Description,omitempty"`
+	MaxLength int `json:"MaxLength,omitempty"`
+	MinLength int `json:"MinLength,omitempty"`
+	MaxValue int `json:"MaxValue,omitempty"`
+	MinValue int `json:"MinValue,omitempty"`
+	NoEcho bool `json:"NoEcho,omitempty"`
+	Type Type `json:"Type"`
+}
+
+// Type is the data type for the parameter
+type Type = string
+
+const (
+	// StringType is the type of literal strings
+	StringType = Type("String")
+	// NummberType is the type of integers or floats
+	NumberType = Type("Number")
+	// ListNumberType is the type of array of integers or floats that are separated by commas
+	ListNumberType = Type("List<Number>")
+	// CommaDelimitedListType is the type of arrays of literal strings that are separated by commas
+	CommaDelimitedListType = Type("CommaDelimitedList")
+
+	// TODO Add AWS-Specific Parameter Types
+	// Ref https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-specific-parameter-types
+)

--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -14,7 +14,7 @@ type Template struct {
 	Transform                *Transform             `json:"Transform,omitempty"`
 	Description              string                 `json:"Description,omitempty"`
 	Metadata                 map[string]interface{} `json:"Metadata,omitempty"`
-	Parameters               map[string]interface{} `json:"Parameters,omitempty"`
+	Parameters               map[string]Parameter   `json:"Parameters,omitempty"`
 	Mappings                 map[string]interface{} `json:"Mappings,omitempty"`
 	Conditions               map[string]interface{} `json:"Conditions,omitempty"`
 	Resources                map[string]interface{} `json:"Resources,omitempty"`
@@ -67,7 +67,7 @@ func NewTemplate() *Template {
 		AWSTemplateFormatVersion: "2010-09-09",
 		Description:              "",
 		Metadata:                 map[string]interface{}{},
-		Parameters:               map[string]interface{}{},
+		Parameters:               map[string]Parameter{},
 		Mappings:                 map[string]interface{}{},
 		Conditions:               map[string]interface{}{},
 		Resources:                map[string]interface{}{},


### PR DESCRIPTION
Adds the `Parameter` type for template parameters, so that goformation stack templates a bit more type-safe :)

In case this is acceptable, I'd also like to add a type for  too. Ref #75 for that.