### PR TITLE
Output a map[interface{}] from the tag unmarshaler as that's what the…

### DIFF
--- a/intrinsics/tags.go
+++ b/intrinsics/tags.go
@@ -24,7 +24,7 @@ func (t *tagUnmarshalerType) UnmarshalYAMLTag(tag string, fieldValue reflect.Val
 
 	tag = prefix + tag
 
-	output := reflect.ValueOf(make(map[string]interface{}))
+	output := reflect.ValueOf(make(map[interface{}]interface{}))
 	key := reflect.ValueOf(tag)
 
 	output.SetMapIndex(key, fieldValue)

--- a/test/yaml/yaml-intrinsic-tags.yaml
+++ b/test/yaml/yaml-intrinsic-tags.yaml
@@ -11,3 +11,5 @@ Resources:
     Properties:
       Runtime: !Sub "${ParamNotExists}4.3"
       Timeout: !Ref TimeoutParam
+      FunctionName: !Base64
+        Ref: AWS::Region


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The yaml library used does not expect to find a `map[string]interface{}` in the unmarshalled YAML output. I've raised a [related PR](https://github.com/sanathkr/yaml/pull/1) on the YAML library so this is belt and braces.

You can easily trigger this issue by trying to load a template that uses a YAML tag on a map, for example:

```yaml
Resources:
  Bucket:
    Type: AWS::S3::Bucket
    Properties:
      BucketName: !Base64
        Ref: AWS::Region
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
