### PR TITLE
[Fix] Add Application.Location and fix SSEEnabled

### DIFF
--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -237,6 +237,7 @@
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapplication",
                     "Required": true,
                     "PrimitiveType": "String",
+                    "Types": [ "ApplicationLocation" ],
                     "UpdateType": "Immutable"
                 },
                 "Parameters": {
@@ -348,6 +349,23 @@
         }
     },
     "PropertyTypes": {
+        "AWS::Serverless::Application.ApplicationLocation": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapplication",
+            "Properties": {
+                "ApplicationId": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapplication",
+                    "PrimitiveType": "String",
+                    "Required": true,
+                    "UpdateType": "Immutable"
+                },
+                "SemanticVersion": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapplication",
+                    "PrimitiveType": "String",
+                    "Required": true,
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
         "AWS::Serverless::Function.S3Location": {
             "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3-location-object",
             "Properties": {
@@ -777,12 +795,10 @@
             "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html",
             "Properties": {
                 "SSEEnabled": {
-                    "Enabled": {
-                        "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html",
-                        "Required": false,
-                        "PrimitiveType": "Boolean",
-                        "UpdateType": "Immutable"
-                    }
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html",
+                    "Required": false,
+                    "PrimitiveType": "Boolean",
+                    "UpdateType": "Immutable"
                 }
             }
         }


### PR DESCRIPTION
The Location property on `AWS::Serverless::Application` can be a `string` or an `ApplicationLocation`, this change adds support for this property.

It also fixes `SSEEnabled` which mistakenly had a nested object with key `Enabled1.