### PR TITLE
[Fix] Make the generated schema public + generate

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -337,8 +337,8 @@ func (rg *ResourceGenerator) generateJSONSchema(specname string, spec *CloudForm
 	var gocode []byte
 	gocode = append(gocode, []byte("package schema\n")...)
 	gocode = append(gocode, []byte("\n")...)
-	gocode = append(gocode, []byte("// "+specname+"Schema defined a JSON Schema that can be used to validate CloudFormation/SAM templates\n")...)
-	gocode = append(gocode, []byte("var "+specname+"Schema = `")...)
+	gocode = append(gocode, []byte("// "+strings.Title(specname)+"Schema defined a JSON Schema that can be used to validate CloudFormation/SAM templates\n")...)
+	gocode = append(gocode, []byte("var "+strings.Title(specname)+"Schema = `")...)
 	gocode = append(gocode, formatted...)
 	gocode = append(gocode, []byte("`\n")...)
 	gofilename := fmt.Sprintf("schema/%s.go", specname)

--- a/schema/cloudformation.go
+++ b/schema/cloudformation.go
@@ -1,7 +1,7 @@
 package schema
 
-// cloudformationSchema defined a JSON Schema that can be used to validate CloudFormation/SAM templates
-var cloudformationSchema = `{
+// CloudformationSchema defined a JSON Schema that can be used to validate CloudFormation/SAM templates
+var CloudformationSchema = `{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "definitions": {

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -1,7 +1,7 @@
 package schema
 
-// samSchema defined a JSON Schema that can be used to validate CloudFormation/SAM templates
-var samSchema = `{
+// SamSchema defined a JSON Schema that can be used to validate CloudFormation/SAM templates
+var SamSchema = `{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "definitions": {


### PR DESCRIPTION
I want to be able to use the generated json schema from the `schema` package but it needs to be public by `Title`izing the string.

Also ran `go generate` which caused a bunch of updates.

For unknown reason `aws-servicediscovery-instance.go` incorrectly assigned the type `Map` instead of interface. I have manually overridden but may look into later.