### PR TITLE
[Feature] Allow custom resources to be defined and parsed

### DIFF
--- a/cloudformation/custom_resource.go
+++ b/cloudformation/custom_resource.go
@@ -1,0 +1,87 @@
+package cloudformation
+
+import (
+	"fmt"
+
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html
+type CustomResource struct {
+	Type       string                 `json:"Type,omitempty"`
+	Properties map[string]interface{} `json:"Properties,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *CustomResource) AWSCloudFormationType() string {
+	return r.Type
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *CustomResource) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *CustomResource) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *CustomResource) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *CustomResource) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *CustomResource) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *CustomResource) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// GetAllCustomResourceResources retrieves all CustomResource items from an AWS CloudFormation template
+func (t *Template) GetAllCustomResources() map[string]*CustomResource {
+	results := map[string]*CustomResource{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *CustomResource:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetCustomResourceWithName retrieves all CustomResource items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetCustomResourceWithName(name string) (*CustomResource, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *CustomResource:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type CustomResource not found", name)
+}

--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -3,6 +3,7 @@ package cloudformation
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/awslabs/goformation/intrinsics"
 	"github.com/sanathkr/yaml"
@@ -66,7 +67,15 @@ func unmarshallResource(name string, raw_json *json.RawMessage) (Resource, error
 		return nil, fmt.Errorf("Cannot find Type for %v", name)
 	}
 
-	resourceStruct := AllResources()[rtype.Type]
+	// Custom Resource Handler
+	var resourceStruct Resource
+
+	if strings.HasPrefix(rtype.Type, "Custom::") {
+		resourceStruct = &CustomResource{Type: rtype.Type}
+	} else {
+		resourceStruct = AllResources()[rtype.Type]
+	}
+
 	err = json.Unmarshal(*raw_json, resourceStruct)
 
 	if err != nil {

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -66,6 +66,40 @@ var _ = Describe("Goformation", func() {
 
 	})
 
+	Context("with a Custom Resource template", func() {
+
+		template, err := goformation.Open("test/yaml/custom-resource.yaml")
+		It("should successfully validate the template", func() {
+			Expect(err).To(BeNil())
+			Expect(template).ShouldNot(BeNil())
+		})
+
+		resources := template.GetAllCustomResources()
+
+		It("should have exactly one resource", func() {
+			Expect(resources).To(HaveLen(1))
+			Expect(resources).To(HaveKey("MyCustomResource"))
+		})
+
+		It("should correctly Marshal the custom resource", func() {
+			data, err := template.JSON()
+			Expect(err).To(BeNil())
+
+			var result map[string]interface{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				Fail(err.Error())
+			}
+
+			resources, ok := result["Resources"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(resources).To(HaveLen(1))
+			Expect(resources).To(HaveKey("MyCustomResource"))
+
+			mcr := resources["MyCustomResource"].(map[string]interface{})
+			Expect(mcr["Properties"]).To(HaveKey("CustomProperty"))
+		})
+	})
+
 	Context("with an AWS CloudFormation template that contains multiple resources", func() {
 
 		Context("described as Go structs", func() {

--- a/test/yaml/custom-resource.yaml
+++ b/test/yaml/custom-resource.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "Custom Resource Test"
+Resources:
+  MyCustomResource:
+    Type: Custom::MyResource
+    Properties:
+      ServiceToken: lambda.arn
+      CustomProperty: property_value


### PR DESCRIPTION
*Issue #, if available:*
#193 

*Description of changes:*

This PR lets goformation Marshal and Unmarshal `Custom::*` resources. This is a pretty minimal change but allows for a lot more functionality. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
