### PR TITLE
[Feature] Intrinsics handlers to encode to Base64

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -30,7 +30,7 @@ func str2Wrap(fn func(interface{}, interface{}) string) intrinsics.IntrinsicHand
 func str3Wrap(fn func(interface{}, interface{}, interface{}) string) intrinsics.IntrinsicHandler {
 	return func(name string, input interface{}, template interface{}) interface{} {
 		if arr, ok := input.([]interface{}); ok {
-			if len(arr) != 2 {
+			if len(arr) != 3 {
 				return nil
 			}
 			return fn(arr[0], arr[1], arr[2])
@@ -42,7 +42,6 @@ func str3Wrap(fn func(interface{}, interface{}, interface{}) string) intrinsics.
 func str2AWrap(fn func(interface{}, []string) string) intrinsics.IntrinsicHandler {
 	return func(name string, input interface{}, template interface{}) interface{} {
 		if arr, ok := input.([]interface{}); ok {
-
 			switch len(arr) {
 			case 0:
 				return nil
@@ -50,7 +49,7 @@ func str2AWrap(fn func(interface{}, []string) string) intrinsics.IntrinsicHandle
 				return fn(arr[0], []string{})
 			case 2:
 				if ls, ok := arr[1].([]interface{}); ok {
-					fn(arr[0], interfaceAtostrA(ls))
+					return fn(arr[0], interfaceAtostrA(ls))
 				}
 			}
 			return nil

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -2,91 +2,191 @@ package cloudformation
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
+
+	"github.com/awslabs/goformation/intrinsics"
 )
 
-// Ref creates a CloudFormation Reference to another resource in the template
-func Ref(logicalName string) string {
-	return encode(`{ "Ref": "` + logicalName + `" }`)
+func strWrap(fn func(interface{}) string) intrinsics.IntrinsicHandler {
+	return func(name string, input interface{}, template interface{}) interface{} {
+		return fn(input)
+	}
 }
 
-// GetAtt returns the value of an attribute from a resource in the template.
-func GetAtt(logicalName string, attribute string) string {
-	return encode(`{ "Fn::GetAtt": [ "` + logicalName + `", "` + attribute + `" ] }`)
+func str2Wrap(fn func(interface{}, interface{}) string) intrinsics.IntrinsicHandler {
+	return func(name string, input interface{}, template interface{}) interface{} {
+		// Check that the input is an array
+		if arr, ok := input.([]interface{}); ok {
+			if len(arr) != 2 {
+				return nil
+			}
+			return fn(arr[0], arr[1])
+		}
+		return nil
+	}
+}
+
+func str3Wrap(fn func(interface{}, interface{}, interface{}) string) intrinsics.IntrinsicHandler {
+	return func(name string, input interface{}, template interface{}) interface{} {
+		if arr, ok := input.([]interface{}); ok {
+			if len(arr) != 2 {
+				return nil
+			}
+			return fn(arr[0], arr[1], arr[2])
+		}
+		return nil
+	}
+}
+
+func str2AWrap(fn func(interface{}, []string) string) intrinsics.IntrinsicHandler {
+	return func(name string, input interface{}, template interface{}) interface{} {
+		if arr, ok := input.([]interface{}); ok {
+
+			switch len(arr) {
+			case 0:
+				return nil
+			case 1:
+				return fn(arr[0], []string{})
+			case 2:
+				if ls, ok := arr[1].([]interface{}); ok {
+					fn(arr[0], interfaceAtostrA(ls))
+				}
+			}
+			return nil
+		}
+		return nil
+	}
+}
+
+func strAWrap(fn func([]string) string) intrinsics.IntrinsicHandler {
+	return func(name string, input interface{}, template interface{}) interface{} {
+		if arr, ok := input.([]interface{}); ok {
+			return fn(interfaceAtostrA(arr))
+		}
+		return nil
+	}
+}
+
+var EncoderIntrinsics = map[string]intrinsics.IntrinsicHandler{
+	"Fn::Base64":      strWrap(Base64),
+	"Fn::And":         strAWrap(And),
+	"Fn::Equals":      str2Wrap(Equals),
+	"Fn::If":          str3Wrap(If),
+	"Fn::Not":         strAWrap(Not),
+	"Fn::Or":          strAWrap(Or),
+	"Fn::FindInMap":   str3Wrap(FindInMap),
+	"Fn::GetAtt":      str2Wrap(GetAtt),
+	"Fn::GetAZs":      strWrap(GetAZs),
+	"Fn::ImportValue": strWrap(ImportValue),
+	"Fn::Join":        str2AWrap(Join),
+	"Fn::Select":      str2AWrap(Select),
+	"Fn::Split":       str2Wrap(Split),
+	"Fn::Sub":         strWrap(Sub),
+	"Ref":             strWrap(Ref),
+	"Fn::Cidr":        str3Wrap(CIDR),
+}
+
+// str -> str fns
+
+// Ref creates a CloudFormation Reference to another resource in the template
+func Ref(logicalName interface{}) string {
+	return encode(fmt.Sprintf(`{ "Ref": "%v" }`, logicalName))
 }
 
 // ImportValue returns the value of an output exported by another stack. You typically use this function to create cross-stack references. In the following example template snippets, Stack A exports VPC security group values and Stack B imports them.
-func ImportValue(name string) string {
-	return encode(`{ "Fn::ImportValue": "` + name + `" }`)
+func ImportValue(name interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::ImportValue": "%v" }`, name))
 }
 
 // Base64 returns the Base64 representation of the input string. This function is typically used to pass encoded data to Amazon EC2 instances by way of the UserData property
-func Base64(input string) string {
-	return encode(`{ "Fn::Base64": "` + input + `" }`)
-}
-
-// CIDR returns an array of CIDR address blocks. The number of CIDR blocks returned is dependent on the count parameter.
-func CIDR(ipBlock, count, cidrBits string) string {
-	return encode(`{ "Fn::Cidr" : [ "` + ipBlock + `", "` + count + `", "` + cidrBits + `" ] }`)
-}
-
-// FindInMap returns the value corresponding to keys in a two-level map that is declared in the Mappings section.
-func FindInMap(mapName, topLevelKey, secondLevelKey string) string {
-	return encode(`{ "Fn::FindInMap" : [ "` + mapName + `", "` + topLevelKey + `", "` + secondLevelKey + `" ] }`)
+func Base64(input interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::Base64": "%v" }`, input))
 }
 
 // GetAZs returns an array that lists Availability Zones for a specified region. Because customers have access to different Availability Zones, the intrinsic function Fn::GetAZs enables template authors to write templates that adapt to the calling user's access. That way you don't have to hard-code a full list of Availability Zones for a specified region.
-func GetAZs(region string) string {
-	return encode(`{ "Fn::GetAZs": "` + region + `" }`)
-}
-
-// Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
-func Join(delimiter string, values []string) string {
-	return encode(`{ "Fn::Join": [ "` + delimiter + `", [ "` + strings.Trim(strings.Join(values, `", "`), `, "`) + `" ] ] }`)
-}
-
-// Select returns a single object from a list of objects by index.
-func Select(index string, list []string) string {
-	return encode(`{ "Fn::Select": [ "` + index + `", [ "` + strings.Trim(strings.Join(list, `", "`), `, "`) + `" ] ] }`)
-}
-
-// Split splits a string into a list of string values so that you can select an element from the resulting string list, use the Fn::Split intrinsic function. Specify the location of splits with a delimiter, such as , (a comma). After you split a string, use the Fn::Select function to pick a specific element.
-func Split(delimiter, source string) string {
-	return encode(`{ "Fn::Split" : [ "` + delimiter + `", "` + source + `" ] }`)
+func GetAZs(region interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::GetAZs": "%v" }`, region))
 }
 
 // Sub substitutes variables in an input string with values that you specify. In your templates, you can use this function to construct commands or outputs that include values that aren't available until you create or update a stack.
-func Sub(value string) string {
-	return encode(`{ "Fn::Sub" : "` + value + `" }`)
+func Sub(value interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::Sub" : "%v" }`, value))
 }
 
-// And returns true if all the specified conditions evaluate to true, or returns false if any one of the conditions evaluates to false. Fn::And acts as an AND operator. The minimum number of conditions that you can include is 2, and the maximum is 10.
-func And(conditions []string) string {
-	return encode(`{ "Fn::And": [ "` + strings.Trim(strings.Join(conditions, `", "`), `, "`) + `" ] }`)
+// (str, str) -> str
+
+// GetAtt returns the value of an attribute from a resource in the template.
+func GetAtt(logicalName interface{}, attribute interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::GetAtt" : [ "%v", "%v" ] }`, logicalName, attribute))
+}
+
+// Split splits a string into a list of string values so that you can select an element from the resulting string list, use the Fn::Split intrinsic function. Specify the location of splits with a delimiter, such as , (a comma). After you split a string, use the Fn::Select function to pick a specific element.
+func Split(delimiter, source interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::Split" : [ "%v", "%v" ] }`, delimiter, source))
 }
 
 // Equals compares if two values are equal. Returns true if the two values are equal or false if they aren't.
-func Equals(value1, value2 string) string {
-	return encode(`{ "Fn::Equals" : [ "` + value1 + `", "` + value2 + `" ] }`)
+func Equals(value1, value2 interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::Equals" : [ "%v", "%v" ] }`, value1, value2))
+}
+
+// (str, str, str) -> str
+
+// CIDR returns an array of CIDR address blocks. The number of CIDR blocks returned is dependent on the count parameter.
+func CIDR(ipBlock, count, cidrBits interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::Cidr" : [ "%v", "%v", "%v" ] }`, ipBlock, count, cidrBits))
+}
+
+// FindInMap returns the value corresponding to keys in a two-level map that is declared in the Mappings section.
+func FindInMap(mapName, topLevelKey, secondLevelKey interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::FindInMap" : [ "%v", "%v", "%v" ] }`, mapName, topLevelKey, secondLevelKey))
 }
 
 // If returns one value if the specified condition evaluates to true and another value if the specified condition evaluates to false. Currently, AWS CloudFormation supports the Fn::If intrinsic function in the metadata attribute, update policy attribute, and property values in the Resources section and Outputs sections of a template. You can use the AWS::NoValue pseudo parameter as a return value to remove the corresponding property.
-func If(value, ifEqual, ifNotEqual string) string {
-	return encode(`{ "Fn::If" : [ "` + value + `", "` + ifEqual + `", "` + ifNotEqual + `" ] }`)
+func If(value, ifEqual, ifNotEqual interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::If" : [ "%v", "%v", "%v" ] }`, value, ifEqual, ifNotEqual))
+}
+
+// (str, []str) -> str
+
+// Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
+func Join(delimiter interface{}, values []string) string {
+	return encode(fmt.Sprintf(`{ "Fn::Join": [ "%v", [ "%v" ] ] }`, delimiter, strings.Trim(strings.Join(values, `", "`), `, "`)))
+}
+
+// Select returns a single object from a list of objects by index.
+func Select(index interface{}, list []string) string {
+	return encode(fmt.Sprintf(`{ "Fn::Select": [ "%v", [ "%v" ] ] }`, index, strings.Trim(strings.Join(list, `", "`), `, "`)))
+}
+
+// ([]str) -> str
+
+// And returns true if all the specified conditions evaluate to true, or returns false if any one of the conditions evaluates to false. Fn::And acts as an AND operator. The minimum number of conditions that you can include is 2, and the maximum is 10.
+func And(conditions []string) string {
+	return encode(fmt.Sprintf(`{ "Fn::And": [ "%v" ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
 }
 
 // Not returns true for a condition that evaluates to false or returns false for a condition that evaluates to true. Fn::Not acts as a NOT operator.
 func Not(conditions []string) string {
-	return encode(`{ "Fn::Not": [ "` + strings.Trim(strings.Join(conditions, `", "`), `, "`) + `" ] }`)
+	return encode(fmt.Sprintf(`{ "Fn::Not": [ "%v" ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
 }
 
 // Or returns true if any one of the specified conditions evaluate to true, or returns false if all of the conditions evaluates to false. Fn::Or acts as an OR operator. The minimum number of conditions that you can include is 2, and the maximum is 10.
 func Or(conditions []string) string {
-	return encode(`{ "Fn::Or": [ "` + strings.Trim(strings.Join(conditions, `", "`), `, "`) + `" ] }`)
+	return encode(fmt.Sprintf(`{ "Fn::Or": [ "%v" ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
 }
 
 // encode takes a string representation of an intrinsic function, and base64 encodes it.
 // This prevents the escaping issues when nesting multiple layers of intrinsic functions.
 func encode(value string) string {
 	return base64.StdEncoding.EncodeToString([]byte(value))
+}
+
+func interfaceAtostrA(values []interface{}) []string {
+	converted := make([]string, len(values))
+	for i := range values {
+		converted[i] = fmt.Sprintf("%v", values[i])
+	}
+	return converted
 }

--- a/cloudformation/intrinsics_test.go
+++ b/cloudformation/intrinsics_test.go
@@ -1,0 +1,124 @@
+package cloudformation_test
+
+import (
+	"strings"
+
+	"github.com/awslabs/goformation"
+	"github.com/awslabs/goformation/cloudformation"
+	"github.com/awslabs/goformation/intrinsics"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Goformation", func() {
+	Context("with a YAML template that contains an intrinsic", func() {
+
+		tests := []struct {
+			Name     string
+			Input    string
+			Expected string
+		}{
+			{
+				Name:     "Ref",
+				Input:    `Description: !Ref tvalue`,
+				Expected: `{"Description":{"Ref":"tvalue"}}`,
+			},
+			{
+				Name:     "ImportValue",
+				Input:    `Description: !ImportValue tvalue`,
+				Expected: `{"Description":{"Fn::ImportValue":"tvalue"}}`,
+			},
+			{
+				Name:     "Base64",
+				Input:    `Description: !Base64 tvalue`,
+				Expected: `{"Description":{"Fn::Base64":"tvalue"}}`,
+			},
+			{
+				Name:     "GetAZs",
+				Input:    `Description: !GetAZs tvalue`,
+				Expected: `{"Description":{"Fn::GetAZs":"tvalue"}}`,
+			},
+			{
+				Name:     "Sub",
+				Input:    `Description: !Sub tvalue`,
+				Expected: `{"Description":{"Fn::Sub":"tvalue"}}`,
+			},
+			{
+				Name:     "GetAtt",
+				Input:    `Description: !GetAtt [object, property]`,
+				Expected: `{"Description":{"Fn::GetAtt":["object","property"]}}`,
+			},
+			{
+				Name:     "Split",
+				Input:    `Description: !Split [d, sss]`,
+				Expected: `{"Description":{"Fn::Split":["d","sss"]}}`,
+			},
+			{
+				Name:     "Equals",
+				Input:    `Description: !Equals [a, b]`,
+				Expected: `{"Description":{"Fn::Equals":["a","b"]}}`,
+			},
+			{
+				Name:     "CIDR",
+				Input:    `Description: !Cidr [a, b, c]`,
+				Expected: `{"Description":{"Fn::Cidr":["a","b","c"]}}`,
+			},
+			{
+				Name:     "FindInMap",
+				Input:    `Description: !FindInMap [a, b, c]`,
+				Expected: `{"Description":{"Fn::FindInMap":["a","b","c"]}}`,
+			},
+			{
+				Name:     "If",
+				Input:    `Description: !If [a, b, c]`,
+				Expected: `{"Description":{"Fn::If":["a","b","c"]}}`,
+			},
+			{
+				Name:     "Join",
+				Input:    `Description: !Join [a, [b, c]]`,
+				Expected: `{"Description":{"Fn::Join":["a",["b","c"]]}}`,
+			},
+			{
+				Name:     "Select",
+				Input:    `Description: !Select [a, [b, c]]`,
+				Expected: `{"Description":{"Fn::Select":["a",["b","c"]]}}`,
+			},
+			{
+				Name:     "And",
+				Input:    `Description: !And [a, b, c]`,
+				Expected: `{"Description":{"Fn::And":["a","b","c"]}}`,
+			},
+			{
+				Name:     "Not",
+				Input:    `Description: !Not [a, b, c]`,
+				Expected: `{"Description":{"Fn::Not":["a","b","c"]}}`,
+			},
+			{
+				Name:     "Or",
+				Input:    `Description: !Or [a, b, c]`,
+				Expected: `{"Description":{"Fn::Or":["a","b","c"]}}`,
+			},
+		}
+
+		for _, test := range tests {
+			test := test
+
+			It("should replace "+test.Name+" with the JSON expanded value", func() {
+				template, err := goformation.ParseYAMLWithOptions([]byte(test.Input), &intrinsics.ProcessorOptions{
+					IntrinsicHandlerOverrides: cloudformation.EncoderIntrinsics,
+				})
+
+				Expect(err).To(BeNil())
+
+				raw, err := template.JSON()
+				output := string(raw)
+				Expect(err).To(BeNil())
+				output = strings.Replace(output, " ", "", -1)
+				output = strings.Replace(output, "\n", "", -1)
+
+				Expect(test.Expected).To(BeEquivalentTo(output))
+			})
+		}
+	})
+})

--- a/intrinsics/tags.go
+++ b/intrinsics/tags.go
@@ -6,8 +6,10 @@ import (
 	yaml "github.com/sanathkr/go-yaml"
 )
 
-var allTags = []string{"Ref", "GetAtt", "Base64", "FindInMap", "GetAZs",
+var allTags = []string{
+	"Ref", "GetAtt", "Base64", "FindInMap", "GetAZs",
 	"ImportValue", "Join", "Select", "Split", "Sub",
+	"Equals", "Cidr", "And", "If", "Not", "Or",
 }
 
 type tagUnmarshalerType struct {


### PR DESCRIPTION
I like the way in which this project encodes the CloudFormation Intrinsic functions to base64 to remain valid within the JSON schema.

I wanted to be able to parse a YAML, edit some attributes in Go, then go to JSON. This required intrinsic handlers to encode to base64.

This reuses the intrinsics encoders in the cloudformation package, wraps their functions and builds the intrinsic handler overrides.

I think in the future I will improve and repackage the intrinsics into a parser package, so that these different handler overrides can be there. 

Ultimately I would like to try reimplement something like https://github.com/awslabs/aws-cfn-template-flip using this library. Though that might be a way off.