### PR TITLE
fix(schema): version attribute of Function::S3Location in SAM is optional

### DIFF
--- a/cloudformation/all.go
+++ b/cloudformation/all.go
@@ -114,6 +114,7 @@ func AllResources() map[string]Resource {
 		"AWS::Config::ConfigurationAggregator":                        &resources.AWSConfigConfigurationAggregator{},
 		"AWS::Config::ConfigurationRecorder":                          &resources.AWSConfigConfigurationRecorder{},
 		"AWS::Config::DeliveryChannel":                                &resources.AWSConfigDeliveryChannel{},
+		"AWS::Config::OrganizationConfigRule":                         &resources.AWSConfigOrganizationConfigRule{},
 		"AWS::Config::RemediationConfiguration":                       &resources.AWSConfigRemediationConfiguration{},
 		"AWS::DAX::Cluster":                                           &resources.AWSDAXCluster{},
 		"AWS::DAX::ParameterGroup":                                    &resources.AWSDAXParameterGroup{},
@@ -177,6 +178,7 @@ func AllResources() map[string]Resource {
 		"AWS::EC2::VPCDHCPOptionsAssociation":                         &resources.AWSEC2VPCDHCPOptionsAssociation{},
 		"AWS::EC2::VPCEndpoint":                                       &resources.AWSEC2VPCEndpoint{},
 		"AWS::EC2::VPCEndpointConnectionNotification":                 &resources.AWSEC2VPCEndpointConnectionNotification{},
+		"AWS::EC2::VPCEndpointService":                                &resources.AWSEC2VPCEndpointService{},
 		"AWS::EC2::VPCEndpointServicePermissions":                     &resources.AWSEC2VPCEndpointServicePermissions{},
 		"AWS::EC2::VPCGatewayAttachment":                              &resources.AWSEC2VPCGatewayAttachment{},
 		"AWS::EC2::VPCPeeringConnection":                              &resources.AWSEC2VPCPeeringConnection{},
@@ -233,6 +235,7 @@ func AllResources() map[string]Resource {
 		"AWS::Glue::SecurityConfiguration":                            &resources.AWSGlueSecurityConfiguration{},
 		"AWS::Glue::Table":                                            &resources.AWSGlueTable{},
 		"AWS::Glue::Trigger":                                          &resources.AWSGlueTrigger{},
+		"AWS::Glue::Workflow":                                         &resources.AWSGlueWorkflow{},
 		"AWS::Greengrass::ConnectorDefinition":                        &resources.AWSGreengrassConnectorDefinition{},
 		"AWS::Greengrass::ConnectorDefinitionVersion":                 &resources.AWSGreengrassConnectorDefinitionVersion{},
 		"AWS::Greengrass::CoreDefinition":                             &resources.AWSGreengrassCoreDefinition{},
@@ -349,6 +352,7 @@ func AllResources() map[string]Resource {
 		"AWS::PinpointEmail::ConfigurationSetEventDestination":        &resources.AWSPinpointEmailConfigurationSetEventDestination{},
 		"AWS::PinpointEmail::DedicatedIpPool":                         &resources.AWSPinpointEmailDedicatedIpPool{},
 		"AWS::PinpointEmail::Identity":                                &resources.AWSPinpointEmailIdentity{},
+		"AWS::QLDB::Ledger":                                           &resources.AWSQLDBLedger{},
 		"AWS::RAM::ResourceShare":                                     &resources.AWSRAMResourceShare{},
 		"AWS::RDS::DBCluster":                                         &resources.AWSRDSDBCluster{},
 		"AWS::RDS::DBClusterParameterGroup":                           &resources.AWSRDSDBClusterParameterGroup{},
@@ -394,15 +398,18 @@ func AllResources() map[string]Resource {
 		"AWS::SSM::Association":                                       &resources.AWSSSMAssociation{},
 		"AWS::SSM::Document":                                          &resources.AWSSSMDocument{},
 		"AWS::SSM::MaintenanceWindow":                                 &resources.AWSSSMMaintenanceWindow{},
+		"AWS::SSM::MaintenanceWindowTarget":                           &resources.AWSSSMMaintenanceWindowTarget{},
 		"AWS::SSM::MaintenanceWindowTask":                             &resources.AWSSSMMaintenanceWindowTask{},
 		"AWS::SSM::Parameter":                                         &resources.AWSSSMParameter{},
 		"AWS::SSM::PatchBaseline":                                     &resources.AWSSSMPatchBaseline{},
 		"AWS::SSM::ResourceDataSync":                                  &resources.AWSSSMResourceDataSync{},
+		"AWS::SageMaker::CodeRepository":                              &resources.AWSSageMakerCodeRepository{},
 		"AWS::SageMaker::Endpoint":                                    &resources.AWSSageMakerEndpoint{},
 		"AWS::SageMaker::EndpointConfig":                              &resources.AWSSageMakerEndpointConfig{},
 		"AWS::SageMaker::Model":                                       &resources.AWSSageMakerModel{},
 		"AWS::SageMaker::NotebookInstance":                            &resources.AWSSageMakerNotebookInstance{},
 		"AWS::SageMaker::NotebookInstanceLifecycleConfig":             &resources.AWSSageMakerNotebookInstanceLifecycleConfig{},
+		"AWS::SageMaker::Workteam":                                    &resources.AWSSageMakerWorkteam{},
 		"AWS::SecretsManager::ResourcePolicy":                         &resources.AWSSecretsManagerResourcePolicy{},
 		"AWS::SecretsManager::RotationSchedule":                       &resources.AWSSecretsManagerRotationSchedule{},
 		"AWS::SecretsManager::Secret":                                 &resources.AWSSecretsManagerSecret{},
@@ -3003,6 +3010,30 @@ func (t *Template) GetAWSConfigDeliveryChannelWithName(name string) (*resources.
 	return nil, fmt.Errorf("resource %q of type AWSConfigDeliveryChannel not found", name)
 }
 
+// GetAllAWSConfigOrganizationConfigRuleResources retrieves all AWSConfigOrganizationConfigRule items from an AWS CloudFormation template
+func (t *Template) GetAllAWSConfigOrganizationConfigRuleResources() map[string]*resources.AWSConfigOrganizationConfigRule {
+	results := map[string]*resources.AWSConfigOrganizationConfigRule{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSConfigOrganizationConfigRule:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSConfigOrganizationConfigRuleWithName retrieves all AWSConfigOrganizationConfigRule items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSConfigOrganizationConfigRuleWithName(name string) (*resources.AWSConfigOrganizationConfigRule, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSConfigOrganizationConfigRule:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSConfigOrganizationConfigRule not found", name)
+}
+
 // GetAllAWSConfigRemediationConfigurationResources retrieves all AWSConfigRemediationConfiguration items from an AWS CloudFormation template
 func (t *Template) GetAllAWSConfigRemediationConfigurationResources() map[string]*resources.AWSConfigRemediationConfiguration {
 	results := map[string]*resources.AWSConfigRemediationConfiguration{}
@@ -4515,6 +4546,30 @@ func (t *Template) GetAWSEC2VPCEndpointConnectionNotificationWithName(name strin
 	return nil, fmt.Errorf("resource %q of type AWSEC2VPCEndpointConnectionNotification not found", name)
 }
 
+// GetAllAWSEC2VPCEndpointServiceResources retrieves all AWSEC2VPCEndpointService items from an AWS CloudFormation template
+func (t *Template) GetAllAWSEC2VPCEndpointServiceResources() map[string]*resources.AWSEC2VPCEndpointService {
+	results := map[string]*resources.AWSEC2VPCEndpointService{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSEC2VPCEndpointService:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSEC2VPCEndpointServiceWithName retrieves all AWSEC2VPCEndpointService items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSEC2VPCEndpointServiceWithName(name string) (*resources.AWSEC2VPCEndpointService, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSEC2VPCEndpointService:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSEC2VPCEndpointService not found", name)
+}
+
 // GetAllAWSEC2VPCEndpointServicePermissionsResources retrieves all AWSEC2VPCEndpointServicePermissions items from an AWS CloudFormation template
 func (t *Template) GetAllAWSEC2VPCEndpointServicePermissionsResources() map[string]*resources.AWSEC2VPCEndpointServicePermissions {
 	results := map[string]*resources.AWSEC2VPCEndpointServicePermissions{}
@@ -5857,6 +5912,30 @@ func (t *Template) GetAWSGlueTriggerWithName(name string) (*resources.AWSGlueTri
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type AWSGlueTrigger not found", name)
+}
+
+// GetAllAWSGlueWorkflowResources retrieves all AWSGlueWorkflow items from an AWS CloudFormation template
+func (t *Template) GetAllAWSGlueWorkflowResources() map[string]*resources.AWSGlueWorkflow {
+	results := map[string]*resources.AWSGlueWorkflow{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSGlueWorkflow:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSGlueWorkflowWithName retrieves all AWSGlueWorkflow items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSGlueWorkflowWithName(name string) (*resources.AWSGlueWorkflow, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSGlueWorkflow:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSGlueWorkflow not found", name)
 }
 
 // GetAllAWSGreengrassConnectorDefinitionResources retrieves all AWSGreengrassConnectorDefinition items from an AWS CloudFormation template
@@ -8643,6 +8722,30 @@ func (t *Template) GetAWSPinpointEmailIdentityWithName(name string) (*resources.
 	return nil, fmt.Errorf("resource %q of type AWSPinpointEmailIdentity not found", name)
 }
 
+// GetAllAWSQLDBLedgerResources retrieves all AWSQLDBLedger items from an AWS CloudFormation template
+func (t *Template) GetAllAWSQLDBLedgerResources() map[string]*resources.AWSQLDBLedger {
+	results := map[string]*resources.AWSQLDBLedger{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSQLDBLedger:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSQLDBLedgerWithName retrieves all AWSQLDBLedger items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSQLDBLedgerWithName(name string) (*resources.AWSQLDBLedger, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSQLDBLedger:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSQLDBLedger not found", name)
+}
+
 // GetAllAWSRAMResourceShareResources retrieves all AWSRAMResourceShare items from an AWS CloudFormation template
 func (t *Template) GetAllAWSRAMResourceShareResources() map[string]*resources.AWSRAMResourceShare {
 	results := map[string]*resources.AWSRAMResourceShare{}
@@ -9723,6 +9826,30 @@ func (t *Template) GetAWSSSMMaintenanceWindowWithName(name string) (*resources.A
 	return nil, fmt.Errorf("resource %q of type AWSSSMMaintenanceWindow not found", name)
 }
 
+// GetAllAWSSSMMaintenanceWindowTargetResources retrieves all AWSSSMMaintenanceWindowTarget items from an AWS CloudFormation template
+func (t *Template) GetAllAWSSSMMaintenanceWindowTargetResources() map[string]*resources.AWSSSMMaintenanceWindowTarget {
+	results := map[string]*resources.AWSSSMMaintenanceWindowTarget{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSSSMMaintenanceWindowTarget:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSSSMMaintenanceWindowTargetWithName retrieves all AWSSSMMaintenanceWindowTarget items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSSSMMaintenanceWindowTargetWithName(name string) (*resources.AWSSSMMaintenanceWindowTarget, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSSSMMaintenanceWindowTarget:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSSSMMaintenanceWindowTarget not found", name)
+}
+
 // GetAllAWSSSMMaintenanceWindowTaskResources retrieves all AWSSSMMaintenanceWindowTask items from an AWS CloudFormation template
 func (t *Template) GetAllAWSSSMMaintenanceWindowTaskResources() map[string]*resources.AWSSSMMaintenanceWindowTask {
 	results := map[string]*resources.AWSSSMMaintenanceWindowTask{}
@@ -9817,6 +9944,30 @@ func (t *Template) GetAWSSSMResourceDataSyncWithName(name string) (*resources.AW
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type AWSSSMResourceDataSync not found", name)
+}
+
+// GetAllAWSSageMakerCodeRepositoryResources retrieves all AWSSageMakerCodeRepository items from an AWS CloudFormation template
+func (t *Template) GetAllAWSSageMakerCodeRepositoryResources() map[string]*resources.AWSSageMakerCodeRepository {
+	results := map[string]*resources.AWSSageMakerCodeRepository{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSSageMakerCodeRepository:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSSageMakerCodeRepositoryWithName retrieves all AWSSageMakerCodeRepository items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSSageMakerCodeRepositoryWithName(name string) (*resources.AWSSageMakerCodeRepository, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSSageMakerCodeRepository:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSSageMakerCodeRepository not found", name)
 }
 
 // GetAllAWSSageMakerEndpointResources retrieves all AWSSageMakerEndpoint items from an AWS CloudFormation template
@@ -9937,6 +10088,30 @@ func (t *Template) GetAWSSageMakerNotebookInstanceLifecycleConfigWithName(name s
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type AWSSageMakerNotebookInstanceLifecycleConfig not found", name)
+}
+
+// GetAllAWSSageMakerWorkteamResources retrieves all AWSSageMakerWorkteam items from an AWS CloudFormation template
+func (t *Template) GetAllAWSSageMakerWorkteamResources() map[string]*resources.AWSSageMakerWorkteam {
+	results := map[string]*resources.AWSSageMakerWorkteam{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *resources.AWSSageMakerWorkteam:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAWSSageMakerWorkteamWithName retrieves all AWSSageMakerWorkteam items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAWSSageMakerWorkteamWithName(name string) (*resources.AWSSageMakerWorkteam, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *resources.AWSSageMakerWorkteam:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type AWSSageMakerWorkteam not found", name)
 }
 
 // GetAllAWSSecretsManagerResourcePolicyResources retrieves all AWSSecretsManagerResourcePolicy items from an AWS CloudFormation template

--- a/cloudformation/resources/aws-applicationautoscaling-scalabletarget.go
+++ b/cloudformation/resources/aws-applicationautoscaling-scalabletarget.go
@@ -46,6 +46,11 @@ type AWSApplicationAutoScalingScalableTarget struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalabletarget.html#cfn-applicationautoscaling-scalabletarget-servicenamespace
 	ServiceNamespace string `json:"ServiceNamespace,omitempty"`
 
+	// SuspendedState AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalabletarget.html#cfn-applicationautoscaling-scalabletarget-suspendedstate
+	SuspendedState *AWSApplicationAutoScalingScalableTarget_SuspendedState `json:"SuspendedState,omitempty"`
+
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy
 

--- a/cloudformation/resources/aws-applicationautoscaling-scalabletarget_suspendedstate.go
+++ b/cloudformation/resources/aws-applicationautoscaling-scalabletarget_suspendedstate.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSApplicationAutoScalingScalableTarget_SuspendedState AWS CloudFormation Resource (AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalabletarget-suspendedstate.html
+type AWSApplicationAutoScalingScalableTarget_SuspendedState struct {
+
+	// DynamicScalingInSuspended AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalabletarget-suspendedstate.html#cfn-applicationautoscaling-scalabletarget-suspendedstate-dynamicscalinginsuspended
+	DynamicScalingInSuspended bool `json:"DynamicScalingInSuspended,omitempty"`
+
+	// DynamicScalingOutSuspended AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalabletarget-suspendedstate.html#cfn-applicationautoscaling-scalabletarget-suspendedstate-dynamicscalingoutsuspended
+	DynamicScalingOutSuspended bool `json:"DynamicScalingOutSuspended,omitempty"`
+
+	// ScheduledScalingSuspended AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalabletarget-suspendedstate.html#cfn-applicationautoscaling-scalabletarget-suspendedstate-scheduledscalingsuspended
+	ScheduledScalingSuspended bool `json:"ScheduledScalingSuspended,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) AWSCloudFormationType() string {
+	return "AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSApplicationAutoScalingScalableTarget_SuspendedState) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-appmesh-route_duration.go
+++ b/cloudformation/resources/aws-appmesh-route_duration.go
@@ -1,0 +1,68 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSAppMeshRoute_Duration AWS CloudFormation Resource (AWS::AppMesh::Route.Duration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-duration.html
+type AWSAppMeshRoute_Duration struct {
+
+	// Unit AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-duration.html#cfn-appmesh-route-duration-unit
+	Unit string `json:"Unit,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-duration.html#cfn-appmesh-route-duration-value
+	Value int `json:"Value"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSAppMeshRoute_Duration) AWSCloudFormationType() string {
+	return "AWS::AppMesh::Route.Duration"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_Duration) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_Duration) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_Duration) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_Duration) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_Duration) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_Duration) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-appmesh-route_headermatchmethod.go
+++ b/cloudformation/resources/aws-appmesh-route_headermatchmethod.go
@@ -1,0 +1,83 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSAppMeshRoute_HeaderMatchMethod AWS CloudFormation Resource (AWS::AppMesh::Route.HeaderMatchMethod)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-headermatchmethod.html
+type AWSAppMeshRoute_HeaderMatchMethod struct {
+
+	// Exact AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-headermatchmethod.html#cfn-appmesh-route-headermatchmethod-exact
+	Exact string `json:"Exact,omitempty"`
+
+	// Prefix AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-headermatchmethod.html#cfn-appmesh-route-headermatchmethod-prefix
+	Prefix string `json:"Prefix,omitempty"`
+
+	// Range AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-headermatchmethod.html#cfn-appmesh-route-headermatchmethod-range
+	Range *AWSAppMeshRoute_MatchRange `json:"Range,omitempty"`
+
+	// Regex AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-headermatchmethod.html#cfn-appmesh-route-headermatchmethod-regex
+	Regex string `json:"Regex,omitempty"`
+
+	// Suffix AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-headermatchmethod.html#cfn-appmesh-route-headermatchmethod-suffix
+	Suffix string `json:"Suffix,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSAppMeshRoute_HeaderMatchMethod) AWSCloudFormationType() string {
+	return "AWS::AppMesh::Route.HeaderMatchMethod"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_HeaderMatchMethod) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_HeaderMatchMethod) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_HeaderMatchMethod) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_HeaderMatchMethod) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_HeaderMatchMethod) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_HeaderMatchMethod) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-appmesh-route_httpretrypolicy.go
+++ b/cloudformation/resources/aws-appmesh-route_httpretrypolicy.go
@@ -1,0 +1,78 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSAppMeshRoute_HttpRetryPolicy AWS CloudFormation Resource (AWS::AppMesh::Route.HttpRetryPolicy)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httpretrypolicy.html
+type AWSAppMeshRoute_HttpRetryPolicy struct {
+
+	// HttpRetryEvents AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httpretrypolicy.html#cfn-appmesh-route-httpretrypolicy-httpretryevents
+	HttpRetryEvents []string `json:"HttpRetryEvents,omitempty"`
+
+	// MaxRetries AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httpretrypolicy.html#cfn-appmesh-route-httpretrypolicy-maxretries
+	MaxRetries int `json:"MaxRetries"`
+
+	// PerRetryTimeout AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httpretrypolicy.html#cfn-appmesh-route-httpretrypolicy-perretrytimeout
+	PerRetryTimeout *AWSAppMeshRoute_Duration `json:"PerRetryTimeout,omitempty"`
+
+	// TcpRetryEvents AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httpretrypolicy.html#cfn-appmesh-route-httpretrypolicy-tcpretryevents
+	TcpRetryEvents []string `json:"TcpRetryEvents,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSAppMeshRoute_HttpRetryPolicy) AWSCloudFormationType() string {
+	return "AWS::AppMesh::Route.HttpRetryPolicy"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_HttpRetryPolicy) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_HttpRetryPolicy) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_HttpRetryPolicy) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_HttpRetryPolicy) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_HttpRetryPolicy) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_HttpRetryPolicy) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-appmesh-route_httproute.go
+++ b/cloudformation/resources/aws-appmesh-route_httproute.go
@@ -16,6 +16,11 @@ type AWSAppMeshRoute_HttpRoute struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproute.html#cfn-appmesh-route-httproute-match
 	Match *AWSAppMeshRoute_HttpRouteMatch `json:"Match,omitempty"`
 
+	// RetryPolicy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproute.html#cfn-appmesh-route-httproute-retrypolicy
+	RetryPolicy *AWSAppMeshRoute_HttpRetryPolicy `json:"RetryPolicy,omitempty"`
+
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy
 

--- a/cloudformation/resources/aws-appmesh-route_httprouteheader.go
+++ b/cloudformation/resources/aws-appmesh-route_httprouteheader.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSAppMeshRoute_HttpRouteHeader AWS CloudFormation Resource (AWS::AppMesh::Route.HttpRouteHeader)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httprouteheader.html
+type AWSAppMeshRoute_HttpRouteHeader struct {
+
+	// Invert AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httprouteheader.html#cfn-appmesh-route-httprouteheader-invert
+	Invert bool `json:"Invert,omitempty"`
+
+	// Match AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httprouteheader.html#cfn-appmesh-route-httprouteheader-match
+	Match *AWSAppMeshRoute_HeaderMatchMethod `json:"Match,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httprouteheader.html#cfn-appmesh-route-httprouteheader-name
+	Name string `json:"Name,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSAppMeshRoute_HttpRouteHeader) AWSCloudFormationType() string {
+	return "AWS::AppMesh::Route.HttpRouteHeader"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_HttpRouteHeader) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_HttpRouteHeader) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_HttpRouteHeader) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_HttpRouteHeader) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_HttpRouteHeader) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_HttpRouteHeader) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-appmesh-route_httproutematch.go
+++ b/cloudformation/resources/aws-appmesh-route_httproutematch.go
@@ -6,10 +6,25 @@ import "github.com/awslabs/goformation/cloudformation/policies"
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproutematch.html
 type AWSAppMeshRoute_HttpRouteMatch struct {
 
+	// Headers AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproutematch.html#cfn-appmesh-route-httproutematch-headers
+	Headers []AWSAppMeshRoute_HttpRouteHeader `json:"Headers,omitempty"`
+
+	// Method AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproutematch.html#cfn-appmesh-route-httproutematch-method
+	Method string `json:"Method,omitempty"`
+
 	// Prefix AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproutematch.html#cfn-appmesh-route-httproutematch-prefix
 	Prefix string `json:"Prefix,omitempty"`
+
+	// Scheme AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httproutematch.html#cfn-appmesh-route-httproutematch-scheme
+	Scheme string `json:"Scheme,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-appmesh-route_matchrange.go
+++ b/cloudformation/resources/aws-appmesh-route_matchrange.go
@@ -1,0 +1,68 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSAppMeshRoute_MatchRange AWS CloudFormation Resource (AWS::AppMesh::Route.MatchRange)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-matchrange.html
+type AWSAppMeshRoute_MatchRange struct {
+
+	// End AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-matchrange.html#cfn-appmesh-route-matchrange-end
+	End int `json:"End"`
+
+	// Start AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-matchrange.html#cfn-appmesh-route-matchrange-start
+	Start int `json:"Start"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSAppMeshRoute_MatchRange) AWSCloudFormationType() string {
+	return "AWS::AppMesh::Route.MatchRange"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_MatchRange) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSAppMeshRoute_MatchRange) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_MatchRange) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSAppMeshRoute_MatchRange) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_MatchRange) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSAppMeshRoute_MatchRange) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-appmesh-route_routespec.go
+++ b/cloudformation/resources/aws-appmesh-route_routespec.go
@@ -11,6 +11,11 @@ type AWSAppMeshRoute_RouteSpec struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-routespec.html#cfn-appmesh-route-routespec-httproute
 	HttpRoute *AWSAppMeshRoute_HttpRoute `json:"HttpRoute,omitempty"`
 
+	// Priority AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-routespec.html#cfn-appmesh-route-routespec-priority
+	Priority int `json:"Priority,omitempty"`
+
 	// TcpRoute AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-routespec.html#cfn-appmesh-route-routespec-tcproute

--- a/cloudformation/resources/aws-appsync-graphqlapi_logconfig.go
+++ b/cloudformation/resources/aws-appsync-graphqlapi_logconfig.go
@@ -11,6 +11,11 @@ type AWSAppSyncGraphQLApi_LogConfig struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-graphqlapi-logconfig.html#cfn-appsync-graphqlapi-logconfig-cloudwatchlogsrolearn
 	CloudWatchLogsRoleArn string `json:"CloudWatchLogsRoleArn,omitempty"`
 
+	// ExcludeVerboseContent AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-graphqlapi-logconfig.html#cfn-appsync-graphqlapi-logconfig-excludeverbosecontent
+	ExcludeVerboseContent bool `json:"ExcludeVerboseContent,omitempty"`
+
 	// FieldLogLevel AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-graphqlapi-logconfig.html#cfn-appsync-graphqlapi-logconfig-fieldloglevel

--- a/cloudformation/resources/aws-cloudwatch-alarm.go
+++ b/cloudformation/resources/aws-cloudwatch-alarm.go
@@ -97,9 +97,14 @@ type AWSCloudWatchAlarm struct {
 	Statistic string `json:"Statistic,omitempty"`
 
 	// Threshold AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold
-	Threshold float64 `json:"Threshold"`
+	Threshold float64 `json:"Threshold,omitempty"`
+
+	// ThresholdMetricId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-dynamic-threshold
+	ThresholdMetricId string `json:"ThresholdMetricId,omitempty"`
 
 	// TreatMissingData AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/resources/aws-cognito-userpool_admincreateuserconfig.go
+++ b/cloudformation/resources/aws-cognito-userpool_admincreateuserconfig.go
@@ -19,7 +19,7 @@ type AWSCognitoUserPool_AdminCreateUserConfig struct {
 	// UnusedAccountValidityDays AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-admincreateuserconfig.html#cfn-cognito-userpool-admincreateuserconfig-unusedaccountvaliditydays
-	UnusedAccountValidityDays float64 `json:"UnusedAccountValidityDays,omitempty"`
+	UnusedAccountValidityDays int `json:"UnusedAccountValidityDays,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-cognito-userpool_passwordpolicy.go
+++ b/cloudformation/resources/aws-cognito-userpool_passwordpolicy.go
@@ -34,7 +34,7 @@ type AWSCognitoUserPool_PasswordPolicy struct {
 	// TemporaryPasswordValidityDays AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-passwordpolicy.html#cfn-cognito-userpool-passwordpolicy-temporarypasswordvaliditydays
-	TemporaryPasswordValidityDays float64 `json:"TemporaryPasswordValidityDays,omitempty"`
+	TemporaryPasswordValidityDays int `json:"TemporaryPasswordValidityDays,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-cognito-userpoolclient.go
+++ b/cloudformation/resources/aws-cognito-userpoolclient.go
@@ -69,7 +69,7 @@ type AWSCognitoUserPoolClient struct {
 	// RefreshTokenValidity AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-refreshtokenvalidity
-	RefreshTokenValidity float64 `json:"RefreshTokenValidity,omitempty"`
+	RefreshTokenValidity int `json:"RefreshTokenValidity,omitempty"`
 
 	// SupportedIdentityProviders AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/resources/aws-config-organizationconfigrule.go
+++ b/cloudformation/resources/aws-config-organizationconfigrule.go
@@ -1,0 +1,138 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSConfigOrganizationConfigRule AWS CloudFormation Resource (AWS::Config::OrganizationConfigRule)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html
+type AWSConfigOrganizationConfigRule struct {
+
+	// ExcludedAccounts AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html#cfn-config-organizationconfigrule-excludedaccounts
+	ExcludedAccounts []string `json:"ExcludedAccounts,omitempty"`
+
+	// OrganizationConfigRuleName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html#cfn-config-organizationconfigrule-organizationconfigrulename
+	OrganizationConfigRuleName string `json:"OrganizationConfigRuleName,omitempty"`
+
+	// OrganizationCustomRuleMetadata AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata
+	OrganizationCustomRuleMetadata *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata `json:"OrganizationCustomRuleMetadata,omitempty"`
+
+	// OrganizationManagedRuleMetadata AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconfigrule.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata
+	OrganizationManagedRuleMetadata *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata `json:"OrganizationManagedRuleMetadata,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSConfigOrganizationConfigRule) AWSCloudFormationType() string {
+	return "AWS::Config::OrganizationConfigRule"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigOrganizationConfigRule) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigOrganizationConfigRule) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigOrganizationConfigRule) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigOrganizationConfigRule) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigOrganizationConfigRule) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigOrganizationConfigRule) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSConfigOrganizationConfigRule) MarshalJSON() ([]byte, error) {
+	type Properties AWSConfigOrganizationConfigRule
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSConfigOrganizationConfigRule) UnmarshalJSON(b []byte) error {
+	type Properties AWSConfigOrganizationConfigRule
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSConfigOrganizationConfigRule(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-config-organizationconfigrule_organizationcustomrulemetadata.go
+++ b/cloudformation/resources/aws-config-organizationconfigrule_organizationcustomrulemetadata.go
@@ -1,0 +1,103 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata AWS CloudFormation Resource (AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html
+type AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-description
+	Description string `json:"Description,omitempty"`
+
+	// InputParameters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-inputparameters
+	InputParameters string `json:"InputParameters,omitempty"`
+
+	// LambdaFunctionArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-lambdafunctionarn
+	LambdaFunctionArn string `json:"LambdaFunctionArn,omitempty"`
+
+	// MaximumExecutionFrequency AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-maximumexecutionfrequency
+	MaximumExecutionFrequency string `json:"MaximumExecutionFrequency,omitempty"`
+
+	// OrganizationConfigRuleTriggerTypes AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-organizationconfigruletriggertypes
+	OrganizationConfigRuleTriggerTypes []string `json:"OrganizationConfigRuleTriggerTypes,omitempty"`
+
+	// ResourceIdScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-resourceidscope
+	ResourceIdScope string `json:"ResourceIdScope,omitempty"`
+
+	// ResourceTypesScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-resourcetypesscope
+	ResourceTypesScope []string `json:"ResourceTypesScope,omitempty"`
+
+	// TagKeyScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-tagkeyscope
+	TagKeyScope string `json:"TagKeyScope,omitempty"`
+
+	// TagValueScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationcustomrulemetadata.html#cfn-config-organizationconfigrule-organizationcustomrulemetadata-tagvaluescope
+	TagValueScope string `json:"TagValueScope,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) AWSCloudFormationType() string {
+	return "AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationCustomRuleMetadata) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-config-organizationconfigrule_organizationmanagedrulemetadata.go
+++ b/cloudformation/resources/aws-config-organizationconfigrule_organizationmanagedrulemetadata.go
@@ -1,0 +1,98 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata AWS CloudFormation Resource (AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html
+type AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-description
+	Description string `json:"Description,omitempty"`
+
+	// InputParameters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-inputparameters
+	InputParameters string `json:"InputParameters,omitempty"`
+
+	// MaximumExecutionFrequency AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-maximumexecutionfrequency
+	MaximumExecutionFrequency string `json:"MaximumExecutionFrequency,omitempty"`
+
+	// ResourceIdScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-resourceidscope
+	ResourceIdScope string `json:"ResourceIdScope,omitempty"`
+
+	// ResourceTypesScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-resourcetypesscope
+	ResourceTypesScope []string `json:"ResourceTypesScope,omitempty"`
+
+	// RuleIdentifier AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-ruleidentifier
+	RuleIdentifier string `json:"RuleIdentifier,omitempty"`
+
+	// TagKeyScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-tagkeyscope
+	TagKeyScope string `json:"TagKeyScope,omitempty"`
+
+	// TagValueScope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconfigrule-organizationmanagedrulemetadata.html#cfn-config-organizationconfigrule-organizationmanagedrulemetadata-tagvaluescope
+	TagValueScope string `json:"TagValueScope,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) AWSCloudFormationType() string {
+	return "AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigOrganizationConfigRule_OrganizationManagedRuleMetadata) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-config-remediationconfiguration.go
+++ b/cloudformation/resources/aws-config-remediationconfiguration.go
@@ -11,10 +11,25 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html
 type AWSConfigRemediationConfiguration struct {
 
+	// Automatic AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html#cfn-config-remediationconfiguration-automatic
+	Automatic bool `json:"Automatic,omitempty"`
+
 	// ConfigRuleName AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html#cfn-config-remediationconfiguration-configrulename
 	ConfigRuleName string `json:"ConfigRuleName,omitempty"`
+
+	// ExecutionControls AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html#cfn-config-remediationconfiguration-executioncontrols
+	ExecutionControls *AWSConfigRemediationConfiguration_ExecutionControls `json:"ExecutionControls,omitempty"`
+
+	// MaximumAutomaticAttempts AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html#cfn-config-remediationconfiguration-maximumautomaticattempts
+	MaximumAutomaticAttempts int `json:"MaximumAutomaticAttempts,omitempty"`
 
 	// Parameters AWS CloudFormation Property
 	// Required: false
@@ -25,6 +40,11 @@ type AWSConfigRemediationConfiguration struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html#cfn-config-remediationconfiguration-resourcetype
 	ResourceType string `json:"ResourceType,omitempty"`
+
+	// RetryAttemptSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-remediationconfiguration.html#cfn-config-remediationconfiguration-retryattemptseconds
+	RetryAttemptSeconds int `json:"RetryAttemptSeconds,omitempty"`
 
 	// TargetId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/resources/aws-config-remediationconfiguration_executioncontrols.go
+++ b/cloudformation/resources/aws-config-remediationconfiguration_executioncontrols.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSConfigRemediationConfiguration_ExecutionControls AWS CloudFormation Resource (AWS::Config::RemediationConfiguration.ExecutionControls)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-remediationconfiguration-executioncontrols.html
+type AWSConfigRemediationConfiguration_ExecutionControls struct {
+
+	// SsmControls AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-remediationconfiguration-executioncontrols.html#cfn-config-remediationconfiguration-executioncontrols-ssmcontrols
+	SsmControls *AWSConfigRemediationConfiguration_SsmControls `json:"SsmControls,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) AWSCloudFormationType() string {
+	return "AWS::Config::RemediationConfiguration.ExecutionControls"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigRemediationConfiguration_ExecutionControls) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-config-remediationconfiguration_ssmcontrols.go
+++ b/cloudformation/resources/aws-config-remediationconfiguration_ssmcontrols.go
@@ -1,0 +1,68 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSConfigRemediationConfiguration_SsmControls AWS CloudFormation Resource (AWS::Config::RemediationConfiguration.SsmControls)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-remediationconfiguration-ssmcontrols.html
+type AWSConfigRemediationConfiguration_SsmControls struct {
+
+	// ConcurrentExecutionRatePercentage AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-remediationconfiguration-ssmcontrols.html#cfn-config-remediationconfiguration-ssmcontrols-concurrentexecutionratepercentage
+	ConcurrentExecutionRatePercentage int `json:"ConcurrentExecutionRatePercentage,omitempty"`
+
+	// ErrorPercentage AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-remediationconfiguration-ssmcontrols.html#cfn-config-remediationconfiguration-ssmcontrols-errorpercentage
+	ErrorPercentage int `json:"ErrorPercentage,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSConfigRemediationConfiguration_SsmControls) AWSCloudFormationType() string {
+	return "AWS::Config::RemediationConfiguration.SsmControls"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigRemediationConfiguration_SsmControls) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSConfigRemediationConfiguration_SsmControls) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigRemediationConfiguration_SsmControls) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSConfigRemediationConfiguration_SsmControls) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigRemediationConfiguration_SsmControls) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSConfigRemediationConfiguration_SsmControls) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-dms-replicationtask.go
+++ b/cloudformation/resources/aws-dms-replicationtask.go
@@ -11,10 +11,20 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationtask.html
 type AWSDMSReplicationTask struct {
 
+	// CdcStartPosition AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationtask.html#cfn-dms-replicationtask-cdcstartposition
+	CdcStartPosition string `json:"CdcStartPosition,omitempty"`
+
 	// CdcStartTime AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationtask.html#cfn-dms-replicationtask-cdcstarttime
 	CdcStartTime float64 `json:"CdcStartTime,omitempty"`
+
+	// CdcStopPosition AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationtask.html#cfn-dms-replicationtask-cdcstopposition
+	CdcStopPosition string `json:"CdcStopPosition,omitempty"`
 
 	// MigrationType AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/resources/aws-docdb-dbcluster.go
+++ b/cloudformation/resources/aws-docdb-dbcluster.go
@@ -36,6 +36,11 @@ type AWSDocDBDBCluster struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html#cfn-docdb-dbcluster-dbsubnetgroupname
 	DBSubnetGroupName string `json:"DBSubnetGroupName,omitempty"`
 
+	// EnableCloudwatchLogsExports AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html#cfn-docdb-dbcluster-enablecloudwatchlogsexports
+	EnableCloudwatchLogsExports []string `json:"EnableCloudwatchLogsExports,omitempty"`
+
 	// EngineVersion AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html#cfn-docdb-dbcluster-engineversion

--- a/cloudformation/resources/aws-dynamodb-table_ssespecification.go
+++ b/cloudformation/resources/aws-dynamodb-table_ssespecification.go
@@ -6,10 +6,20 @@ import "github.com/awslabs/goformation/cloudformation/policies"
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html
 type AWSDynamoDBTable_SSESpecification struct {
 
+	// KMSMasterKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html#cfn-dynamodb-table-ssespecification-kmsmasterkeyid
+	KMSMasterKeyId string `json:"KMSMasterKeyId,omitempty"`
+
 	// SSEEnabled AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html#cfn-dynamodb-table-ssespecification-sseenabled
 	SSEEnabled bool `json:"SSEEnabled"`
+
+	// SSEType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html#cfn-dynamodb-table-ssespecification-ssetype
+	SSEType string `json:"SSEType,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-ec2-clientvpnendpoint_tagspecification.go
+++ b/cloudformation/resources/aws-ec2-clientvpnendpoint_tagspecification.go
@@ -7,12 +7,12 @@ import "github.com/awslabs/goformation/cloudformation/policies"
 type AWSEC2ClientVpnEndpoint_TagSpecification struct {
 
 	// ResourceType AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-clientvpnendpoint-tagspecification.html#cfn-ec2-clientvpnendpoint-tagspecification-resourcetype
 	ResourceType string `json:"ResourceType,omitempty"`
 
 	// Tags AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-clientvpnendpoint-tagspecification.html#cfn-ec2-clientvpnendpoint-tagspecification-tags
 	Tags []Tag `json:"Tags,omitempty"`
 

--- a/cloudformation/resources/aws-ec2-instance.go
+++ b/cloudformation/resources/aws-ec2-instance.go
@@ -31,6 +31,11 @@ type AWSEC2Instance struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-blockdevicemappings
 	BlockDeviceMappings []AWSEC2Instance_BlockDeviceMapping `json:"BlockDeviceMappings,omitempty"`
 
+	// CpuOptions AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-cpuoptions
+	CpuOptions *AWSEC2Instance_CpuOptions `json:"CpuOptions,omitempty"`
+
 	// CreditSpecification AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-creditspecification

--- a/cloudformation/resources/aws-ec2-instance_cpuoptions.go
+++ b/cloudformation/resources/aws-ec2-instance_cpuoptions.go
@@ -1,0 +1,68 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSEC2Instance_CpuOptions AWS CloudFormation Resource (AWS::EC2::Instance.CpuOptions)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-cpuoptions.html
+type AWSEC2Instance_CpuOptions struct {
+
+	// CoreCount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-cpuoptions.html#cfn-ec2-instance-cpuoptions-corecount
+	CoreCount int `json:"CoreCount,omitempty"`
+
+	// ThreadsPerCore AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-cpuoptions.html#cfn-ec2-instance-cpuoptions-threadspercore
+	ThreadsPerCore int `json:"ThreadsPerCore,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSEC2Instance_CpuOptions) AWSCloudFormationType() string {
+	return "AWS::EC2::Instance.CpuOptions"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEC2Instance_CpuOptions) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEC2Instance_CpuOptions) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEC2Instance_CpuOptions) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEC2Instance_CpuOptions) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEC2Instance_CpuOptions) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEC2Instance_CpuOptions) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-ec2-instance_ebs.go
+++ b/cloudformation/resources/aws-ec2-instance_ebs.go
@@ -21,6 +21,11 @@ type AWSEC2Instance_Ebs struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html#cfn-ec2-blockdev-template-iops
 	Iops int `json:"Iops,omitempty"`
 
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html#cfn-ec2-instance-ebs-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
 	// SnapshotId AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html#cfn-ec2-blockdev-template-snapshotid

--- a/cloudformation/resources/aws-ec2-vpcendpointservice.go
+++ b/cloudformation/resources/aws-ec2-vpcendpointservice.go
@@ -1,0 +1,128 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSEC2VPCEndpointService AWS CloudFormation Resource (AWS::EC2::VPCEndpointService)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservice.html
+type AWSEC2VPCEndpointService struct {
+
+	// AcceptanceRequired AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservice.html#cfn-ec2-vpcendpointservice-acceptancerequired
+	AcceptanceRequired bool `json:"AcceptanceRequired,omitempty"`
+
+	// NetworkLoadBalancerArns AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservice.html#cfn-ec2-vpcendpointservice-networkloadbalancerarns
+	NetworkLoadBalancerArns []string `json:"NetworkLoadBalancerArns,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSEC2VPCEndpointService) AWSCloudFormationType() string {
+	return "AWS::EC2::VPCEndpointService"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEC2VPCEndpointService) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEC2VPCEndpointService) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEC2VPCEndpointService) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEC2VPCEndpointService) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEC2VPCEndpointService) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEC2VPCEndpointService) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSEC2VPCEndpointService) MarshalJSON() ([]byte, error) {
+	type Properties AWSEC2VPCEndpointService
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSEC2VPCEndpointService) UnmarshalJSON(b []byte) error {
+	type Properties AWSEC2VPCEndpointService
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSEC2VPCEndpointService(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-ecs-taskdefinition.go
+++ b/cloudformation/resources/aws-ecs-taskdefinition.go
@@ -31,6 +31,11 @@ type AWSECSTaskDefinition struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-family
 	Family string `json:"Family,omitempty"`
 
+	// IpcMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-ipcmode
+	IpcMode string `json:"IpcMode,omitempty"`
+
 	// Memory AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-memory
@@ -40,6 +45,11 @@ type AWSECSTaskDefinition struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-networkmode
 	NetworkMode string `json:"NetworkMode,omitempty"`
+
+	// PidMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-pidmode
+	PidMode string `json:"PidMode,omitempty"`
 
 	// PlacementConstraints AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/resources/aws-ecs-taskdefinition_containerdefinition.go
+++ b/cloudformation/resources/aws-ecs-taskdefinition_containerdefinition.go
@@ -81,6 +81,11 @@ type AWSECSTaskDefinition_ContainerDefinition struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-image
 	Image string `json:"Image,omitempty"`
 
+	// Interactive AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-interactive
+	Interactive bool `json:"Interactive,omitempty"`
+
 	// Links AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-links
@@ -126,6 +131,11 @@ type AWSECSTaskDefinition_ContainerDefinition struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-privileged
 	Privileged bool `json:"Privileged,omitempty"`
 
+	// PseudoTerminal AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-pseudoterminal
+	PseudoTerminal bool `json:"PseudoTerminal,omitempty"`
+
 	// ReadonlyRootFilesystem AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-readonlyrootfilesystem
@@ -155,6 +165,11 @@ type AWSECSTaskDefinition_ContainerDefinition struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-stoptimeout
 	StopTimeout int `json:"StopTimeout,omitempty"`
+
+	// SystemControls AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-systemcontrols
+	SystemControls []AWSECSTaskDefinition_SystemControl `json:"SystemControls,omitempty"`
 
 	// Ulimits AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/resources/aws-ecs-taskdefinition_logconfiguration.go
+++ b/cloudformation/resources/aws-ecs-taskdefinition_logconfiguration.go
@@ -16,6 +16,11 @@ type AWSECSTaskDefinition_LogConfiguration struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.html#cfn-ecs-taskdefinition-containerdefinition-logconfiguration-options
 	Options map[string]string `json:"Options,omitempty"`
 
+	// SecretOptions AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-logconfiguration.html#cfn-ecs-taskdefinition-logconfiguration-secretoptions
+	SecretOptions []AWSECSTaskDefinition_Secret `json:"SecretOptions,omitempty"`
+
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy
 

--- a/cloudformation/resources/aws-ecs-taskdefinition_systemcontrol.go
+++ b/cloudformation/resources/aws-ecs-taskdefinition_systemcontrol.go
@@ -1,0 +1,68 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSECSTaskDefinition_SystemControl AWS CloudFormation Resource (AWS::ECS::TaskDefinition.SystemControl)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-systemcontrol.html
+type AWSECSTaskDefinition_SystemControl struct {
+
+	// Namespace AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-systemcontrol.html#cfn-ecs-taskdefinition-systemcontrol-namespace
+	Namespace string `json:"Namespace,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-systemcontrol.html#cfn-ecs-taskdefinition-systemcontrol-value
+	Value string `json:"Value,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSECSTaskDefinition_SystemControl) AWSCloudFormationType() string {
+	return "AWS::ECS::TaskDefinition.SystemControl"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSECSTaskDefinition_SystemControl) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSECSTaskDefinition_SystemControl) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSECSTaskDefinition_SystemControl) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSECSTaskDefinition_SystemControl) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSECSTaskDefinition_SystemControl) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSECSTaskDefinition_SystemControl) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-ecs-taskdefinition_tmpfs.go
+++ b/cloudformation/resources/aws-ecs-taskdefinition_tmpfs.go
@@ -17,9 +17,9 @@ type AWSECSTaskDefinition_Tmpfs struct {
 	MountOptions []string `json:"MountOptions,omitempty"`
 
 	// Size AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-tmpfs.html#cfn-ecs-taskdefinition-tmpfs-size
-	Size int `json:"Size,omitempty"`
+	Size int `json:"Size"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-elasticache-replicationgroup.go
+++ b/cloudformation/resources/aws-elasticache-replicationgroup.go
@@ -61,6 +61,11 @@ type AWSElastiCacheReplicationGroup struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-engineversion
 	EngineVersion string `json:"EngineVersion,omitempty"`
 
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
 	// NodeGroupConfiguration AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-nodegroupconfiguration

--- a/cloudformation/resources/aws-elasticsearch-domain_elasticsearchclusterconfig.go
+++ b/cloudformation/resources/aws-elasticsearch-domain_elasticsearchclusterconfig.go
@@ -31,6 +31,11 @@ type AWSElasticsearchDomain_ElasticsearchClusterConfig struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-elasticsearchclusterconfig.html#cfn-elasticsearch-domain-elasticseachclusterconfig-instnacetype
 	InstanceType string `json:"InstanceType,omitempty"`
 
+	// ZoneAwarenessConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-elasticsearchclusterconfig.html#cfn-elasticsearch-domain-elasticsearchclusterconfig-zoneawarenessconfig
+	ZoneAwarenessConfig *AWSElasticsearchDomain_ZoneAwarenessConfig `json:"ZoneAwarenessConfig,omitempty"`
+
 	// ZoneAwarenessEnabled AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-elasticsearchclusterconfig.html#cfn-elasticsearch-domain-elasticseachclusterconfig-zoneawarenessenabled

--- a/cloudformation/resources/aws-elasticsearch-domain_zoneawarenessconfig.go
+++ b/cloudformation/resources/aws-elasticsearch-domain_zoneawarenessconfig.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSElasticsearchDomain_ZoneAwarenessConfig AWS CloudFormation Resource (AWS::Elasticsearch::Domain.ZoneAwarenessConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-zoneawarenessconfig.html
+type AWSElasticsearchDomain_ZoneAwarenessConfig struct {
+
+	// AvailabilityZoneCount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-zoneawarenessconfig.html#cfn-elasticsearch-domain-zoneawarenessconfig-availabilityzonecount
+	AvailabilityZoneCount int `json:"AvailabilityZoneCount,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) AWSCloudFormationType() string {
+	return "AWS::Elasticsearch::Domain.ZoneAwarenessConfig"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSElasticsearchDomain_ZoneAwarenessConfig) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-events-rule_awsvpcconfiguration.go
+++ b/cloudformation/resources/aws-events-rule_awsvpcconfiguration.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSEventsRule_AwsVpcConfiguration AWS CloudFormation Resource (AWS::Events::Rule.AwsVpcConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-awsvpcconfiguration.html
+type AWSEventsRule_AwsVpcConfiguration struct {
+
+	// AssignPublicIp AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-awsvpcconfiguration.html#cfn-events-rule-awsvpcconfiguration-assignpublicip
+	AssignPublicIp string `json:"AssignPublicIp,omitempty"`
+
+	// SecurityGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-awsvpcconfiguration.html#cfn-events-rule-awsvpcconfiguration-securitygroups
+	SecurityGroups []string `json:"SecurityGroups,omitempty"`
+
+	// Subnets AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-awsvpcconfiguration.html#cfn-events-rule-awsvpcconfiguration-subnets
+	Subnets []string `json:"Subnets,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSEventsRule_AwsVpcConfiguration) AWSCloudFormationType() string {
+	return "AWS::Events::Rule.AwsVpcConfiguration"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEventsRule_AwsVpcConfiguration) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEventsRule_AwsVpcConfiguration) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEventsRule_AwsVpcConfiguration) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEventsRule_AwsVpcConfiguration) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEventsRule_AwsVpcConfiguration) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEventsRule_AwsVpcConfiguration) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-events-rule_ecsparameters.go
+++ b/cloudformation/resources/aws-events-rule_ecsparameters.go
@@ -6,6 +6,26 @@ import "github.com/awslabs/goformation/cloudformation/policies"
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-ecsparameters.html
 type AWSEventsRule_EcsParameters struct {
 
+	// Group AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-ecsparameters.html#cfn-events-rule-ecsparameters-group
+	Group string `json:"Group,omitempty"`
+
+	// LaunchType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-ecsparameters.html#cfn-events-rule-ecsparameters-launchtype
+	LaunchType string `json:"LaunchType,omitempty"`
+
+	// NetworkConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-ecsparameters.html#cfn-events-rule-ecsparameters-networkconfiguration
+	NetworkConfiguration *AWSEventsRule_NetworkConfiguration `json:"NetworkConfiguration,omitempty"`
+
+	// PlatformVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-ecsparameters.html#cfn-events-rule-ecsparameters-platformversion
+	PlatformVersion string `json:"PlatformVersion,omitempty"`
+
 	// TaskCount AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-ecsparameters.html#cfn-events-rule-ecsparameters-taskcount

--- a/cloudformation/resources/aws-events-rule_networkconfiguration.go
+++ b/cloudformation/resources/aws-events-rule_networkconfiguration.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSEventsRule_NetworkConfiguration AWS CloudFormation Resource (AWS::Events::Rule.NetworkConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-networkconfiguration.html
+type AWSEventsRule_NetworkConfiguration struct {
+
+	// AwsVpcConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-networkconfiguration.html#cfn-events-rule-networkconfiguration-awsvpcconfiguration
+	AwsVpcConfiguration *AWSEventsRule_AwsVpcConfiguration `json:"AwsVpcConfiguration,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSEventsRule_NetworkConfiguration) AWSCloudFormationType() string {
+	return "AWS::Events::Rule.NetworkConfiguration"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEventsRule_NetworkConfiguration) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSEventsRule_NetworkConfiguration) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEventsRule_NetworkConfiguration) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSEventsRule_NetworkConfiguration) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEventsRule_NetworkConfiguration) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSEventsRule_NetworkConfiguration) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-glue-devendpoint.go
+++ b/cloudformation/resources/aws-glue-devendpoint.go
@@ -11,6 +11,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html
 type AWSGlueDevEndpoint struct {
 
+	// Arguments AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-arguments
+	Arguments interface{} `json:"Arguments,omitempty"`
+
 	// EndpointName AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-endpointname
@@ -26,10 +31,20 @@ type AWSGlueDevEndpoint struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-extrapythonlibss3path
 	ExtraPythonLibsS3Path string `json:"ExtraPythonLibsS3Path,omitempty"`
 
+	// GlueVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-glueversion
+	GlueVersion string `json:"GlueVersion,omitempty"`
+
 	// NumberOfNodes AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-numberofnodes
 	NumberOfNodes int `json:"NumberOfNodes,omitempty"`
+
+	// NumberOfWorkers AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-numberofworkers
+	NumberOfWorkers int `json:"NumberOfWorkers,omitempty"`
 
 	// PublicKey AWS CloudFormation Property
 	// Required: false
@@ -60,6 +75,11 @@ type AWSGlueDevEndpoint struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-tags
 	Tags interface{} `json:"Tags,omitempty"`
+
+	// WorkerType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-devendpoint.html#cfn-glue-devendpoint-workertype
+	WorkerType string `json:"WorkerType,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-glue-job.go
+++ b/cloudformation/resources/aws-glue-job.go
@@ -66,6 +66,11 @@ type AWSGlueJob struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html#cfn-glue-job-name
 	Name string `json:"Name,omitempty"`
 
+	// NotificationProperty AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html#cfn-glue-job-notificationproperty
+	NotificationProperty *AWSGlueJob_NotificationProperty `json:"NotificationProperty,omitempty"`
+
 	// NumberOfWorkers AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html#cfn-glue-job-numberofworkers
@@ -85,6 +90,11 @@ type AWSGlueJob struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html#cfn-glue-job-tags
 	Tags interface{} `json:"Tags,omitempty"`
+
+	// Timeout AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-job.html#cfn-glue-job-timeout
+	Timeout int `json:"Timeout,omitempty"`
 
 	// WorkerType AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/resources/aws-glue-job_notificationproperty.go
+++ b/cloudformation/resources/aws-glue-job_notificationproperty.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSGlueJob_NotificationProperty AWS CloudFormation Resource (AWS::Glue::Job.NotificationProperty)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-job-notificationproperty.html
+type AWSGlueJob_NotificationProperty struct {
+
+	// NotifyDelayAfter AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-job-notificationproperty.html#cfn-glue-job-notificationproperty-notifydelayafter
+	NotifyDelayAfter int `json:"NotifyDelayAfter,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSGlueJob_NotificationProperty) AWSCloudFormationType() string {
+	return "AWS::Glue::Job.NotificationProperty"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSGlueJob_NotificationProperty) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSGlueJob_NotificationProperty) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSGlueJob_NotificationProperty) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSGlueJob_NotificationProperty) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSGlueJob_NotificationProperty) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSGlueJob_NotificationProperty) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-glue-trigger.go
+++ b/cloudformation/resources/aws-glue-trigger.go
@@ -36,6 +36,11 @@ type AWSGlueTrigger struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html#cfn-glue-trigger-schedule
 	Schedule string `json:"Schedule,omitempty"`
 
+	// StartOnCreation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html#cfn-glue-trigger-startoncreation
+	StartOnCreation bool `json:"StartOnCreation,omitempty"`
+
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html#cfn-glue-trigger-tags
@@ -45,6 +50,11 @@ type AWSGlueTrigger struct {
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html#cfn-glue-trigger-type
 	Type string `json:"Type,omitempty"`
+
+	// WorkflowName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-trigger.html#cfn-glue-trigger-workflowname
+	WorkflowName string `json:"WorkflowName,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-glue-trigger_action.go
+++ b/cloudformation/resources/aws-glue-trigger_action.go
@@ -11,15 +11,30 @@ type AWSGlueTrigger_Action struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-action.html#cfn-glue-trigger-action-arguments
 	Arguments interface{} `json:"Arguments,omitempty"`
 
+	// CrawlerName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-action.html#cfn-glue-trigger-action-crawlername
+	CrawlerName string `json:"CrawlerName,omitempty"`
+
 	// JobName AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-action.html#cfn-glue-trigger-action-jobname
 	JobName string `json:"JobName,omitempty"`
 
+	// NotificationProperty AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-action.html#cfn-glue-trigger-action-notificationproperty
+	NotificationProperty *AWSGlueTrigger_NotificationProperty `json:"NotificationProperty,omitempty"`
+
 	// SecurityConfiguration AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-action.html#cfn-glue-trigger-action-securityconfiguration
 	SecurityConfiguration string `json:"SecurityConfiguration,omitempty"`
+
+	// Timeout AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-action.html#cfn-glue-trigger-action-timeout
+	Timeout int `json:"Timeout,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-glue-trigger_condition.go
+++ b/cloudformation/resources/aws-glue-trigger_condition.go
@@ -6,6 +6,16 @@ import "github.com/awslabs/goformation/cloudformation/policies"
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-condition.html
 type AWSGlueTrigger_Condition struct {
 
+	// CrawlState AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-condition.html#cfn-glue-trigger-condition-crawlstate
+	CrawlState string `json:"CrawlState,omitempty"`
+
+	// CrawlerName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-condition.html#cfn-glue-trigger-condition-crawlername
+	CrawlerName string `json:"CrawlerName,omitempty"`
+
 	// JobName AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-condition.html#cfn-glue-trigger-condition-jobname

--- a/cloudformation/resources/aws-glue-trigger_notificationproperty.go
+++ b/cloudformation/resources/aws-glue-trigger_notificationproperty.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSGlueTrigger_NotificationProperty AWS CloudFormation Resource (AWS::Glue::Trigger.NotificationProperty)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-notificationproperty.html
+type AWSGlueTrigger_NotificationProperty struct {
+
+	// NotifyDelayAfter AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-notificationproperty.html#cfn-glue-trigger-notificationproperty-notifydelayafter
+	NotifyDelayAfter int `json:"NotifyDelayAfter,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSGlueTrigger_NotificationProperty) AWSCloudFormationType() string {
+	return "AWS::Glue::Trigger.NotificationProperty"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSGlueTrigger_NotificationProperty) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSGlueTrigger_NotificationProperty) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSGlueTrigger_NotificationProperty) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSGlueTrigger_NotificationProperty) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSGlueTrigger_NotificationProperty) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSGlueTrigger_NotificationProperty) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-glue-workflow.go
+++ b/cloudformation/resources/aws-glue-workflow.go
@@ -1,0 +1,138 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSGlueWorkflow AWS CloudFormation Resource (AWS::Glue::Workflow)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html
+type AWSGlueWorkflow struct {
+
+	// DefaultRunProperties AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html#cfn-glue-workflow-defaultrunproperties
+	DefaultRunProperties interface{} `json:"DefaultRunProperties,omitempty"`
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html#cfn-glue-workflow-description
+	Description string `json:"Description,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html#cfn-glue-workflow-name
+	Name string `json:"Name,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-glue-workflow.html#cfn-glue-workflow-tags
+	Tags interface{} `json:"Tags,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSGlueWorkflow) AWSCloudFormationType() string {
+	return "AWS::Glue::Workflow"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSGlueWorkflow) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSGlueWorkflow) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSGlueWorkflow) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSGlueWorkflow) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSGlueWorkflow) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSGlueWorkflow) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSGlueWorkflow) MarshalJSON() ([]byte, error) {
+	type Properties AWSGlueWorkflow
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSGlueWorkflow) UnmarshalJSON(b []byte) error {
+	type Properties AWSGlueWorkflow
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSGlueWorkflow(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-iam-role.go
+++ b/cloudformation/resources/aws-iam-role.go
@@ -16,6 +16,11 @@ type AWSIAMRole struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-assumerolepolicydocument
 	AssumeRolePolicyDocument interface{} `json:"AssumeRolePolicyDocument,omitempty"`
 
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-description
+	Description string `json:"Description,omitempty"`
+
 	// ManagedPolicyArns AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-managepolicyarns
@@ -45,6 +50,11 @@ type AWSIAMRole struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-rolename
 	RoleName string `json:"RoleName,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-tags
+	Tags []Tag `json:"Tags,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-lambda-eventsourcemapping.go
+++ b/cloudformation/resources/aws-lambda-eventsourcemapping.go
@@ -31,6 +31,11 @@ type AWSLambdaEventSourceMapping struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-functionname
 	FunctionName string `json:"FunctionName,omitempty"`
 
+	// MaximumBatchingWindowInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumbatchingwindowinseconds
+	MaximumBatchingWindowInSeconds int `json:"MaximumBatchingWindowInSeconds,omitempty"`
+
 	// StartingPosition AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition

--- a/cloudformation/resources/aws-neptune-dbcluster.go
+++ b/cloudformation/resources/aws-neptune-dbcluster.go
@@ -36,6 +36,11 @@ type AWSNeptuneDBCluster struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-dbsubnetgroupname
 	DBSubnetGroupName string `json:"DBSubnetGroupName,omitempty"`
 
+	// EnableCloudwatchLogsExports AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-enablecloudwatchlogsexports
+	EnableCloudwatchLogsExports []string `json:"EnableCloudwatchLogsExports,omitempty"`
+
 	// IamAuthEnabled AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-iamauthenabled

--- a/cloudformation/resources/aws-qldb-ledger.go
+++ b/cloudformation/resources/aws-qldb-ledger.go
@@ -1,0 +1,138 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSQLDBLedger AWS CloudFormation Resource (AWS::QLDB::Ledger)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html
+type AWSQLDBLedger struct {
+
+	// DeletionProtection AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html#cfn-qldb-ledger-deletionprotection
+	DeletionProtection bool `json:"DeletionProtection,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html#cfn-qldb-ledger-name
+	Name string `json:"Name,omitempty"`
+
+	// PermissionsMode AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html#cfn-qldb-ledger-permissionsmode
+	PermissionsMode string `json:"PermissionsMode,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-qldb-ledger.html#cfn-qldb-ledger-tags
+	Tags []Tag `json:"Tags,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSQLDBLedger) AWSCloudFormationType() string {
+	return "AWS::QLDB::Ledger"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSQLDBLedger) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSQLDBLedger) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSQLDBLedger) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSQLDBLedger) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSQLDBLedger) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSQLDBLedger) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSQLDBLedger) MarshalJSON() ([]byte, error) {
+	type Properties AWSQLDBLedger
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSQLDBLedger) UnmarshalJSON(b []byte) error {
+	type Properties AWSQLDBLedger
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSQLDBLedger(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-rds-dbcluster.go
+++ b/cloudformation/resources/aws-rds-dbcluster.go
@@ -11,6 +11,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html
 type AWSRDSDBCluster struct {
 
+	// AssociatedRoles AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-associatedroles
+	AssociatedRoles []AWSRDSDBCluster_DBClusterRole `json:"AssociatedRoles,omitempty"`
+
 	// AvailabilityZones AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-availabilityzones
@@ -111,6 +116,11 @@ type AWSRDSDBCluster struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-replicationsourceidentifier
 	ReplicationSourceIdentifier string `json:"ReplicationSourceIdentifier,omitempty"`
 
+	// RestoreType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-restoretype
+	RestoreType string `json:"RestoreType,omitempty"`
+
 	// ScalingConfiguration AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-scalingconfiguration
@@ -120,6 +130,11 @@ type AWSRDSDBCluster struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-snapshotidentifier
 	SnapshotIdentifier string `json:"SnapshotIdentifier,omitempty"`
+
+	// SourceDBClusterIdentifier AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-sourcedbclusteridentifier
+	SourceDBClusterIdentifier string `json:"SourceDBClusterIdentifier,omitempty"`
 
 	// SourceRegion AWS CloudFormation Property
 	// Required: false
@@ -135,6 +150,11 @@ type AWSRDSDBCluster struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-tags
 	Tags []Tag `json:"Tags,omitempty"`
+
+	// UseLatestRestorableTime AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-uselatestrestorabletime
+	UseLatestRestorableTime bool `json:"UseLatestRestorableTime,omitempty"`
 
 	// VpcSecurityGroupIds AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/resources/aws-rds-dbcluster_dbclusterrole.go
+++ b/cloudformation/resources/aws-rds-dbcluster_dbclusterrole.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSRDSDBCluster_DBClusterRole AWS CloudFormation Resource (AWS::RDS::DBCluster.DBClusterRole)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-dbclusterrole.html
+type AWSRDSDBCluster_DBClusterRole struct {
+
+	// FeatureName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-dbclusterrole.html#cfn-rds-dbcluster-dbclusterrole-featurename
+	FeatureName string `json:"FeatureName,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-dbclusterrole.html#cfn-rds-dbcluster-dbclusterrole-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// Status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-dbclusterrole.html#cfn-rds-dbcluster-dbclusterrole-status
+	Status string `json:"Status,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSRDSDBCluster_DBClusterRole) AWSCloudFormationType() string {
+	return "AWS::RDS::DBCluster.DBClusterRole"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSRDSDBCluster_DBClusterRole) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSRDSDBCluster_DBClusterRole) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSRDSDBCluster_DBClusterRole) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSRDSDBCluster_DBClusterRole) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSRDSDBCluster_DBClusterRole) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSRDSDBCluster_DBClusterRole) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-rds-dbinstance.go
+++ b/cloudformation/resources/aws-rds-dbinstance.go
@@ -21,6 +21,11 @@ type AWSRDSDBInstance struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-allowmajorversionupgrade
 	AllowMajorVersionUpgrade bool `json:"AllowMajorVersionUpgrade,omitempty"`
 
+	// AssociatedRoles AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-associatedroles
+	AssociatedRoles []AWSRDSDBInstance_DBInstanceRole `json:"AssociatedRoles,omitempty"`
+
 	// AutoMinorVersionUpgrade AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-autominorversionupgrade

--- a/cloudformation/resources/aws-rds-dbinstance_dbinstancerole.go
+++ b/cloudformation/resources/aws-rds-dbinstance_dbinstancerole.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSRDSDBInstance_DBInstanceRole AWS CloudFormation Resource (AWS::RDS::DBInstance.DBInstanceRole)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbinstance-dbinstancerole.html
+type AWSRDSDBInstance_DBInstanceRole struct {
+
+	// FeatureName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbinstance-dbinstancerole.html#cfn-rds-dbinstance-dbinstancerole-featurename
+	FeatureName string `json:"FeatureName,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbinstance-dbinstancerole.html#cfn-rds-dbinstance-dbinstancerole-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// Status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbinstance-dbinstancerole.html#cfn-rds-dbinstance-dbinstancerole-status
+	Status string `json:"Status,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSRDSDBInstance_DBInstanceRole) AWSCloudFormationType() string {
+	return "AWS::RDS::DBInstance.DBInstanceRole"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSRDSDBInstance_DBInstanceRole) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSRDSDBInstance_DBInstanceRole) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSRDSDBInstance_DBInstanceRole) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSRDSDBInstance_DBInstanceRole) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSRDSDBInstance_DBInstanceRole) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSRDSDBInstance_DBInstanceRole) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-sagemaker-coderepository.go
+++ b/cloudformation/resources/aws-sagemaker-coderepository.go
@@ -1,0 +1,128 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSSageMakerCodeRepository AWS CloudFormation Resource (AWS::SageMaker::CodeRepository)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-coderepository.html
+type AWSSageMakerCodeRepository struct {
+
+	// CodeRepositoryName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-coderepository.html#cfn-sagemaker-coderepository-coderepositoryname
+	CodeRepositoryName string `json:"CodeRepositoryName,omitempty"`
+
+	// GitConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-coderepository.html#cfn-sagemaker-coderepository-gitconfig
+	GitConfig *AWSSageMakerCodeRepository_GitConfig `json:"GitConfig,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSageMakerCodeRepository) AWSCloudFormationType() string {
+	return "AWS::SageMaker::CodeRepository"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerCodeRepository) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerCodeRepository) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerCodeRepository) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerCodeRepository) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerCodeRepository) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerCodeRepository) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSSageMakerCodeRepository) MarshalJSON() ([]byte, error) {
+	type Properties AWSSageMakerCodeRepository
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSSageMakerCodeRepository) UnmarshalJSON(b []byte) error {
+	type Properties AWSSageMakerCodeRepository
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSSageMakerCodeRepository(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-sagemaker-coderepository_gitconfig.go
+++ b/cloudformation/resources/aws-sagemaker-coderepository_gitconfig.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSSageMakerCodeRepository_GitConfig AWS CloudFormation Resource (AWS::SageMaker::CodeRepository.GitConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-coderepository-gitconfig.html
+type AWSSageMakerCodeRepository_GitConfig struct {
+
+	// Branch AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-coderepository-gitconfig.html#cfn-sagemaker-coderepository-gitconfig-branch
+	Branch string `json:"Branch,omitempty"`
+
+	// RepositoryUrl AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-coderepository-gitconfig.html#cfn-sagemaker-coderepository-gitconfig-repositoryurl
+	RepositoryUrl string `json:"RepositoryUrl,omitempty"`
+
+	// SecretArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-coderepository-gitconfig.html#cfn-sagemaker-coderepository-gitconfig-secretarn
+	SecretArn string `json:"SecretArn,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSageMakerCodeRepository_GitConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::CodeRepository.GitConfig"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerCodeRepository_GitConfig) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerCodeRepository_GitConfig) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerCodeRepository_GitConfig) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerCodeRepository_GitConfig) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerCodeRepository_GitConfig) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerCodeRepository_GitConfig) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-sagemaker-workteam.go
+++ b/cloudformation/resources/aws-sagemaker-workteam.go
@@ -1,0 +1,143 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSSageMakerWorkteam AWS CloudFormation Resource (AWS::SageMaker::Workteam)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html
+type AWSSageMakerWorkteam struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html#cfn-sagemaker-workteam-description
+	Description string `json:"Description,omitempty"`
+
+	// MemberDefinitions AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html#cfn-sagemaker-workteam-memberdefinitions
+	MemberDefinitions []AWSSageMakerWorkteam_MemberDefinition `json:"MemberDefinitions,omitempty"`
+
+	// NotificationConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html#cfn-sagemaker-workteam-notificationconfiguration
+	NotificationConfiguration *AWSSageMakerWorkteam_NotificationConfiguration `json:"NotificationConfiguration,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html#cfn-sagemaker-workteam-tags
+	Tags []Tag `json:"Tags,omitempty"`
+
+	// WorkteamName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-workteam.html#cfn-sagemaker-workteam-workteamname
+	WorkteamName string `json:"WorkteamName,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSageMakerWorkteam) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Workteam"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSSageMakerWorkteam) MarshalJSON() ([]byte, error) {
+	type Properties AWSSageMakerWorkteam
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSSageMakerWorkteam) UnmarshalJSON(b []byte) error {
+	type Properties AWSSageMakerWorkteam
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSSageMakerWorkteam(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-sagemaker-workteam_cognitomemberdefinition.go
+++ b/cloudformation/resources/aws-sagemaker-workteam_cognitomemberdefinition.go
@@ -1,0 +1,73 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSSageMakerWorkteam_CognitoMemberDefinition AWS CloudFormation Resource (AWS::SageMaker::Workteam.CognitoMemberDefinition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-cognitomemberdefinition.html
+type AWSSageMakerWorkteam_CognitoMemberDefinition struct {
+
+	// CognitoClientId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-cognitomemberdefinition.html#cfn-sagemaker-workteam-cognitomemberdefinition-cognitoclientid
+	CognitoClientId string `json:"CognitoClientId,omitempty"`
+
+	// CognitoUserGroup AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-cognitomemberdefinition.html#cfn-sagemaker-workteam-cognitomemberdefinition-cognitousergroup
+	CognitoUserGroup string `json:"CognitoUserGroup,omitempty"`
+
+	// CognitoUserPool AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-cognitomemberdefinition.html#cfn-sagemaker-workteam-cognitomemberdefinition-cognitouserpool
+	CognitoUserPool string `json:"CognitoUserPool,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Workteam.CognitoMemberDefinition"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam_CognitoMemberDefinition) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-sagemaker-workteam_memberdefinition.go
+++ b/cloudformation/resources/aws-sagemaker-workteam_memberdefinition.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSSageMakerWorkteam_MemberDefinition AWS CloudFormation Resource (AWS::SageMaker::Workteam.MemberDefinition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-memberdefinition.html
+type AWSSageMakerWorkteam_MemberDefinition struct {
+
+	// CognitoMemberDefinition AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-memberdefinition.html#cfn-sagemaker-workteam-memberdefinition-cognitomemberdefinition
+	CognitoMemberDefinition *AWSSageMakerWorkteam_CognitoMemberDefinition `json:"CognitoMemberDefinition,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSageMakerWorkteam_MemberDefinition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Workteam.MemberDefinition"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam_MemberDefinition) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam_MemberDefinition) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam_MemberDefinition) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam_MemberDefinition) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam_MemberDefinition) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam_MemberDefinition) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-sagemaker-workteam_notificationconfiguration.go
+++ b/cloudformation/resources/aws-sagemaker-workteam_notificationconfiguration.go
@@ -1,0 +1,63 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSSageMakerWorkteam_NotificationConfiguration AWS CloudFormation Resource (AWS::SageMaker::Workteam.NotificationConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-notificationconfiguration.html
+type AWSSageMakerWorkteam_NotificationConfiguration struct {
+
+	// NotificationTopicArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-workteam-notificationconfiguration.html#cfn-sagemaker-workteam-notificationconfiguration-notificationtopicarn
+	NotificationTopicArn string `json:"NotificationTopicArn,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Workteam.NotificationConfiguration"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSageMakerWorkteam_NotificationConfiguration) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/aws-serverless-function_s3location.go
+++ b/cloudformation/resources/aws-serverless-function_s3location.go
@@ -17,9 +17,9 @@ type AWSServerlessFunction_S3Location struct {
 	Key string `json:"Key,omitempty"`
 
 	// Version AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-	Version int `json:"Version"`
+	Version int `json:"Version,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy
 	_deletionPolicy policies.DeletionPolicy

--- a/cloudformation/resources/aws-ssm-maintenancewindowtarget.go
+++ b/cloudformation/resources/aws-ssm-maintenancewindowtarget.go
@@ -1,0 +1,148 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/awslabs/goformation/cloudformation/policies"
+)
+
+// AWSSSMMaintenanceWindowTarget AWS CloudFormation Resource (AWS::SSM::MaintenanceWindowTarget)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html
+type AWSSSMMaintenanceWindowTarget struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-description
+	Description string `json:"Description,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-name
+	Name string `json:"Name,omitempty"`
+
+	// OwnerInformation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-ownerinformation
+	OwnerInformation string `json:"OwnerInformation,omitempty"`
+
+	// ResourceType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-resourcetype
+	ResourceType string `json:"ResourceType,omitempty"`
+
+	// Targets AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets
+	Targets []AWSSSMMaintenanceWindowTarget_Targets `json:"Targets,omitempty"`
+
+	// WindowId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-windowid
+	WindowId string `json:"WindowId,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSSMMaintenanceWindowTarget) AWSCloudFormationType() string {
+	return "AWS::SSM::MaintenanceWindowTarget"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSSMMaintenanceWindowTarget) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSSMMaintenanceWindowTarget) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSSMMaintenanceWindowTarget) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSSMMaintenanceWindowTarget) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSSMMaintenanceWindowTarget) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSSMMaintenanceWindowTarget) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AWSSSMMaintenanceWindowTarget) MarshalJSON() ([]byte, error) {
+	type Properties AWSSSMMaintenanceWindowTarget
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r._dependsOn,
+		Metadata:       r._metadata,
+		DeletionPolicy: r._deletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AWSSSMMaintenanceWindowTarget) UnmarshalJSON(b []byte) error {
+	type Properties AWSSSMMaintenanceWindowTarget
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AWSSSMMaintenanceWindowTarget(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r._dependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r._metadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r._deletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/resources/aws-ssm-maintenancewindowtarget_targets.go
+++ b/cloudformation/resources/aws-ssm-maintenancewindowtarget_targets.go
@@ -1,0 +1,68 @@
+package resources
+
+import "github.com/awslabs/goformation/cloudformation/policies"
+
+// AWSSSMMaintenanceWindowTarget_Targets AWS CloudFormation Resource (AWS::SSM::MaintenanceWindowTarget.Targets)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-maintenancewindowtarget-targets.html
+type AWSSSMMaintenanceWindowTarget_Targets struct {
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-maintenancewindowtarget-targets.html#cfn-ssm-maintenancewindowtarget-targets-key
+	Key string `json:"Key,omitempty"`
+
+	// Values AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-maintenancewindowtarget-targets.html#cfn-ssm-maintenancewindowtarget-targets-values
+	Values []string `json:"Values,omitempty"`
+
+	// _deletionPolicy represents a CloudFormation DeletionPolicy
+	_deletionPolicy policies.DeletionPolicy
+
+	// _dependsOn stores the logical ID of the resources to be created before this resource
+	_dependsOn []string
+
+	// _metadata stores structured data associated with this resource
+	_metadata map[string]interface{}
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AWSSSMMaintenanceWindowTarget_Targets) AWSCloudFormationType() string {
+	return "AWS::SSM::MaintenanceWindowTarget.Targets"
+}
+
+// DependsOn returns a slice of logical ID names this resource depends on.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSSMMaintenanceWindowTarget_Targets) DependsOn() []string {
+	return r._dependsOn
+}
+
+// SetDependsOn specify that the creation of this resource follows another.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html
+func (r *AWSSSMMaintenanceWindowTarget_Targets) SetDependsOn(dependencies []string) {
+	r._dependsOn = dependencies
+}
+
+// Metadata returns the metadata associated with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSSMMaintenanceWindowTarget_Targets) Metadata() map[string]interface{} {
+	return r._metadata
+}
+
+// SetMetadata enables you to associate structured data with this resource.
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-metadata.html
+func (r *AWSSSMMaintenanceWindowTarget_Targets) SetMetadata(metadata map[string]interface{}) {
+	r._metadata = metadata
+}
+
+// DeletionPolicy returns the AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSSMMaintenanceWindowTarget_Targets) DeletionPolicy() policies.DeletionPolicy {
+	return r._deletionPolicy
+}
+
+// SetDeletionPolicy applies an AWS CloudFormation DeletionPolicy to this resource
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+func (r *AWSSSMMaintenanceWindowTarget_Targets) SetDeletionPolicy(policy policies.DeletionPolicy) {
+	r._deletionPolicy = policy
+}

--- a/cloudformation/resources/tag.go
+++ b/cloudformation/resources/tag.go
@@ -3,17 +3,17 @@ package resources
 import "github.com/awslabs/goformation/cloudformation/policies"
 
 // Tag AWS CloudFormation Resource (Tag)
-// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotevents-input-tag.html
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
 type Tag struct {
 
 	// Key AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotevents-input-tag.html#cfn-iotevents-input-tag-key
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-key
 	Key string `json:"Key,omitempty"`
 
 	// Value AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotevents-input-tag.html#cfn-iotevents-input-tag-value
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-value
 	Value string `json:"Value,omitempty"`
 
 	// _deletionPolicy represents a CloudFormation DeletionPolicy

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -402,7 +402,7 @@
                 },
                 "Version": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
-                    "Required": true,
+                    "Required": false,
                     "PrimitiveType": "Integer",
                     "UpdateType": "Immutable"
                 }

--- a/schema/cloudformation.go
+++ b/schema/cloudformation.go
@@ -3656,6 +3656,71 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.Duration": {
+            "additionalProperties": false,
+            "properties": {
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HeaderMatchMethod": {
+            "additionalProperties": false,
+            "properties": {
+                "Exact": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Range": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.MatchRange"
+                },
+                "Regex": {
+                    "type": "string"
+                },
+                "Suffix": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HttpRetryPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "HttpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxRetries": {
+                    "type": "number"
+                },
+                "PerRetryTimeout": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.Duration"
+                },
+                "TcpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MaxRetries",
+                "PerRetryTimeout"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRoute": {
             "additionalProperties": false,
             "properties": {
@@ -3664,6 +3729,9 @@ var CloudformationSchema = `{
                 },
                 "Match": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteMatch"
+                },
+                "RetryPolicy": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HttpRetryPolicy"
                 }
             },
             "required": [
@@ -3687,10 +3755,40 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.HttpRouteHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "Invert": {
+                    "type": "boolean"
+                },
+                "Match": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HeaderMatchMethod"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRouteMatch": {
             "additionalProperties": false,
             "properties": {
+                "Headers": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteHeader"
+                    },
+                    "type": "array"
+                },
+                "Method": {
+                    "type": "string"
+                },
                 "Prefix": {
+                    "type": "string"
+                },
+                "Scheme": {
                     "type": "string"
                 }
             },
@@ -3699,11 +3797,30 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.MatchRange": {
+            "additionalProperties": false,
+            "properties": {
+                "End": {
+                    "type": "number"
+                },
+                "Start": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "End",
+                "Start"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.RouteSpec": {
             "additionalProperties": false,
             "properties": {
                 "HttpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRoute"
+                },
+                "Priority": {
+                    "type": "number"
                 },
                 "TcpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.TcpRoute"
@@ -5393,6 +5510,9 @@ var CloudformationSchema = `{
                 "CloudWatchLogsRoleArn": {
                     "type": "string"
                 },
+                "ExcludeVerboseContent": {
+                    "type": "boolean"
+                },
                 "FieldLogLevel": {
                     "type": "string"
                 }
@@ -5650,6 +5770,9 @@ var CloudformationSchema = `{
                         },
                         "ServiceNamespace": {
                             "type": "string"
+                        },
+                        "SuspendedState": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState"
                         }
                     },
                     "required": [
@@ -5710,6 +5833,21 @@ var CloudformationSchema = `{
                 "Schedule",
                 "ScheduledActionName"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState": {
+            "additionalProperties": false,
+            "properties": {
+                "DynamicScalingInSuspended": {
+                    "type": "boolean"
+                },
+                "DynamicScalingOutSuspended": {
+                    "type": "boolean"
+                },
+                "ScheduledScalingSuspended": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy": {
@@ -9576,6 +9714,9 @@ var CloudformationSchema = `{
                         "Threshold": {
                             "type": "number"
                         },
+                        "ThresholdMetricId": {
+                            "type": "string"
+                        },
                         "TreatMissingData": {
                             "type": "string"
                         },
@@ -9585,8 +9726,7 @@ var CloudformationSchema = `{
                     },
                     "required": [
                         "ComparisonOperator",
-                        "EvaluationPeriods",
-                        "Threshold"
+                        "EvaluationPeriods"
                     ],
                     "type": "object"
                 },
@@ -13027,6 +13167,151 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::Config::OrganizationConfigRule": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConfigRuleName": {
+                            "type": "string"
+                        },
+                        "OrganizationCustomRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata"
+                        },
+                        "OrganizationManagedRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata"
+                        }
+                    },
+                    "required": [
+                        "OrganizationConfigRuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConfigRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "LambdaFunctionArn": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "OrganizationConfigRuleTriggerTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LambdaFunctionArn",
+                "OrganizationConfigRuleTriggerTypes"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RuleIdentifier": {
+                    "type": "string"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RuleIdentifier"
+            ],
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -13059,14 +13344,26 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Automatic": {
+                            "type": "boolean"
+                        },
                         "ConfigRuleName": {
                             "type": "string"
+                        },
+                        "ExecutionControls": {
+                            "$ref": "#/definitions/AWS::Config::RemediationConfiguration.ExecutionControls"
+                        },
+                        "MaximumAutomaticAttempts": {
+                            "type": "number"
                         },
                         "Parameters": {
                             "type": "object"
                         },
                         "ResourceType": {
                             "type": "string"
+                        },
+                        "RetryAttemptSeconds": {
+                            "type": "number"
                         },
                         "TargetId": {
                             "type": "string"
@@ -13098,6 +13395,15 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Config::RemediationConfiguration.ExecutionControls": {
+            "additionalProperties": false,
+            "properties": {
+                "SsmControls": {
+                    "$ref": "#/definitions/AWS::Config::RemediationConfiguration.SsmControls"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration.RemediationParameterValue": {
             "additionalProperties": false,
             "properties": {
@@ -13115,6 +13421,18 @@ var CloudformationSchema = `{
             "properties": {
                 "Value": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Config::RemediationConfiguration.SsmControls": {
+            "additionalProperties": false,
+            "properties": {
+                "ConcurrentExecutionRatePercentage": {
+                    "type": "number"
+                },
+                "ErrorPercentage": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -14074,8 +14392,14 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "CdcStartPosition": {
+                            "type": "string"
+                        },
                         "CdcStartTime": {
                             "type": "number"
+                        },
+                        "CdcStopPosition": {
+                            "type": "string"
                         },
                         "MigrationType": {
                             "type": "string"
@@ -14559,6 +14883,12 @@ var CloudformationSchema = `{
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "EngineVersion": {
                             "type": "string"
@@ -15057,8 +15387,14 @@ var CloudformationSchema = `{
         "AWS::DynamoDB::Table.SSESpecification": {
             "additionalProperties": false,
             "properties": {
+                "KMSMasterKeyId": {
+                    "type": "string"
+                },
                 "SSEEnabled": {
                     "type": "boolean"
+                },
+                "SSEType": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -15429,6 +15765,10 @@ var CloudformationSchema = `{
                     "type": "array"
                 }
             },
+            "required": [
+                "ResourceType",
+                "Tags"
+            ],
             "type": "object"
         },
         "AWS::EC2::ClientVpnRoute": {
@@ -16276,6 +16616,9 @@ var CloudformationSchema = `{
                             },
                             "type": "array"
                         },
+                        "CpuOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.CpuOptions"
+                        },
                         "CreditSpecification": {
                             "$ref": "#/definitions/AWS::EC2::Instance.CreditSpecification"
                         },
@@ -16451,6 +16794,18 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::EC2::Instance.CpuOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "CoreCount": {
+                    "type": "number"
+                },
+                "ThreadsPerCore": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::EC2::Instance.CreditSpecification": {
             "additionalProperties": false,
             "properties": {
@@ -16471,6 +16826,9 @@ var CloudformationSchema = `{
                 },
                 "Iops": {
                     "type": "number"
+                },
+                "KmsKeyId": {
+                    "type": "string"
                 },
                 "SnapshotId": {
                     "type": "string"
@@ -19606,6 +19964,66 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::EC2::VPCEndpointService": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AcceptanceRequired": {
+                            "type": "boolean"
+                        },
+                        "NetworkLoadBalancerArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkLoadBalancerArns"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCEndpointService"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::EC2::VPCEndpointServicePermissions": {
             "additionalProperties": false,
             "properties": {
@@ -20626,10 +21044,16 @@ var CloudformationSchema = `{
                         "Family": {
                             "type": "string"
                         },
+                        "IpcMode": {
+                            "type": "string"
+                        },
                         "Memory": {
                             "type": "string"
                         },
                         "NetworkMode": {
+                            "type": "string"
+                        },
+                        "PidMode": {
                             "type": "string"
                         },
                         "PlacementConstraints": {
@@ -20755,6 +21179,9 @@ var CloudformationSchema = `{
                 "Image": {
                     "type": "string"
                 },
+                "Interactive": {
+                    "type": "boolean"
+                },
                 "Links": {
                     "items": {
                         "type": "string"
@@ -20791,6 +21218,9 @@ var CloudformationSchema = `{
                 "Privileged": {
                     "type": "boolean"
                 },
+                "PseudoTerminal": {
+                    "type": "boolean"
+                },
                 "ReadonlyRootFilesystem": {
                     "type": "boolean"
                 },
@@ -20814,6 +21244,12 @@ var CloudformationSchema = `{
                 },
                 "StopTimeout": {
                     "type": "number"
+                },
+                "SystemControls": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.SystemControl"
+                    },
+                    "type": "array"
                 },
                 "Ulimits": {
                     "items": {
@@ -21029,6 +21465,12 @@ var CloudformationSchema = `{
                         }
                     },
                     "type": "object"
+                },
+                "SecretOptions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.Secret"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -21128,6 +21570,22 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::ECS::TaskDefinition.SystemControl": {
+            "additionalProperties": false,
+            "properties": {
+                "Namespace": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Namespace",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint": {
             "additionalProperties": false,
             "properties": {
@@ -21159,6 +21617,9 @@ var CloudformationSchema = `{
                     "type": "number"
                 }
             },
+            "required": [
+                "Size"
+            ],
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.Ulimit": {
@@ -23118,6 +23579,9 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
                             "type": "string"
                         },
                         "NodeGroupConfiguration": {
@@ -25217,6 +25681,9 @@ var CloudformationSchema = `{
                 "InstanceType": {
                     "type": "string"
                 },
+                "ZoneAwarenessConfig": {
+                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.ZoneAwarenessConfig"
+                },
                 "ZoneAwarenessEnabled": {
                     "type": "boolean"
                 }
@@ -25267,6 +25734,15 @@ var CloudformationSchema = `{
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.ZoneAwarenessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZoneCount": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -25422,9 +25898,45 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Events::Rule.AwsVpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::Events::Rule.EcsParameters": {
             "additionalProperties": false,
             "properties": {
+                "Group": {
+                    "type": "string"
+                },
+                "LaunchType": {
+                    "type": "string"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.NetworkConfiguration"
+                },
+                "PlatformVersion": {
+                    "type": "string"
+                },
                 "TaskCount": {
                     "type": "number"
                 },
@@ -25468,6 +25980,15 @@ var CloudformationSchema = `{
             "required": [
                 "PartitionKeyPath"
             ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AwsVpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.AwsVpcConfiguration"
+                }
+            },
             "type": "object"
         },
         "AWS::Events::Rule.RunCommandParameters": {
@@ -26572,6 +27093,9 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Arguments": {
+                            "type": "object"
+                        },
                         "EndpointName": {
                             "type": "string"
                         },
@@ -26581,7 +27105,13 @@ var CloudformationSchema = `{
                         "ExtraPythonLibsS3Path": {
                             "type": "string"
                         },
+                        "GlueVersion": {
+                            "type": "string"
+                        },
                         "NumberOfNodes": {
+                            "type": "number"
+                        },
+                        "NumberOfWorkers": {
                             "type": "number"
                         },
                         "PublicKey": {
@@ -26604,6 +27134,9 @@ var CloudformationSchema = `{
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "WorkerType": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -26689,6 +27222,9 @@ var CloudformationSchema = `{
                         "Name": {
                             "type": "string"
                         },
+                        "NotificationProperty": {
+                            "$ref": "#/definitions/AWS::Glue::Job.NotificationProperty"
+                        },
                         "NumberOfWorkers": {
                             "type": "number"
                         },
@@ -26700,6 +27236,9 @@ var CloudformationSchema = `{
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "Timeout": {
+                            "type": "number"
                         },
                         "WorkerType": {
                             "type": "string"
@@ -26756,6 +27295,15 @@ var CloudformationSchema = `{
                 },
                 "ScriptLocation": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Job.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27506,10 +28054,16 @@ var CloudformationSchema = `{
                         "Schedule": {
                             "type": "string"
                         },
+                        "StartOnCreation": {
+                            "type": "boolean"
+                        },
                         "Tags": {
                             "type": "object"
                         },
                         "Type": {
+                            "type": "string"
+                        },
+                        "WorkflowName": {
                             "type": "string"
                         }
                     },
@@ -27538,11 +28092,20 @@ var CloudformationSchema = `{
                 "Arguments": {
                     "type": "object"
                 },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
+                "NotificationProperty": {
+                    "$ref": "#/definitions/AWS::Glue::Trigger.NotificationProperty"
+                },
                 "SecurityConfiguration": {
                     "type": "string"
+                },
+                "Timeout": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27550,6 +28113,12 @@ var CloudformationSchema = `{
         "AWS::Glue::Trigger.Condition": {
             "additionalProperties": false,
             "properties": {
+                "CrawlState": {
+                    "type": "string"
+                },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
@@ -27558,6 +28127,15 @@ var CloudformationSchema = `{
                 },
                 "State": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Trigger.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27575,6 +28153,65 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Glue::Workflow": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultRunProperties": {
+                            "type": "object"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Glue::Workflow"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Greengrass::ConnectorDefinition": {
@@ -30285,6 +30922,9 @@ var CloudformationSchema = `{
                         "AssumeRolePolicyDocument": {
                             "type": "object"
                         },
+                        "Description": {
+                            "type": "string"
+                        },
                         "ManagedPolicyArns": {
                             "items": {
                                 "type": "string"
@@ -30308,6 +30948,12 @@ var CloudformationSchema = `{
                         },
                         "RoleName": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -35768,6 +36414,9 @@ var CloudformationSchema = `{
                         "FunctionName": {
                             "type": "string"
                         },
+                        "MaximumBatchingWindowInSeconds": {
+                            "type": "number"
+                        },
                         "StartingPosition": {
                             "type": "string"
                         }
@@ -37818,6 +38467,12 @@ var CloudformationSchema = `{
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -41372,6 +42027,72 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::QLDB::Ledger": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "PermissionsMode": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PermissionsMode"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::QLDB::Ledger"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::RAM::ResourceShare": {
             "additionalProperties": false,
             "properties": {
@@ -41479,6 +42200,12 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBCluster.DBClusterRole"
+                            },
+                            "type": "array"
+                        },
                         "AvailabilityZones": {
                             "items": {
                                 "type": "string"
@@ -41545,10 +42272,16 @@ var CloudformationSchema = `{
                         "ReplicationSourceIdentifier": {
                             "type": "string"
                         },
+                        "RestoreType": {
+                            "type": "string"
+                        },
                         "ScalingConfiguration": {
                             "$ref": "#/definitions/AWS::RDS::DBCluster.ScalingConfiguration"
                         },
                         "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "SourceDBClusterIdentifier": {
                             "type": "string"
                         },
                         "SourceRegion": {
@@ -41562,6 +42295,9 @@ var CloudformationSchema = `{
                                 "$ref": "#/definitions/Tag"
                             },
                             "type": "array"
+                        },
+                        "UseLatestRestorableTime": {
+                            "type": "boolean"
                         },
                         "VpcSecurityGroupIds": {
                             "items": {
@@ -41585,6 +42321,24 @@ var CloudformationSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBCluster.DBClusterRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -41711,6 +42465,12 @@ var CloudformationSchema = `{
                         },
                         "AllowMajorVersionUpgrade": {
                             "type": "boolean"
+                        },
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBInstance.DBInstanceRole"
+                            },
+                            "type": "array"
                         },
                         "AutoMinorVersionUpgrade": {
                             "type": "boolean"
@@ -41884,6 +42644,25 @@ var CloudformationSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBInstance.DBInstanceRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FeatureName",
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -46401,6 +47180,98 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SSM::MaintenanceWindowTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "OwnerInformation": {
+                            "type": "string"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget.Targets"
+                            },
+                            "type": "array"
+                        },
+                        "WindowId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResourceType",
+                        "Targets",
+                        "WindowId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::MaintenanceWindowTarget"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::MaintenanceWindowTarget.Targets": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::SSM::MaintenanceWindowTask": {
             "additionalProperties": false,
             "properties": {
@@ -46976,6 +47847,81 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SageMaker::CodeRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeRepositoryName": {
+                            "type": "string"
+                        },
+                        "GitConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository.GitConfig"
+                        }
+                    },
+                    "required": [
+                        "GitConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::CodeRepository"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::CodeRepository.GitConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Branch": {
+                    "type": "string"
+                },
+                "RepositoryUrl": {
+                    "type": "string"
+                },
+                "SecretArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RepositoryUrl"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -47432,6 +48378,118 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "MemberDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SageMaker::Workteam.MemberDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationConfiguration": {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam.NotificationConfiguration"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "WorkteamName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Workteam"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.CognitoMemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoClientId": {
+                    "type": "string"
+                },
+                "CognitoUserGroup": {
+                    "type": "string"
+                },
+                "CognitoUserPool": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "CognitoClientId",
+                "CognitoUserGroup",
+                "CognitoUserPool"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.MemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoMemberDefinition": {
+                    "$ref": "#/definitions/AWS::SageMaker::Workteam.CognitoMemberDefinition"
+                }
+            },
+            "required": [
+                "CognitoMemberDefinition"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.NotificationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "NotificationTopicArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "NotificationTopicArn"
+            ],
             "type": "object"
         },
         "AWS::SecretsManager::ResourcePolicy": {
@@ -51805,6 +52863,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
                         },
                         {
@@ -51994,6 +53055,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointConnectionNotification"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EC2::VPCEndpointService"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointServicePermissions"
                         },
                         {
@@ -52160,6 +53224,9 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Glue::Trigger"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Glue::Workflow"
                         },
                         {
                             "$ref": "#/definitions/AWS::Greengrass::ConnectorDefinition"
@@ -52510,6 +53577,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::PinpointEmail::Identity"
                         },
                         {
+                            "$ref": "#/definitions/AWS::QLDB::Ledger"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::RAM::ResourceShare"
                         },
                         {
@@ -52645,6 +53715,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindow"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTask"
                         },
                         {
@@ -52655,6 +53728,9 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::SSM::ResourceDataSync"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -52670,6 +53746,9 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam"
                         },
                         {
                             "$ref": "#/definitions/AWS::SecretsManager::ResourcePolicy"

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -3653,6 +3653,71 @@
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.Duration": {
+            "additionalProperties": false,
+            "properties": {
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HeaderMatchMethod": {
+            "additionalProperties": false,
+            "properties": {
+                "Exact": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Range": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.MatchRange"
+                },
+                "Regex": {
+                    "type": "string"
+                },
+                "Suffix": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HttpRetryPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "HttpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxRetries": {
+                    "type": "number"
+                },
+                "PerRetryTimeout": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.Duration"
+                },
+                "TcpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MaxRetries",
+                "PerRetryTimeout"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRoute": {
             "additionalProperties": false,
             "properties": {
@@ -3661,6 +3726,9 @@
                 },
                 "Match": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteMatch"
+                },
+                "RetryPolicy": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HttpRetryPolicy"
                 }
             },
             "required": [
@@ -3684,10 +3752,40 @@
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.HttpRouteHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "Invert": {
+                    "type": "boolean"
+                },
+                "Match": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HeaderMatchMethod"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRouteMatch": {
             "additionalProperties": false,
             "properties": {
+                "Headers": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteHeader"
+                    },
+                    "type": "array"
+                },
+                "Method": {
+                    "type": "string"
+                },
                 "Prefix": {
+                    "type": "string"
+                },
+                "Scheme": {
                     "type": "string"
                 }
             },
@@ -3696,11 +3794,30 @@
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.MatchRange": {
+            "additionalProperties": false,
+            "properties": {
+                "End": {
+                    "type": "number"
+                },
+                "Start": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "End",
+                "Start"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.RouteSpec": {
             "additionalProperties": false,
             "properties": {
                 "HttpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRoute"
+                },
+                "Priority": {
+                    "type": "number"
                 },
                 "TcpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.TcpRoute"
@@ -5390,6 +5507,9 @@
                 "CloudWatchLogsRoleArn": {
                     "type": "string"
                 },
+                "ExcludeVerboseContent": {
+                    "type": "boolean"
+                },
                 "FieldLogLevel": {
                     "type": "string"
                 }
@@ -5647,6 +5767,9 @@
                         },
                         "ServiceNamespace": {
                             "type": "string"
+                        },
+                        "SuspendedState": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState"
                         }
                     },
                     "required": [
@@ -5707,6 +5830,21 @@
                 "Schedule",
                 "ScheduledActionName"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState": {
+            "additionalProperties": false,
+            "properties": {
+                "DynamicScalingInSuspended": {
+                    "type": "boolean"
+                },
+                "DynamicScalingOutSuspended": {
+                    "type": "boolean"
+                },
+                "ScheduledScalingSuspended": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy": {
@@ -9573,6 +9711,9 @@
                         "Threshold": {
                             "type": "number"
                         },
+                        "ThresholdMetricId": {
+                            "type": "string"
+                        },
                         "TreatMissingData": {
                             "type": "string"
                         },
@@ -9582,8 +9723,7 @@
                     },
                     "required": [
                         "ComparisonOperator",
-                        "EvaluationPeriods",
-                        "Threshold"
+                        "EvaluationPeriods"
                     ],
                     "type": "object"
                 },
@@ -13024,6 +13164,151 @@
             },
             "type": "object"
         },
+        "AWS::Config::OrganizationConfigRule": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConfigRuleName": {
+                            "type": "string"
+                        },
+                        "OrganizationCustomRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata"
+                        },
+                        "OrganizationManagedRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata"
+                        }
+                    },
+                    "required": [
+                        "OrganizationConfigRuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConfigRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "LambdaFunctionArn": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "OrganizationConfigRuleTriggerTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LambdaFunctionArn",
+                "OrganizationConfigRuleTriggerTypes"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RuleIdentifier": {
+                    "type": "string"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RuleIdentifier"
+            ],
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -13056,14 +13341,26 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Automatic": {
+                            "type": "boolean"
+                        },
                         "ConfigRuleName": {
                             "type": "string"
+                        },
+                        "ExecutionControls": {
+                            "$ref": "#/definitions/AWS::Config::RemediationConfiguration.ExecutionControls"
+                        },
+                        "MaximumAutomaticAttempts": {
+                            "type": "number"
                         },
                         "Parameters": {
                             "type": "object"
                         },
                         "ResourceType": {
                             "type": "string"
+                        },
+                        "RetryAttemptSeconds": {
+                            "type": "number"
                         },
                         "TargetId": {
                             "type": "string"
@@ -13095,6 +13392,15 @@
             ],
             "type": "object"
         },
+        "AWS::Config::RemediationConfiguration.ExecutionControls": {
+            "additionalProperties": false,
+            "properties": {
+                "SsmControls": {
+                    "$ref": "#/definitions/AWS::Config::RemediationConfiguration.SsmControls"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration.RemediationParameterValue": {
             "additionalProperties": false,
             "properties": {
@@ -13112,6 +13418,18 @@
             "properties": {
                 "Value": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Config::RemediationConfiguration.SsmControls": {
+            "additionalProperties": false,
+            "properties": {
+                "ConcurrentExecutionRatePercentage": {
+                    "type": "number"
+                },
+                "ErrorPercentage": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -14071,8 +14389,14 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "CdcStartPosition": {
+                            "type": "string"
+                        },
                         "CdcStartTime": {
                             "type": "number"
+                        },
+                        "CdcStopPosition": {
+                            "type": "string"
                         },
                         "MigrationType": {
                             "type": "string"
@@ -14556,6 +14880,12 @@
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "EngineVersion": {
                             "type": "string"
@@ -15054,8 +15384,14 @@
         "AWS::DynamoDB::Table.SSESpecification": {
             "additionalProperties": false,
             "properties": {
+                "KMSMasterKeyId": {
+                    "type": "string"
+                },
                 "SSEEnabled": {
                     "type": "boolean"
+                },
+                "SSEType": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -15426,6 +15762,10 @@
                     "type": "array"
                 }
             },
+            "required": [
+                "ResourceType",
+                "Tags"
+            ],
             "type": "object"
         },
         "AWS::EC2::ClientVpnRoute": {
@@ -16273,6 +16613,9 @@
                             },
                             "type": "array"
                         },
+                        "CpuOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.CpuOptions"
+                        },
                         "CreditSpecification": {
                             "$ref": "#/definitions/AWS::EC2::Instance.CreditSpecification"
                         },
@@ -16448,6 +16791,18 @@
             ],
             "type": "object"
         },
+        "AWS::EC2::Instance.CpuOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "CoreCount": {
+                    "type": "number"
+                },
+                "ThreadsPerCore": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::EC2::Instance.CreditSpecification": {
             "additionalProperties": false,
             "properties": {
@@ -16468,6 +16823,9 @@
                 },
                 "Iops": {
                     "type": "number"
+                },
+                "KmsKeyId": {
+                    "type": "string"
                 },
                 "SnapshotId": {
                     "type": "string"
@@ -19603,6 +19961,66 @@
             ],
             "type": "object"
         },
+        "AWS::EC2::VPCEndpointService": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AcceptanceRequired": {
+                            "type": "boolean"
+                        },
+                        "NetworkLoadBalancerArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkLoadBalancerArns"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCEndpointService"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::EC2::VPCEndpointServicePermissions": {
             "additionalProperties": false,
             "properties": {
@@ -20623,10 +21041,16 @@
                         "Family": {
                             "type": "string"
                         },
+                        "IpcMode": {
+                            "type": "string"
+                        },
                         "Memory": {
                             "type": "string"
                         },
                         "NetworkMode": {
+                            "type": "string"
+                        },
+                        "PidMode": {
                             "type": "string"
                         },
                         "PlacementConstraints": {
@@ -20752,6 +21176,9 @@
                 "Image": {
                     "type": "string"
                 },
+                "Interactive": {
+                    "type": "boolean"
+                },
                 "Links": {
                     "items": {
                         "type": "string"
@@ -20788,6 +21215,9 @@
                 "Privileged": {
                     "type": "boolean"
                 },
+                "PseudoTerminal": {
+                    "type": "boolean"
+                },
                 "ReadonlyRootFilesystem": {
                     "type": "boolean"
                 },
@@ -20811,6 +21241,12 @@
                 },
                 "StopTimeout": {
                     "type": "number"
+                },
+                "SystemControls": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.SystemControl"
+                    },
+                    "type": "array"
                 },
                 "Ulimits": {
                     "items": {
@@ -21026,6 +21462,12 @@
                         }
                     },
                     "type": "object"
+                },
+                "SecretOptions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.Secret"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -21125,6 +21567,22 @@
             ],
             "type": "object"
         },
+        "AWS::ECS::TaskDefinition.SystemControl": {
+            "additionalProperties": false,
+            "properties": {
+                "Namespace": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Namespace",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint": {
             "additionalProperties": false,
             "properties": {
@@ -21156,6 +21614,9 @@
                     "type": "number"
                 }
             },
+            "required": [
+                "Size"
+            ],
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.Ulimit": {
@@ -23115,6 +23576,9 @@
                             "type": "string"
                         },
                         "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
                             "type": "string"
                         },
                         "NodeGroupConfiguration": {
@@ -25214,6 +25678,9 @@
                 "InstanceType": {
                     "type": "string"
                 },
+                "ZoneAwarenessConfig": {
+                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.ZoneAwarenessConfig"
+                },
                 "ZoneAwarenessEnabled": {
                     "type": "boolean"
                 }
@@ -25264,6 +25731,15 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.ZoneAwarenessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZoneCount": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -25419,9 +25895,45 @@
             ],
             "type": "object"
         },
+        "AWS::Events::Rule.AwsVpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::Events::Rule.EcsParameters": {
             "additionalProperties": false,
             "properties": {
+                "Group": {
+                    "type": "string"
+                },
+                "LaunchType": {
+                    "type": "string"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.NetworkConfiguration"
+                },
+                "PlatformVersion": {
+                    "type": "string"
+                },
                 "TaskCount": {
                     "type": "number"
                 },
@@ -25465,6 +25977,15 @@
             "required": [
                 "PartitionKeyPath"
             ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AwsVpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.AwsVpcConfiguration"
+                }
+            },
             "type": "object"
         },
         "AWS::Events::Rule.RunCommandParameters": {
@@ -26569,6 +27090,9 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Arguments": {
+                            "type": "object"
+                        },
                         "EndpointName": {
                             "type": "string"
                         },
@@ -26578,7 +27102,13 @@
                         "ExtraPythonLibsS3Path": {
                             "type": "string"
                         },
+                        "GlueVersion": {
+                            "type": "string"
+                        },
                         "NumberOfNodes": {
+                            "type": "number"
+                        },
+                        "NumberOfWorkers": {
                             "type": "number"
                         },
                         "PublicKey": {
@@ -26601,6 +27131,9 @@
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "WorkerType": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -26686,6 +27219,9 @@
                         "Name": {
                             "type": "string"
                         },
+                        "NotificationProperty": {
+                            "$ref": "#/definitions/AWS::Glue::Job.NotificationProperty"
+                        },
                         "NumberOfWorkers": {
                             "type": "number"
                         },
@@ -26697,6 +27233,9 @@
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "Timeout": {
+                            "type": "number"
                         },
                         "WorkerType": {
                             "type": "string"
@@ -26753,6 +27292,15 @@
                 },
                 "ScriptLocation": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Job.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27503,10 +28051,16 @@
                         "Schedule": {
                             "type": "string"
                         },
+                        "StartOnCreation": {
+                            "type": "boolean"
+                        },
                         "Tags": {
                             "type": "object"
                         },
                         "Type": {
+                            "type": "string"
+                        },
+                        "WorkflowName": {
                             "type": "string"
                         }
                     },
@@ -27535,11 +28089,20 @@
                 "Arguments": {
                     "type": "object"
                 },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
+                "NotificationProperty": {
+                    "$ref": "#/definitions/AWS::Glue::Trigger.NotificationProperty"
+                },
                 "SecurityConfiguration": {
                     "type": "string"
+                },
+                "Timeout": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27547,6 +28110,12 @@
         "AWS::Glue::Trigger.Condition": {
             "additionalProperties": false,
             "properties": {
+                "CrawlState": {
+                    "type": "string"
+                },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
@@ -27555,6 +28124,15 @@
                 },
                 "State": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Trigger.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27572,6 +28150,65 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Glue::Workflow": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultRunProperties": {
+                            "type": "object"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Glue::Workflow"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Greengrass::ConnectorDefinition": {
@@ -30282,6 +30919,9 @@
                         "AssumeRolePolicyDocument": {
                             "type": "object"
                         },
+                        "Description": {
+                            "type": "string"
+                        },
                         "ManagedPolicyArns": {
                             "items": {
                                 "type": "string"
@@ -30305,6 +30945,12 @@
                         },
                         "RoleName": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -35765,6 +36411,9 @@
                         "FunctionName": {
                             "type": "string"
                         },
+                        "MaximumBatchingWindowInSeconds": {
+                            "type": "number"
+                        },
                         "StartingPosition": {
                             "type": "string"
                         }
@@ -37815,6 +38464,12 @@
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -41369,6 +42024,72 @@
             },
             "type": "object"
         },
+        "AWS::QLDB::Ledger": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "PermissionsMode": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PermissionsMode"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::QLDB::Ledger"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::RAM::ResourceShare": {
             "additionalProperties": false,
             "properties": {
@@ -41476,6 +42197,12 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBCluster.DBClusterRole"
+                            },
+                            "type": "array"
+                        },
                         "AvailabilityZones": {
                             "items": {
                                 "type": "string"
@@ -41542,10 +42269,16 @@
                         "ReplicationSourceIdentifier": {
                             "type": "string"
                         },
+                        "RestoreType": {
+                            "type": "string"
+                        },
                         "ScalingConfiguration": {
                             "$ref": "#/definitions/AWS::RDS::DBCluster.ScalingConfiguration"
                         },
                         "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "SourceDBClusterIdentifier": {
                             "type": "string"
                         },
                         "SourceRegion": {
@@ -41559,6 +42292,9 @@
                                 "$ref": "#/definitions/Tag"
                             },
                             "type": "array"
+                        },
+                        "UseLatestRestorableTime": {
+                            "type": "boolean"
                         },
                         "VpcSecurityGroupIds": {
                             "items": {
@@ -41582,6 +42318,24 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBCluster.DBClusterRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -41708,6 +42462,12 @@
                         },
                         "AllowMajorVersionUpgrade": {
                             "type": "boolean"
+                        },
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBInstance.DBInstanceRole"
+                            },
+                            "type": "array"
                         },
                         "AutoMinorVersionUpgrade": {
                             "type": "boolean"
@@ -41881,6 +42641,25 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBInstance.DBInstanceRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FeatureName",
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -46398,6 +47177,98 @@
             ],
             "type": "object"
         },
+        "AWS::SSM::MaintenanceWindowTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "OwnerInformation": {
+                            "type": "string"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget.Targets"
+                            },
+                            "type": "array"
+                        },
+                        "WindowId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResourceType",
+                        "Targets",
+                        "WindowId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::MaintenanceWindowTarget"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::MaintenanceWindowTarget.Targets": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::SSM::MaintenanceWindowTask": {
             "additionalProperties": false,
             "properties": {
@@ -46973,6 +47844,81 @@
             ],
             "type": "object"
         },
+        "AWS::SageMaker::CodeRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeRepositoryName": {
+                            "type": "string"
+                        },
+                        "GitConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository.GitConfig"
+                        }
+                    },
+                    "required": [
+                        "GitConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::CodeRepository"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::CodeRepository.GitConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Branch": {
+                    "type": "string"
+                },
+                "RepositoryUrl": {
+                    "type": "string"
+                },
+                "SecretArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RepositoryUrl"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -47429,6 +48375,118 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "MemberDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SageMaker::Workteam.MemberDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationConfiguration": {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam.NotificationConfiguration"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "WorkteamName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Workteam"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.CognitoMemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoClientId": {
+                    "type": "string"
+                },
+                "CognitoUserGroup": {
+                    "type": "string"
+                },
+                "CognitoUserPool": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "CognitoClientId",
+                "CognitoUserGroup",
+                "CognitoUserPool"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.MemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoMemberDefinition": {
+                    "$ref": "#/definitions/AWS::SageMaker::Workteam.CognitoMemberDefinition"
+                }
+            },
+            "required": [
+                "CognitoMemberDefinition"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.NotificationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "NotificationTopicArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "NotificationTopicArn"
+            ],
             "type": "object"
         },
         "AWS::SecretsManager::ResourcePolicy": {
@@ -51802,6 +52860,9 @@
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
                         },
                         {
@@ -51991,6 +53052,9 @@
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointConnectionNotification"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EC2::VPCEndpointService"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointServicePermissions"
                         },
                         {
@@ -52157,6 +53221,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Glue::Trigger"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Glue::Workflow"
                         },
                         {
                             "$ref": "#/definitions/AWS::Greengrass::ConnectorDefinition"
@@ -52507,6 +53574,9 @@
                             "$ref": "#/definitions/AWS::PinpointEmail::Identity"
                         },
                         {
+                            "$ref": "#/definitions/AWS::QLDB::Ledger"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::RAM::ResourceShare"
                         },
                         {
@@ -52642,6 +53712,9 @@
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindow"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTask"
                         },
                         {
@@ -52652,6 +53725,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::SSM::ResourceDataSync"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -52667,6 +53743,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam"
                         },
                         {
                             "$ref": "#/definitions/AWS::SecretsManager::ResourcePolicy"

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -3656,6 +3656,71 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.Duration": {
+            "additionalProperties": false,
+            "properties": {
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HeaderMatchMethod": {
+            "additionalProperties": false,
+            "properties": {
+                "Exact": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Range": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.MatchRange"
+                },
+                "Regex": {
+                    "type": "string"
+                },
+                "Suffix": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HttpRetryPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "HttpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxRetries": {
+                    "type": "number"
+                },
+                "PerRetryTimeout": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.Duration"
+                },
+                "TcpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MaxRetries",
+                "PerRetryTimeout"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRoute": {
             "additionalProperties": false,
             "properties": {
@@ -3664,6 +3729,9 @@ var SamSchema = `{
                 },
                 "Match": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteMatch"
+                },
+                "RetryPolicy": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HttpRetryPolicy"
                 }
             },
             "required": [
@@ -3687,10 +3755,40 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.HttpRouteHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "Invert": {
+                    "type": "boolean"
+                },
+                "Match": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HeaderMatchMethod"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRouteMatch": {
             "additionalProperties": false,
             "properties": {
+                "Headers": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteHeader"
+                    },
+                    "type": "array"
+                },
+                "Method": {
+                    "type": "string"
+                },
                 "Prefix": {
+                    "type": "string"
+                },
+                "Scheme": {
                     "type": "string"
                 }
             },
@@ -3699,11 +3797,30 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.MatchRange": {
+            "additionalProperties": false,
+            "properties": {
+                "End": {
+                    "type": "number"
+                },
+                "Start": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "End",
+                "Start"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.RouteSpec": {
             "additionalProperties": false,
             "properties": {
                 "HttpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRoute"
+                },
+                "Priority": {
+                    "type": "number"
                 },
                 "TcpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.TcpRoute"
@@ -5393,6 +5510,9 @@ var SamSchema = `{
                 "CloudWatchLogsRoleArn": {
                     "type": "string"
                 },
+                "ExcludeVerboseContent": {
+                    "type": "boolean"
+                },
                 "FieldLogLevel": {
                     "type": "string"
                 }
@@ -5650,6 +5770,9 @@ var SamSchema = `{
                         },
                         "ServiceNamespace": {
                             "type": "string"
+                        },
+                        "SuspendedState": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState"
                         }
                     },
                     "required": [
@@ -5710,6 +5833,21 @@ var SamSchema = `{
                 "Schedule",
                 "ScheduledActionName"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState": {
+            "additionalProperties": false,
+            "properties": {
+                "DynamicScalingInSuspended": {
+                    "type": "boolean"
+                },
+                "DynamicScalingOutSuspended": {
+                    "type": "boolean"
+                },
+                "ScheduledScalingSuspended": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy": {
@@ -9576,6 +9714,9 @@ var SamSchema = `{
                         "Threshold": {
                             "type": "number"
                         },
+                        "ThresholdMetricId": {
+                            "type": "string"
+                        },
                         "TreatMissingData": {
                             "type": "string"
                         },
@@ -9585,8 +9726,7 @@ var SamSchema = `{
                     },
                     "required": [
                         "ComparisonOperator",
-                        "EvaluationPeriods",
-                        "Threshold"
+                        "EvaluationPeriods"
                     ],
                     "type": "object"
                 },
@@ -13027,6 +13167,151 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::Config::OrganizationConfigRule": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConfigRuleName": {
+                            "type": "string"
+                        },
+                        "OrganizationCustomRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata"
+                        },
+                        "OrganizationManagedRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata"
+                        }
+                    },
+                    "required": [
+                        "OrganizationConfigRuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConfigRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "LambdaFunctionArn": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "OrganizationConfigRuleTriggerTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LambdaFunctionArn",
+                "OrganizationConfigRuleTriggerTypes"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RuleIdentifier": {
+                    "type": "string"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RuleIdentifier"
+            ],
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -13059,14 +13344,26 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Automatic": {
+                            "type": "boolean"
+                        },
                         "ConfigRuleName": {
                             "type": "string"
+                        },
+                        "ExecutionControls": {
+                            "$ref": "#/definitions/AWS::Config::RemediationConfiguration.ExecutionControls"
+                        },
+                        "MaximumAutomaticAttempts": {
+                            "type": "number"
                         },
                         "Parameters": {
                             "type": "object"
                         },
                         "ResourceType": {
                             "type": "string"
+                        },
+                        "RetryAttemptSeconds": {
+                            "type": "number"
                         },
                         "TargetId": {
                             "type": "string"
@@ -13098,6 +13395,15 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Config::RemediationConfiguration.ExecutionControls": {
+            "additionalProperties": false,
+            "properties": {
+                "SsmControls": {
+                    "$ref": "#/definitions/AWS::Config::RemediationConfiguration.SsmControls"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration.RemediationParameterValue": {
             "additionalProperties": false,
             "properties": {
@@ -13115,6 +13421,18 @@ var SamSchema = `{
             "properties": {
                 "Value": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Config::RemediationConfiguration.SsmControls": {
+            "additionalProperties": false,
+            "properties": {
+                "ConcurrentExecutionRatePercentage": {
+                    "type": "number"
+                },
+                "ErrorPercentage": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -14074,8 +14392,14 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "CdcStartPosition": {
+                            "type": "string"
+                        },
                         "CdcStartTime": {
                             "type": "number"
+                        },
+                        "CdcStopPosition": {
+                            "type": "string"
                         },
                         "MigrationType": {
                             "type": "string"
@@ -14559,6 +14883,12 @@ var SamSchema = `{
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "EngineVersion": {
                             "type": "string"
@@ -15057,8 +15387,14 @@ var SamSchema = `{
         "AWS::DynamoDB::Table.SSESpecification": {
             "additionalProperties": false,
             "properties": {
+                "KMSMasterKeyId": {
+                    "type": "string"
+                },
                 "SSEEnabled": {
                     "type": "boolean"
+                },
+                "SSEType": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -15429,6 +15765,10 @@ var SamSchema = `{
                     "type": "array"
                 }
             },
+            "required": [
+                "ResourceType",
+                "Tags"
+            ],
             "type": "object"
         },
         "AWS::EC2::ClientVpnRoute": {
@@ -16276,6 +16616,9 @@ var SamSchema = `{
                             },
                             "type": "array"
                         },
+                        "CpuOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.CpuOptions"
+                        },
                         "CreditSpecification": {
                             "$ref": "#/definitions/AWS::EC2::Instance.CreditSpecification"
                         },
@@ -16451,6 +16794,18 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::EC2::Instance.CpuOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "CoreCount": {
+                    "type": "number"
+                },
+                "ThreadsPerCore": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::EC2::Instance.CreditSpecification": {
             "additionalProperties": false,
             "properties": {
@@ -16471,6 +16826,9 @@ var SamSchema = `{
                 },
                 "Iops": {
                     "type": "number"
+                },
+                "KmsKeyId": {
+                    "type": "string"
                 },
                 "SnapshotId": {
                     "type": "string"
@@ -19606,6 +19964,66 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::EC2::VPCEndpointService": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AcceptanceRequired": {
+                            "type": "boolean"
+                        },
+                        "NetworkLoadBalancerArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkLoadBalancerArns"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCEndpointService"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::EC2::VPCEndpointServicePermissions": {
             "additionalProperties": false,
             "properties": {
@@ -20626,10 +21044,16 @@ var SamSchema = `{
                         "Family": {
                             "type": "string"
                         },
+                        "IpcMode": {
+                            "type": "string"
+                        },
                         "Memory": {
                             "type": "string"
                         },
                         "NetworkMode": {
+                            "type": "string"
+                        },
+                        "PidMode": {
                             "type": "string"
                         },
                         "PlacementConstraints": {
@@ -20755,6 +21179,9 @@ var SamSchema = `{
                 "Image": {
                     "type": "string"
                 },
+                "Interactive": {
+                    "type": "boolean"
+                },
                 "Links": {
                     "items": {
                         "type": "string"
@@ -20791,6 +21218,9 @@ var SamSchema = `{
                 "Privileged": {
                     "type": "boolean"
                 },
+                "PseudoTerminal": {
+                    "type": "boolean"
+                },
                 "ReadonlyRootFilesystem": {
                     "type": "boolean"
                 },
@@ -20814,6 +21244,12 @@ var SamSchema = `{
                 },
                 "StopTimeout": {
                     "type": "number"
+                },
+                "SystemControls": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.SystemControl"
+                    },
+                    "type": "array"
                 },
                 "Ulimits": {
                     "items": {
@@ -21029,6 +21465,12 @@ var SamSchema = `{
                         }
                     },
                     "type": "object"
+                },
+                "SecretOptions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.Secret"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -21128,6 +21570,22 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::ECS::TaskDefinition.SystemControl": {
+            "additionalProperties": false,
+            "properties": {
+                "Namespace": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Namespace",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint": {
             "additionalProperties": false,
             "properties": {
@@ -21159,6 +21617,9 @@ var SamSchema = `{
                     "type": "number"
                 }
             },
+            "required": [
+                "Size"
+            ],
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.Ulimit": {
@@ -23118,6 +23579,9 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
                             "type": "string"
                         },
                         "NodeGroupConfiguration": {
@@ -25217,6 +25681,9 @@ var SamSchema = `{
                 "InstanceType": {
                     "type": "string"
                 },
+                "ZoneAwarenessConfig": {
+                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.ZoneAwarenessConfig"
+                },
                 "ZoneAwarenessEnabled": {
                     "type": "boolean"
                 }
@@ -25267,6 +25734,15 @@ var SamSchema = `{
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.ZoneAwarenessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZoneCount": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -25422,9 +25898,45 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Events::Rule.AwsVpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::Events::Rule.EcsParameters": {
             "additionalProperties": false,
             "properties": {
+                "Group": {
+                    "type": "string"
+                },
+                "LaunchType": {
+                    "type": "string"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.NetworkConfiguration"
+                },
+                "PlatformVersion": {
+                    "type": "string"
+                },
                 "TaskCount": {
                     "type": "number"
                 },
@@ -25468,6 +25980,15 @@ var SamSchema = `{
             "required": [
                 "PartitionKeyPath"
             ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AwsVpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.AwsVpcConfiguration"
+                }
+            },
             "type": "object"
         },
         "AWS::Events::Rule.RunCommandParameters": {
@@ -26572,6 +27093,9 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Arguments": {
+                            "type": "object"
+                        },
                         "EndpointName": {
                             "type": "string"
                         },
@@ -26581,7 +27105,13 @@ var SamSchema = `{
                         "ExtraPythonLibsS3Path": {
                             "type": "string"
                         },
+                        "GlueVersion": {
+                            "type": "string"
+                        },
                         "NumberOfNodes": {
+                            "type": "number"
+                        },
+                        "NumberOfWorkers": {
                             "type": "number"
                         },
                         "PublicKey": {
@@ -26604,6 +27134,9 @@ var SamSchema = `{
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "WorkerType": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -26689,6 +27222,9 @@ var SamSchema = `{
                         "Name": {
                             "type": "string"
                         },
+                        "NotificationProperty": {
+                            "$ref": "#/definitions/AWS::Glue::Job.NotificationProperty"
+                        },
                         "NumberOfWorkers": {
                             "type": "number"
                         },
@@ -26700,6 +27236,9 @@ var SamSchema = `{
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "Timeout": {
+                            "type": "number"
                         },
                         "WorkerType": {
                             "type": "string"
@@ -26756,6 +27295,15 @@ var SamSchema = `{
                 },
                 "ScriptLocation": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Job.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27506,10 +28054,16 @@ var SamSchema = `{
                         "Schedule": {
                             "type": "string"
                         },
+                        "StartOnCreation": {
+                            "type": "boolean"
+                        },
                         "Tags": {
                             "type": "object"
                         },
                         "Type": {
+                            "type": "string"
+                        },
+                        "WorkflowName": {
                             "type": "string"
                         }
                     },
@@ -27538,11 +28092,20 @@ var SamSchema = `{
                 "Arguments": {
                     "type": "object"
                 },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
+                "NotificationProperty": {
+                    "$ref": "#/definitions/AWS::Glue::Trigger.NotificationProperty"
+                },
                 "SecurityConfiguration": {
                     "type": "string"
+                },
+                "Timeout": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27550,6 +28113,12 @@ var SamSchema = `{
         "AWS::Glue::Trigger.Condition": {
             "additionalProperties": false,
             "properties": {
+                "CrawlState": {
+                    "type": "string"
+                },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
@@ -27558,6 +28127,15 @@ var SamSchema = `{
                 },
                 "State": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Trigger.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27575,6 +28153,65 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Glue::Workflow": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultRunProperties": {
+                            "type": "object"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Glue::Workflow"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Greengrass::ConnectorDefinition": {
@@ -30285,6 +30922,9 @@ var SamSchema = `{
                         "AssumeRolePolicyDocument": {
                             "type": "object"
                         },
+                        "Description": {
+                            "type": "string"
+                        },
                         "ManagedPolicyArns": {
                             "items": {
                                 "type": "string"
@@ -30308,6 +30948,12 @@ var SamSchema = `{
                         },
                         "RoleName": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -35768,6 +36414,9 @@ var SamSchema = `{
                         "FunctionName": {
                             "type": "string"
                         },
+                        "MaximumBatchingWindowInSeconds": {
+                            "type": "number"
+                        },
                         "StartingPosition": {
                             "type": "string"
                         }
@@ -37818,6 +38467,12 @@ var SamSchema = `{
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -41372,6 +42027,72 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::QLDB::Ledger": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "PermissionsMode": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PermissionsMode"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::QLDB::Ledger"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::RAM::ResourceShare": {
             "additionalProperties": false,
             "properties": {
@@ -41479,6 +42200,12 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBCluster.DBClusterRole"
+                            },
+                            "type": "array"
+                        },
                         "AvailabilityZones": {
                             "items": {
                                 "type": "string"
@@ -41545,10 +42272,16 @@ var SamSchema = `{
                         "ReplicationSourceIdentifier": {
                             "type": "string"
                         },
+                        "RestoreType": {
+                            "type": "string"
+                        },
                         "ScalingConfiguration": {
                             "$ref": "#/definitions/AWS::RDS::DBCluster.ScalingConfiguration"
                         },
                         "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "SourceDBClusterIdentifier": {
                             "type": "string"
                         },
                         "SourceRegion": {
@@ -41562,6 +42295,9 @@ var SamSchema = `{
                                 "$ref": "#/definitions/Tag"
                             },
                             "type": "array"
+                        },
+                        "UseLatestRestorableTime": {
+                            "type": "boolean"
                         },
                         "VpcSecurityGroupIds": {
                             "items": {
@@ -41585,6 +42321,24 @@ var SamSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBCluster.DBClusterRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -41711,6 +42465,12 @@ var SamSchema = `{
                         },
                         "AllowMajorVersionUpgrade": {
                             "type": "boolean"
+                        },
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBInstance.DBInstanceRole"
+                            },
+                            "type": "array"
                         },
                         "AutoMinorVersionUpgrade": {
                             "type": "boolean"
@@ -41884,6 +42644,25 @@ var SamSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBInstance.DBInstanceRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FeatureName",
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -46401,6 +47180,98 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SSM::MaintenanceWindowTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "OwnerInformation": {
+                            "type": "string"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget.Targets"
+                            },
+                            "type": "array"
+                        },
+                        "WindowId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResourceType",
+                        "Targets",
+                        "WindowId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::MaintenanceWindowTarget"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::MaintenanceWindowTarget.Targets": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::SSM::MaintenanceWindowTask": {
             "additionalProperties": false,
             "properties": {
@@ -46976,6 +47847,81 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SageMaker::CodeRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeRepositoryName": {
+                            "type": "string"
+                        },
+                        "GitConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository.GitConfig"
+                        }
+                    },
+                    "required": [
+                        "GitConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::CodeRepository"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::CodeRepository.GitConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Branch": {
+                    "type": "string"
+                },
+                "RepositoryUrl": {
+                    "type": "string"
+                },
+                "SecretArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RepositoryUrl"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -47432,6 +48378,118 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "MemberDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SageMaker::Workteam.MemberDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationConfiguration": {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam.NotificationConfiguration"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "WorkteamName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Workteam"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.CognitoMemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoClientId": {
+                    "type": "string"
+                },
+                "CognitoUserGroup": {
+                    "type": "string"
+                },
+                "CognitoUserPool": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "CognitoClientId",
+                "CognitoUserGroup",
+                "CognitoUserPool"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.MemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoMemberDefinition": {
+                    "$ref": "#/definitions/AWS::SageMaker::Workteam.CognitoMemberDefinition"
+                }
+            },
+            "required": [
+                "CognitoMemberDefinition"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.NotificationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "NotificationTopicArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "NotificationTopicArn"
+            ],
             "type": "object"
         },
         "AWS::SecretsManager::ResourcePolicy": {
@@ -48586,8 +49644,7 @@ var SamSchema = `{
             },
             "required": [
                 "Bucket",
-                "Key",
-                "Version"
+                "Key"
             ],
             "type": "object"
         },
@@ -53033,6 +54090,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
                         },
                         {
@@ -53222,6 +54282,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointConnectionNotification"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EC2::VPCEndpointService"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointServicePermissions"
                         },
                         {
@@ -53388,6 +54451,9 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Glue::Trigger"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Glue::Workflow"
                         },
                         {
                             "$ref": "#/definitions/AWS::Greengrass::ConnectorDefinition"
@@ -53738,6 +54804,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::PinpointEmail::Identity"
                         },
                         {
+                            "$ref": "#/definitions/AWS::QLDB::Ledger"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::RAM::ResourceShare"
                         },
                         {
@@ -53873,6 +54942,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindow"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTask"
                         },
                         {
@@ -53883,6 +54955,9 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::SSM::ResourceDataSync"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -53898,6 +54973,9 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam"
                         },
                         {
                             "$ref": "#/definitions/AWS::SecretsManager::ResourcePolicy"

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -3653,6 +3653,71 @@
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.Duration": {
+            "additionalProperties": false,
+            "properties": {
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HeaderMatchMethod": {
+            "additionalProperties": false,
+            "properties": {
+                "Exact": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Range": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.MatchRange"
+                },
+                "Regex": {
+                    "type": "string"
+                },
+                "Suffix": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AppMesh::Route.HttpRetryPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "HttpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxRetries": {
+                    "type": "number"
+                },
+                "PerRetryTimeout": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.Duration"
+                },
+                "TcpRetryEvents": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MaxRetries",
+                "PerRetryTimeout"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRoute": {
             "additionalProperties": false,
             "properties": {
@@ -3661,6 +3726,9 @@
                 },
                 "Match": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteMatch"
+                },
+                "RetryPolicy": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HttpRetryPolicy"
                 }
             },
             "required": [
@@ -3684,10 +3752,40 @@
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.HttpRouteHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "Invert": {
+                    "type": "boolean"
+                },
+                "Match": {
+                    "$ref": "#/definitions/AWS::AppMesh::Route.HeaderMatchMethod"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.HttpRouteMatch": {
             "additionalProperties": false,
             "properties": {
+                "Headers": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AppMesh::Route.HttpRouteHeader"
+                    },
+                    "type": "array"
+                },
+                "Method": {
+                    "type": "string"
+                },
                 "Prefix": {
+                    "type": "string"
+                },
+                "Scheme": {
                     "type": "string"
                 }
             },
@@ -3696,11 +3794,30 @@
             ],
             "type": "object"
         },
+        "AWS::AppMesh::Route.MatchRange": {
+            "additionalProperties": false,
+            "properties": {
+                "End": {
+                    "type": "number"
+                },
+                "Start": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "End",
+                "Start"
+            ],
+            "type": "object"
+        },
         "AWS::AppMesh::Route.RouteSpec": {
             "additionalProperties": false,
             "properties": {
                 "HttpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.HttpRoute"
+                },
+                "Priority": {
+                    "type": "number"
                 },
                 "TcpRoute": {
                     "$ref": "#/definitions/AWS::AppMesh::Route.TcpRoute"
@@ -5390,6 +5507,9 @@
                 "CloudWatchLogsRoleArn": {
                     "type": "string"
                 },
+                "ExcludeVerboseContent": {
+                    "type": "boolean"
+                },
                 "FieldLogLevel": {
                     "type": "string"
                 }
@@ -5647,6 +5767,9 @@
                         },
                         "ServiceNamespace": {
                             "type": "string"
+                        },
+                        "SuspendedState": {
+                            "$ref": "#/definitions/AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState"
                         }
                     },
                     "required": [
@@ -5707,6 +5830,21 @@
                 "Schedule",
                 "ScheduledActionName"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationAutoScaling::ScalableTarget.SuspendedState": {
+            "additionalProperties": false,
+            "properties": {
+                "DynamicScalingInSuspended": {
+                    "type": "boolean"
+                },
+                "DynamicScalingOutSuspended": {
+                    "type": "boolean"
+                },
+                "ScheduledScalingSuspended": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationAutoScaling::ScalingPolicy": {
@@ -9573,6 +9711,9 @@
                         "Threshold": {
                             "type": "number"
                         },
+                        "ThresholdMetricId": {
+                            "type": "string"
+                        },
                         "TreatMissingData": {
                             "type": "string"
                         },
@@ -9582,8 +9723,7 @@
                     },
                     "required": [
                         "ComparisonOperator",
-                        "EvaluationPeriods",
-                        "Threshold"
+                        "EvaluationPeriods"
                     ],
                     "type": "object"
                 },
@@ -13024,6 +13164,151 @@
             },
             "type": "object"
         },
+        "AWS::Config::OrganizationConfigRule": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConfigRuleName": {
+                            "type": "string"
+                        },
+                        "OrganizationCustomRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata"
+                        },
+                        "OrganizationManagedRuleMetadata": {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata"
+                        }
+                    },
+                    "required": [
+                        "OrganizationConfigRuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConfigRule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationCustomRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "LambdaFunctionArn": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "OrganizationConfigRuleTriggerTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LambdaFunctionArn",
+                "OrganizationConfigRuleTriggerTypes"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConfigRule.OrganizationManagedRuleMetadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "InputParameters": {
+                    "type": "string"
+                },
+                "MaximumExecutionFrequency": {
+                    "type": "string"
+                },
+                "ResourceIdScope": {
+                    "type": "string"
+                },
+                "ResourceTypesScope": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RuleIdentifier": {
+                    "type": "string"
+                },
+                "TagKeyScope": {
+                    "type": "string"
+                },
+                "TagValueScope": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RuleIdentifier"
+            ],
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -13056,14 +13341,26 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Automatic": {
+                            "type": "boolean"
+                        },
                         "ConfigRuleName": {
                             "type": "string"
+                        },
+                        "ExecutionControls": {
+                            "$ref": "#/definitions/AWS::Config::RemediationConfiguration.ExecutionControls"
+                        },
+                        "MaximumAutomaticAttempts": {
+                            "type": "number"
                         },
                         "Parameters": {
                             "type": "object"
                         },
                         "ResourceType": {
                             "type": "string"
+                        },
+                        "RetryAttemptSeconds": {
+                            "type": "number"
                         },
                         "TargetId": {
                             "type": "string"
@@ -13095,6 +13392,15 @@
             ],
             "type": "object"
         },
+        "AWS::Config::RemediationConfiguration.ExecutionControls": {
+            "additionalProperties": false,
+            "properties": {
+                "SsmControls": {
+                    "$ref": "#/definitions/AWS::Config::RemediationConfiguration.SsmControls"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Config::RemediationConfiguration.RemediationParameterValue": {
             "additionalProperties": false,
             "properties": {
@@ -13112,6 +13418,18 @@
             "properties": {
                 "Value": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Config::RemediationConfiguration.SsmControls": {
+            "additionalProperties": false,
+            "properties": {
+                "ConcurrentExecutionRatePercentage": {
+                    "type": "number"
+                },
+                "ErrorPercentage": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -14071,8 +14389,14 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "CdcStartPosition": {
+                            "type": "string"
+                        },
                         "CdcStartTime": {
                             "type": "number"
+                        },
+                        "CdcStopPosition": {
+                            "type": "string"
                         },
                         "MigrationType": {
                             "type": "string"
@@ -14556,6 +14880,12 @@
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "EngineVersion": {
                             "type": "string"
@@ -15054,8 +15384,14 @@
         "AWS::DynamoDB::Table.SSESpecification": {
             "additionalProperties": false,
             "properties": {
+                "KMSMasterKeyId": {
+                    "type": "string"
+                },
                 "SSEEnabled": {
                     "type": "boolean"
+                },
+                "SSEType": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -15426,6 +15762,10 @@
                     "type": "array"
                 }
             },
+            "required": [
+                "ResourceType",
+                "Tags"
+            ],
             "type": "object"
         },
         "AWS::EC2::ClientVpnRoute": {
@@ -16273,6 +16613,9 @@
                             },
                             "type": "array"
                         },
+                        "CpuOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.CpuOptions"
+                        },
                         "CreditSpecification": {
                             "$ref": "#/definitions/AWS::EC2::Instance.CreditSpecification"
                         },
@@ -16448,6 +16791,18 @@
             ],
             "type": "object"
         },
+        "AWS::EC2::Instance.CpuOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "CoreCount": {
+                    "type": "number"
+                },
+                "ThreadsPerCore": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::EC2::Instance.CreditSpecification": {
             "additionalProperties": false,
             "properties": {
@@ -16468,6 +16823,9 @@
                 },
                 "Iops": {
                     "type": "number"
+                },
+                "KmsKeyId": {
+                    "type": "string"
                 },
                 "SnapshotId": {
                     "type": "string"
@@ -19603,6 +19961,66 @@
             ],
             "type": "object"
         },
+        "AWS::EC2::VPCEndpointService": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AcceptanceRequired": {
+                            "type": "boolean"
+                        },
+                        "NetworkLoadBalancerArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkLoadBalancerArns"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::VPCEndpointService"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::EC2::VPCEndpointServicePermissions": {
             "additionalProperties": false,
             "properties": {
@@ -20623,10 +21041,16 @@
                         "Family": {
                             "type": "string"
                         },
+                        "IpcMode": {
+                            "type": "string"
+                        },
                         "Memory": {
                             "type": "string"
                         },
                         "NetworkMode": {
+                            "type": "string"
+                        },
+                        "PidMode": {
                             "type": "string"
                         },
                         "PlacementConstraints": {
@@ -20752,6 +21176,9 @@
                 "Image": {
                     "type": "string"
                 },
+                "Interactive": {
+                    "type": "boolean"
+                },
                 "Links": {
                     "items": {
                         "type": "string"
@@ -20788,6 +21215,9 @@
                 "Privileged": {
                     "type": "boolean"
                 },
+                "PseudoTerminal": {
+                    "type": "boolean"
+                },
                 "ReadonlyRootFilesystem": {
                     "type": "boolean"
                 },
@@ -20811,6 +21241,12 @@
                 },
                 "StopTimeout": {
                     "type": "number"
+                },
+                "SystemControls": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.SystemControl"
+                    },
+                    "type": "array"
                 },
                 "Ulimits": {
                     "items": {
@@ -21026,6 +21462,12 @@
                         }
                     },
                     "type": "object"
+                },
+                "SecretOptions": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ECS::TaskDefinition.Secret"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
@@ -21125,6 +21567,22 @@
             ],
             "type": "object"
         },
+        "AWS::ECS::TaskDefinition.SystemControl": {
+            "additionalProperties": false,
+            "properties": {
+                "Namespace": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Namespace",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::TaskDefinition.TaskDefinitionPlacementConstraint": {
             "additionalProperties": false,
             "properties": {
@@ -21156,6 +21614,9 @@
                     "type": "number"
                 }
             },
+            "required": [
+                "Size"
+            ],
             "type": "object"
         },
         "AWS::ECS::TaskDefinition.Ulimit": {
@@ -23115,6 +23576,9 @@
                             "type": "string"
                         },
                         "EngineVersion": {
+                            "type": "string"
+                        },
+                        "KmsKeyId": {
                             "type": "string"
                         },
                         "NodeGroupConfiguration": {
@@ -25214,6 +25678,9 @@
                 "InstanceType": {
                     "type": "string"
                 },
+                "ZoneAwarenessConfig": {
+                    "$ref": "#/definitions/AWS::Elasticsearch::Domain.ZoneAwarenessConfig"
+                },
                 "ZoneAwarenessEnabled": {
                     "type": "boolean"
                 }
@@ -25264,6 +25731,15 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Elasticsearch::Domain.ZoneAwarenessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AvailabilityZoneCount": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -25419,9 +25895,45 @@
             ],
             "type": "object"
         },
+        "AWS::Events::Rule.AwsVpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::Events::Rule.EcsParameters": {
             "additionalProperties": false,
             "properties": {
+                "Group": {
+                    "type": "string"
+                },
+                "LaunchType": {
+                    "type": "string"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.NetworkConfiguration"
+                },
+                "PlatformVersion": {
+                    "type": "string"
+                },
                 "TaskCount": {
                     "type": "number"
                 },
@@ -25465,6 +25977,15 @@
             "required": [
                 "PartitionKeyPath"
             ],
+            "type": "object"
+        },
+        "AWS::Events::Rule.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AwsVpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Events::Rule.AwsVpcConfiguration"
+                }
+            },
             "type": "object"
         },
         "AWS::Events::Rule.RunCommandParameters": {
@@ -26569,6 +27090,9 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Arguments": {
+                            "type": "object"
+                        },
                         "EndpointName": {
                             "type": "string"
                         },
@@ -26578,7 +27102,13 @@
                         "ExtraPythonLibsS3Path": {
                             "type": "string"
                         },
+                        "GlueVersion": {
+                            "type": "string"
+                        },
                         "NumberOfNodes": {
+                            "type": "number"
+                        },
+                        "NumberOfWorkers": {
                             "type": "number"
                         },
                         "PublicKey": {
@@ -26601,6 +27131,9 @@
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "WorkerType": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -26686,6 +27219,9 @@
                         "Name": {
                             "type": "string"
                         },
+                        "NotificationProperty": {
+                            "$ref": "#/definitions/AWS::Glue::Job.NotificationProperty"
+                        },
                         "NumberOfWorkers": {
                             "type": "number"
                         },
@@ -26697,6 +27233,9 @@
                         },
                         "Tags": {
                             "type": "object"
+                        },
+                        "Timeout": {
+                            "type": "number"
                         },
                         "WorkerType": {
                             "type": "string"
@@ -26753,6 +27292,15 @@
                 },
                 "ScriptLocation": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Job.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27503,10 +28051,16 @@
                         "Schedule": {
                             "type": "string"
                         },
+                        "StartOnCreation": {
+                            "type": "boolean"
+                        },
                         "Tags": {
                             "type": "object"
                         },
                         "Type": {
+                            "type": "string"
+                        },
+                        "WorkflowName": {
                             "type": "string"
                         }
                     },
@@ -27535,11 +28089,20 @@
                 "Arguments": {
                     "type": "object"
                 },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
+                "NotificationProperty": {
+                    "$ref": "#/definitions/AWS::Glue::Trigger.NotificationProperty"
+                },
                 "SecurityConfiguration": {
                     "type": "string"
+                },
+                "Timeout": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27547,6 +28110,12 @@
         "AWS::Glue::Trigger.Condition": {
             "additionalProperties": false,
             "properties": {
+                "CrawlState": {
+                    "type": "string"
+                },
+                "CrawlerName": {
+                    "type": "string"
+                },
                 "JobName": {
                     "type": "string"
                 },
@@ -27555,6 +28124,15 @@
                 },
                 "State": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Trigger.NotificationProperty": {
+            "additionalProperties": false,
+            "properties": {
+                "NotifyDelayAfter": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -27572,6 +28150,65 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Glue::Workflow": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DefaultRunProperties": {
+                            "type": "object"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Glue::Workflow"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::Greengrass::ConnectorDefinition": {
@@ -30282,6 +30919,9 @@
                         "AssumeRolePolicyDocument": {
                             "type": "object"
                         },
+                        "Description": {
+                            "type": "string"
+                        },
                         "ManagedPolicyArns": {
                             "items": {
                                 "type": "string"
@@ -30305,6 +30945,12 @@
                         },
                         "RoleName": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -35765,6 +36411,9 @@
                         "FunctionName": {
                             "type": "string"
                         },
+                        "MaximumBatchingWindowInSeconds": {
+                            "type": "number"
+                        },
                         "StartingPosition": {
                             "type": "string"
                         }
@@ -37815,6 +38464,12 @@
                         },
                         "DBSubnetGroupName": {
                             "type": "string"
+                        },
+                        "EnableCloudwatchLogsExports": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -41369,6 +42024,72 @@
             },
             "type": "object"
         },
+        "AWS::QLDB::Ledger": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "PermissionsMode": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PermissionsMode"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::QLDB::Ledger"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::RAM::ResourceShare": {
             "additionalProperties": false,
             "properties": {
@@ -41476,6 +42197,12 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBCluster.DBClusterRole"
+                            },
+                            "type": "array"
+                        },
                         "AvailabilityZones": {
                             "items": {
                                 "type": "string"
@@ -41542,10 +42269,16 @@
                         "ReplicationSourceIdentifier": {
                             "type": "string"
                         },
+                        "RestoreType": {
+                            "type": "string"
+                        },
                         "ScalingConfiguration": {
                             "$ref": "#/definitions/AWS::RDS::DBCluster.ScalingConfiguration"
                         },
                         "SnapshotIdentifier": {
+                            "type": "string"
+                        },
+                        "SourceDBClusterIdentifier": {
                             "type": "string"
                         },
                         "SourceRegion": {
@@ -41559,6 +42292,9 @@
                                 "$ref": "#/definitions/Tag"
                             },
                             "type": "array"
+                        },
+                        "UseLatestRestorableTime": {
+                            "type": "boolean"
                         },
                         "VpcSecurityGroupIds": {
                             "items": {
@@ -41582,6 +42318,24 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBCluster.DBClusterRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -41708,6 +42462,12 @@
                         },
                         "AllowMajorVersionUpgrade": {
                             "type": "boolean"
+                        },
+                        "AssociatedRoles": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::RDS::DBInstance.DBInstanceRole"
+                            },
+                            "type": "array"
                         },
                         "AutoMinorVersionUpgrade": {
                             "type": "boolean"
@@ -41881,6 +42641,25 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::RDS::DBInstance.DBInstanceRole": {
+            "additionalProperties": false,
+            "properties": {
+                "FeatureName": {
+                    "type": "string"
+                },
+                "RoleArn": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FeatureName",
+                "RoleArn"
             ],
             "type": "object"
         },
@@ -46398,6 +47177,98 @@
             ],
             "type": "object"
         },
+        "AWS::SSM::MaintenanceWindowTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "OwnerInformation": {
+                            "type": "string"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "Targets": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget.Targets"
+                            },
+                            "type": "array"
+                        },
+                        "WindowId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ResourceType",
+                        "Targets",
+                        "WindowId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSM::MaintenanceWindowTarget"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SSM::MaintenanceWindowTarget.Targets": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::SSM::MaintenanceWindowTask": {
             "additionalProperties": false,
             "properties": {
@@ -46973,6 +47844,81 @@
             ],
             "type": "object"
         },
+        "AWS::SageMaker::CodeRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CodeRepositoryName": {
+                            "type": "string"
+                        },
+                        "GitConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository.GitConfig"
+                        }
+                    },
+                    "required": [
+                        "GitConfig"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::CodeRepository"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::CodeRepository.GitConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Branch": {
+                    "type": "string"
+                },
+                "RepositoryUrl": {
+                    "type": "string"
+                },
+                "SecretArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "RepositoryUrl"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -47429,6 +48375,118 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "MemberDefinitions": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::SageMaker::Workteam.MemberDefinition"
+                            },
+                            "type": "array"
+                        },
+                        "NotificationConfiguration": {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam.NotificationConfiguration"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "WorkteamName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Workteam"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.CognitoMemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoClientId": {
+                    "type": "string"
+                },
+                "CognitoUserGroup": {
+                    "type": "string"
+                },
+                "CognitoUserPool": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "CognitoClientId",
+                "CognitoUserGroup",
+                "CognitoUserPool"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.MemberDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "CognitoMemberDefinition": {
+                    "$ref": "#/definitions/AWS::SageMaker::Workteam.CognitoMemberDefinition"
+                }
+            },
+            "required": [
+                "CognitoMemberDefinition"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Workteam.NotificationConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "NotificationTopicArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "NotificationTopicArn"
+            ],
             "type": "object"
         },
         "AWS::SecretsManager::ResourcePolicy": {
@@ -48583,8 +49641,7 @@
             },
             "required": [
                 "Bucket",
-                "Key",
-                "Version"
+                "Key"
             ],
             "type": "object"
         },
@@ -53030,6 +54087,9 @@
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
                         },
                         {
@@ -53219,6 +54279,9 @@
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointConnectionNotification"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EC2::VPCEndpointService"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::EC2::VPCEndpointServicePermissions"
                         },
                         {
@@ -53385,6 +54448,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Glue::Trigger"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Glue::Workflow"
                         },
                         {
                             "$ref": "#/definitions/AWS::Greengrass::ConnectorDefinition"
@@ -53735,6 +54801,9 @@
                             "$ref": "#/definitions/AWS::PinpointEmail::Identity"
                         },
                         {
+                            "$ref": "#/definitions/AWS::QLDB::Ledger"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::RAM::ResourceShare"
                         },
                         {
@@ -53870,6 +54939,9 @@
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindow"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTarget"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSM::MaintenanceWindowTask"
                         },
                         {
@@ -53880,6 +54952,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::SSM::ResourceDataSync"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -53895,6 +54970,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Workteam"
                         },
                         {
                             "$ref": "#/definitions/AWS::SecretsManager::ResourcePolicy"


### PR DESCRIPTION
SAM specification marks this field as optional but is marked as required in this repo.
SAM spec is here - https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3-location-object

See generate/sam-2016-10-31.json for the change. The rest of the changes come from running `go generate`.

fixes #87
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
