### PR TITLE
[Refactor] Return pointers from template.Resources finder methods

### DIFF
--- a/generate/templates/resource.template
+++ b/generate/templates/resource.template
@@ -78,9 +78,9 @@ func (r *{{.StructName}}) SetCreationPolicy(policy *CreationPolicy) {
 }
 {{end}}
 {{if not .IsCustomProperty}}
-// MarshalJSON is a custom JSON marshalling hook that embeds this object into 
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
 // an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
-func (r {{.StructName}}) MarshalJSON() ([]byte, error) {
+func (r *{{.StructName}}) MarshalJSON() ([]byte, error) {
 	type Properties {{.StructName}}
 	return json.Marshal(&struct{
 		Type string
@@ -92,7 +92,7 @@ func (r {{.StructName}}) MarshalJSON() ([]byte, error) {
 		{{if .HasCreationPolicy}}CreationPolicy *CreationPolicy `json:"CreationPolicy,omitempty"`{{end}}
 	}{
 		Type: r.AWSCloudFormationType(),
-		Properties: (Properties)(r),
+		Properties: (Properties)(*r),
 		DependsOn: r._dependsOn,
 		Metadata: r._metadata,
 		DeletionPolicy: r._deletionPolicy,
@@ -126,16 +126,16 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 	if res.Metadata != nil {
 		r._metadata = res.Metadata
 	}
-	
-	return nil	
+
+	return nil
 }
 
 // GetAll{{.StructName}}Resources retrieves all {{.StructName}} items from an AWS CloudFormation template
-func (t *Template) GetAll{{.StructName}}Resources () map[string]{{.StructName}} {
-    results := map[string]{{.StructName}}{}
+func (t *Template) GetAll{{.StructName}}Resources () map[string]*{{.StructName}} {
+    results := map[string]*{{.StructName}}{}
 	for name, untyped := range t.Resources {
 		switch resource := untyped.(type) {
-		case {{.StructName}}:
+		case *{{.StructName}}:
 			// We found a strongly typed resource of the correct type; use it
 			results[name] = resource
 		case map[string]interface{}:
@@ -147,7 +147,8 @@ func (t *Template) GetAll{{.StructName}}Resources () map[string]{{.StructName}} 
 					if b, err := json.Marshal(resource); err == nil {
 						var result {{.StructName}}
 						if err := json.Unmarshal(b, &result); err == nil {
-							results[name] = result
+							t.Resources[name] = &result
+							results[name] = &result
 						}
 					}
 				}
@@ -159,10 +160,10 @@ func (t *Template) GetAll{{.StructName}}Resources () map[string]{{.StructName}} 
 
 // Get{{.StructName}}WithName retrieves all {{.StructName}} items from an AWS CloudFormation template
 // whose logical ID matches the provided name. Returns an error if not found.
-func (t *Template) Get{{.StructName}}WithName (name string) ({{.StructName}}, error) {
-	if untyped, ok := t.Resources[name]; ok {		
+func (t *Template) Get{{.StructName}}WithName (name string) (*{{.StructName}}, error) {
+	if untyped, ok := t.Resources[name]; ok {
 		switch resource := untyped.(type) {
-		case {{.StructName}}:
+		case *{{.StructName}}:
 			// We found a strongly typed resource of the correct type; use it
 			return resource, nil
 		case map[string]interface{}:
@@ -174,13 +175,14 @@ func (t *Template) Get{{.StructName}}WithName (name string) ({{.StructName}}, er
 					if b, err := json.Marshal(resource); err == nil {
 						var result {{.StructName}}
 						if err := json.Unmarshal(b, &result); err == nil {
-							return result, nil
+							t.Resources[name] = &result
+							return &result, nil
 						}
 					}
 				}
-			}	
+			}
 		}
 	}
-    return {{.StructName}}{}, errors.New("resource not found")
+    return nil, errors.New("resource not found")
 }
 {{end}}


### PR DESCRIPTION
By returning pointers from the generated code users are able change the resources attributes before they are sent to cloud formation. e.g.:


```
template, _ := goformation.Open("template.yaml")
function, _ := template.GetAWSServerlessFunctionWithName("FunctionName")
function.FunctionName = "edit-the-name"
template.YAML()
```

Previously, this would not have worked for two reasons:
1. The found instance did not replace the `map[string]interface{}` in `template.Resources`
2. The returned instance was a Struct not a reference. 
