### PR TITLE
feat(schema): CloudFormation Updates (2019-12-09)

### DIFF
--- a/cloudformation/accessanalyzer/aws-accessanalyzer-analyzer.go
+++ b/cloudformation/accessanalyzer/aws-accessanalyzer-analyzer.go
@@ -1,4 +1,4 @@
-package guardduty
+package accessanalyzer
 
 import (
 	"bytes"
@@ -6,41 +6,32 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
-// Filter AWS CloudFormation Resource (AWS::GuardDuty::Filter)
-// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html
-type Filter struct {
+// Analyzer AWS CloudFormation Resource (AWS::AccessAnalyzer::Analyzer)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html
+type Analyzer struct {
 
-	// Action AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action
-	Action string `json:"Action,omitempty"`
+	// AnalyzerName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html#cfn-accessanalyzer-analyzer-analyzername
+	AnalyzerName string `json:"AnalyzerName,omitempty"`
 
-	// Description AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description
-	Description string `json:"Description,omitempty"`
+	// ArchiveRules AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html#cfn-accessanalyzer-analyzer-archiverules
+	ArchiveRules []Analyzer_ArchiveRule `json:"ArchiveRules,omitempty"`
 
-	// DetectorId AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-detectorid
-	DetectorId string `json:"DetectorId,omitempty"`
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html#cfn-accessanalyzer-analyzer-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
-	// FindingCriteria AWS CloudFormation Property
+	// Type AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-findingcriteria
-	FindingCriteria *Filter_FindingCriteria `json:"FindingCriteria,omitempty"`
-
-	// Name AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-name
-	Name string `json:"Name,omitempty"`
-
-	// Rank AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-rank
-	Rank int `json:"Rank"`
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-accessanalyzer-analyzer.html#cfn-accessanalyzer-analyzer-type
+	Type string `json:"Type,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
@@ -53,14 +44,14 @@ type Filter struct {
 }
 
 // AWSCloudFormationType returns the AWS CloudFormation resource type
-func (r *Filter) AWSCloudFormationType() string {
-	return "AWS::GuardDuty::Filter"
+func (r *Analyzer) AWSCloudFormationType() string {
+	return "AWS::AccessAnalyzer::Analyzer"
 }
 
 // MarshalJSON is a custom JSON marshalling hook that embeds this object into
 // an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
-func (r Filter) MarshalJSON() ([]byte, error) {
-	type Properties Filter
+func (r Analyzer) MarshalJSON() ([]byte, error) {
+	type Properties Analyzer
 	return json.Marshal(&struct {
 		Type           string
 		Properties     Properties
@@ -78,8 +69,8 @@ func (r Filter) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
 // AWS CloudFormation resource object, and just keeps the 'Properties' field.
-func (r *Filter) UnmarshalJSON(b []byte) error {
-	type Properties Filter
+func (r *Analyzer) UnmarshalJSON(b []byte) error {
+	type Properties Analyzer
 	res := &struct {
 		Type           string
 		Properties     *Properties
@@ -98,7 +89,7 @@ func (r *Filter) UnmarshalJSON(b []byte) error {
 
 	// If the resource has no Properties set, it could be nil
 	if res.Properties != nil {
-		*r = Filter(*res.Properties)
+		*r = Analyzer(*res.Properties)
 	}
 	if res.DependsOn != nil {
 		r.AWSCloudFormationDependsOn = res.DependsOn

--- a/cloudformation/accessanalyzer/aws-accessanalyzer-analyzer_archiverule.go
+++ b/cloudformation/accessanalyzer/aws-accessanalyzer-analyzer_archiverule.go
@@ -1,0 +1,34 @@
+package accessanalyzer
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Analyzer_ArchiveRule AWS CloudFormation Resource (AWS::AccessAnalyzer::Analyzer.ArchiveRule)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-archiverule.html
+type Analyzer_ArchiveRule struct {
+
+	// Filter AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-archiverule.html#cfn-accessanalyzer-analyzer-archiverule-filter
+	Filter []Analyzer_Filter `json:"Filter,omitempty"`
+
+	// RuleName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-archiverule.html#cfn-accessanalyzer-analyzer-archiverule-rulename
+	RuleName string `json:"RuleName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Analyzer_ArchiveRule) AWSCloudFormationType() string {
+	return "AWS::AccessAnalyzer::Analyzer.ArchiveRule"
+}

--- a/cloudformation/accessanalyzer/aws-accessanalyzer-analyzer_filter.go
+++ b/cloudformation/accessanalyzer/aws-accessanalyzer-analyzer_filter.go
@@ -1,0 +1,49 @@
+package accessanalyzer
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Analyzer_Filter AWS CloudFormation Resource (AWS::AccessAnalyzer::Analyzer.Filter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-filter.html
+type Analyzer_Filter struct {
+
+	// Contains AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-filter.html#cfn-accessanalyzer-analyzer-filter-contains
+	Contains []string `json:"Contains,omitempty"`
+
+	// Eq AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-filter.html#cfn-accessanalyzer-analyzer-filter-eq
+	Eq []string `json:"Eq,omitempty"`
+
+	// Exists AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-filter.html#cfn-accessanalyzer-analyzer-filter-exists
+	Exists bool `json:"Exists,omitempty"`
+
+	// Neq AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-filter.html#cfn-accessanalyzer-analyzer-filter-neq
+	Neq []string `json:"Neq,omitempty"`
+
+	// Property AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-accessanalyzer-analyzer-filter.html#cfn-accessanalyzer-analyzer-filter-property
+	Property string `json:"Property,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Analyzer_Filter) AWSCloudFormationType() string {
+	return "AWS::AccessAnalyzer::Analyzer.Filter"
+}

--- a/cloudformation/all.go
+++ b/cloudformation/all.go
@@ -2,6 +2,7 @@ package cloudformation
 
 import (
 	"fmt"
+	"github.com/awslabs/goformation/v4/cloudformation/accessanalyzer"
 	"github.com/awslabs/goformation/v4/cloudformation/amazonmq"
 	"github.com/awslabs/goformation/v4/cloudformation/amplify"
 	"github.com/awslabs/goformation/v4/cloudformation/apigateway"
@@ -50,6 +51,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/elasticsearch"
 	"github.com/awslabs/goformation/v4/cloudformation/emr"
 	"github.com/awslabs/goformation/v4/cloudformation/events"
+	"github.com/awslabs/goformation/v4/cloudformation/eventschemas"
 	"github.com/awslabs/goformation/v4/cloudformation/fsx"
 	"github.com/awslabs/goformation/v4/cloudformation/gamelift"
 	"github.com/awslabs/goformation/v4/cloudformation/glue"
@@ -110,6 +112,7 @@ import (
 // AllResources fetches an iterable map all CloudFormation and SAM resources
 func AllResources() map[string]Resource {
 	return map[string]Resource{
+		"AWS::AccessAnalyzer::Analyzer":                               &accessanalyzer.Analyzer{},
 		"AWS::AmazonMQ::Broker":                                       &amazonmq.Broker{},
 		"AWS::AmazonMQ::Configuration":                                &amazonmq.Configuration{},
 		"AWS::AmazonMQ::ConfigurationAssociation":                     &amazonmq.ConfigurationAssociation{},
@@ -334,6 +337,9 @@ func AllResources() map[string]Resource {
 		"AWS::ElasticLoadBalancingV2::LoadBalancer":                   &elasticloadbalancingv2.LoadBalancer{},
 		"AWS::ElasticLoadBalancingV2::TargetGroup":                    &elasticloadbalancingv2.TargetGroup{},
 		"AWS::Elasticsearch::Domain":                                  &elasticsearch.Domain{},
+		"AWS::EventSchemas::Discoverer":                               &eventschemas.Discoverer{},
+		"AWS::EventSchemas::Registry":                                 &eventschemas.Registry{},
+		"AWS::EventSchemas::Schema":                                   &eventschemas.Schema{},
 		"AWS::Events::EventBus":                                       &events.EventBus{},
 		"AWS::Events::EventBusPolicy":                                 &events.EventBusPolicy{},
 		"AWS::Events::Rule":                                           &events.Rule{},
@@ -510,6 +516,7 @@ func AllResources() map[string]Resource {
 		"AWS::Route53Resolver::ResolverEndpoint":                      &route53resolver.ResolverEndpoint{},
 		"AWS::Route53Resolver::ResolverRule":                          &route53resolver.ResolverRule{},
 		"AWS::Route53Resolver::ResolverRuleAssociation":               &route53resolver.ResolverRuleAssociation{},
+		"AWS::S3::AccessPoint":                                        &s3.AccessPoint{},
 		"AWS::S3::Bucket":                                             &s3.Bucket{},
 		"AWS::S3::BucketPolicy":                                       &s3.BucketPolicy{},
 		"AWS::SDB::Domain":                                            &sdb.Domain{},
@@ -597,6 +604,30 @@ func AllResources() map[string]Resource {
 		"AWS::WorkSpaces::Workspace":                                  &workspaces.Workspace{},
 		"Alexa::ASK::Skill":                                           &ask.Skill{},
 	}
+}
+
+// GetAllAccessAnalyzerAnalyzerResources retrieves all accessanalyzer.Analyzer items from an AWS CloudFormation template
+func (t *Template) GetAllAccessAnalyzerAnalyzerResources() map[string]*accessanalyzer.Analyzer {
+	results := map[string]*accessanalyzer.Analyzer{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *accessanalyzer.Analyzer:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAccessAnalyzerAnalyzerWithName retrieves all accessanalyzer.Analyzer items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAccessAnalyzerAnalyzerWithName(name string) (*accessanalyzer.Analyzer, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *accessanalyzer.Analyzer:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type accessanalyzer.Analyzer not found", name)
 }
 
 // GetAllAmazonMQBrokerResources retrieves all amazonmq.Broker items from an AWS CloudFormation template
@@ -5975,6 +6006,78 @@ func (t *Template) GetElasticsearchDomainWithName(name string) (*elasticsearch.D
 	return nil, fmt.Errorf("resource %q of type elasticsearch.Domain not found", name)
 }
 
+// GetAllEventSchemasDiscovererResources retrieves all eventschemas.Discoverer items from an AWS CloudFormation template
+func (t *Template) GetAllEventSchemasDiscovererResources() map[string]*eventschemas.Discoverer {
+	results := map[string]*eventschemas.Discoverer{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *eventschemas.Discoverer:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEventSchemasDiscovererWithName retrieves all eventschemas.Discoverer items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEventSchemasDiscovererWithName(name string) (*eventschemas.Discoverer, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *eventschemas.Discoverer:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type eventschemas.Discoverer not found", name)
+}
+
+// GetAllEventSchemasRegistryResources retrieves all eventschemas.Registry items from an AWS CloudFormation template
+func (t *Template) GetAllEventSchemasRegistryResources() map[string]*eventschemas.Registry {
+	results := map[string]*eventschemas.Registry{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *eventschemas.Registry:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEventSchemasRegistryWithName retrieves all eventschemas.Registry items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEventSchemasRegistryWithName(name string) (*eventschemas.Registry, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *eventschemas.Registry:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type eventschemas.Registry not found", name)
+}
+
+// GetAllEventSchemasSchemaResources retrieves all eventschemas.Schema items from an AWS CloudFormation template
+func (t *Template) GetAllEventSchemasSchemaResources() map[string]*eventschemas.Schema {
+	results := map[string]*eventschemas.Schema{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *eventschemas.Schema:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEventSchemasSchemaWithName retrieves all eventschemas.Schema items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEventSchemasSchemaWithName(name string) (*eventschemas.Schema, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *eventschemas.Schema:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type eventschemas.Schema not found", name)
+}
+
 // GetAllEventsEventBusResources retrieves all events.EventBus items from an AWS CloudFormation template
 func (t *Template) GetAllEventsEventBusResources() map[string]*events.EventBus {
 	results := map[string]*events.EventBus{}
@@ -10197,6 +10300,30 @@ func (t *Template) GetRoute53ResolverResolverRuleAssociationWithName(name string
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type route53resolver.ResolverRuleAssociation not found", name)
+}
+
+// GetAllS3AccessPointResources retrieves all s3.AccessPoint items from an AWS CloudFormation template
+func (t *Template) GetAllS3AccessPointResources() map[string]*s3.AccessPoint {
+	results := map[string]*s3.AccessPoint{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *s3.AccessPoint:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetS3AccessPointWithName retrieves all s3.AccessPoint items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetS3AccessPointWithName(name string) (*s3.AccessPoint, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *s3.AccessPoint:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type s3.AccessPoint not found", name)
 }
 
 // GetAllS3BucketResources retrieves all s3.Bucket items from an AWS CloudFormation template

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-api.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-api.go
@@ -17,6 +17,31 @@ type Api struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-apikeyselectionexpression
 	ApiKeySelectionExpression string `json:"ApiKeySelectionExpression,omitempty"`
 
+	// BasePath AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-basepath
+	BasePath string `json:"BasePath,omitempty"`
+
+	// Body AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-body
+	Body interface{} `json:"Body,omitempty"`
+
+	// BodyS3Location AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-bodys3location
+	BodyS3Location *Api_BodyS3Location `json:"BodyS3Location,omitempty"`
+
+	// CorsConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-corsconfiguration
+	CorsConfiguration *Api_Cors `json:"CorsConfiguration,omitempty"`
+
+	// CredentialsArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-credentialsarn
+	CredentialsArn string `json:"CredentialsArn,omitempty"`
+
 	// Description AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-description
@@ -27,18 +52,28 @@ type Api struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-disableschemavalidation
 	DisableSchemaValidation bool `json:"DisableSchemaValidation,omitempty"`
 
+	// FailOnWarnings AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-failonwarnings
+	FailOnWarnings bool `json:"FailOnWarnings,omitempty"`
+
 	// Name AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-name
 	Name string `json:"Name,omitempty"`
 
 	// ProtocolType AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-protocoltype
 	ProtocolType string `json:"ProtocolType,omitempty"`
 
+	// RouteKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-routekey
+	RouteKey string `json:"RouteKey,omitempty"`
+
 	// RouteSelectionExpression AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-routeselectionexpression
 	RouteSelectionExpression string `json:"RouteSelectionExpression,omitempty"`
 
@@ -46,6 +81,11 @@ type Api struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-tags
 	Tags interface{} `json:"Tags,omitempty"`
+
+	// Target AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-target
+	Target string `json:"Target,omitempty"`
 
 	// Version AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-api_bodys3location.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-api_bodys3location.go
@@ -1,0 +1,44 @@
+package apigatewayv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Api_BodyS3Location AWS CloudFormation Resource (AWS::ApiGatewayV2::Api.BodyS3Location)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-bodys3location.html
+type Api_BodyS3Location struct {
+
+	// Bucket AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-bodys3location.html#cfn-apigatewayv2-api-bodys3location-bucket
+	Bucket string `json:"Bucket,omitempty"`
+
+	// Etag AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-bodys3location.html#cfn-apigatewayv2-api-bodys3location-etag
+	Etag string `json:"Etag,omitempty"`
+
+	// Key AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-bodys3location.html#cfn-apigatewayv2-api-bodys3location-key
+	Key string `json:"Key,omitempty"`
+
+	// Version AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-bodys3location.html#cfn-apigatewayv2-api-bodys3location-version
+	Version string `json:"Version,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Api_BodyS3Location) AWSCloudFormationType() string {
+	return "AWS::ApiGatewayV2::Api.BodyS3Location"
+}

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-api_cors.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-api_cors.go
@@ -1,0 +1,54 @@
+package apigatewayv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Api_Cors AWS CloudFormation Resource (AWS::ApiGatewayV2::Api.Cors)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html
+type Api_Cors struct {
+
+	// AllowCredentials AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html#cfn-apigatewayv2-api-cors-allowcredentials
+	AllowCredentials bool `json:"AllowCredentials,omitempty"`
+
+	// AllowHeaders AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html#cfn-apigatewayv2-api-cors-allowheaders
+	AllowHeaders []string `json:"AllowHeaders,omitempty"`
+
+	// AllowMethods AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html#cfn-apigatewayv2-api-cors-allowmethods
+	AllowMethods []string `json:"AllowMethods,omitempty"`
+
+	// AllowOrigins AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html#cfn-apigatewayv2-api-cors-alloworigins
+	AllowOrigins []string `json:"AllowOrigins,omitempty"`
+
+	// ExposeHeaders AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html#cfn-apigatewayv2-api-cors-exposeheaders
+	ExposeHeaders []string `json:"ExposeHeaders,omitempty"`
+
+	// MaxAge AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-api-cors.html#cfn-apigatewayv2-api-cors-maxage
+	MaxAge int `json:"MaxAge,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Api_Cors) AWSCloudFormationType() string {
+	return "AWS::ApiGatewayV2::Api.Cors"
+}

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-authorizer.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-authorizer.go
@@ -33,7 +33,7 @@ type Authorizer struct {
 	AuthorizerType string `json:"AuthorizerType,omitempty"`
 
 	// AuthorizerUri AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-authorizer.html#cfn-apigatewayv2-authorizer-authorizeruri
 	AuthorizerUri string `json:"AuthorizerUri,omitempty"`
 
@@ -46,6 +46,11 @@ type Authorizer struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-authorizer.html#cfn-apigatewayv2-authorizer-identityvalidationexpression
 	IdentityValidationExpression string `json:"IdentityValidationExpression,omitempty"`
+
+	// JwtConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-authorizer.html#cfn-apigatewayv2-authorizer-jwtconfiguration
+	JwtConfiguration *Authorizer_JWTConfiguration `json:"JwtConfiguration,omitempty"`
 
 	// Name AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-authorizer_jwtconfiguration.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-authorizer_jwtconfiguration.go
@@ -1,0 +1,34 @@
+package apigatewayv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Authorizer_JWTConfiguration AWS CloudFormation Resource (AWS::ApiGatewayV2::Authorizer.JWTConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-authorizer-jwtconfiguration.html
+type Authorizer_JWTConfiguration struct {
+
+	// Audience AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-authorizer-jwtconfiguration.html#cfn-apigatewayv2-authorizer-jwtconfiguration-audience
+	Audience []string `json:"Audience,omitempty"`
+
+	// Issuer AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-authorizer-jwtconfiguration.html#cfn-apigatewayv2-authorizer-jwtconfiguration-issuer
+	Issuer string `json:"Issuer,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Authorizer_JWTConfiguration) AWSCloudFormationType() string {
+	return "AWS::ApiGatewayV2::Authorizer.JWTConfiguration"
+}

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-integration.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-integration.go
@@ -57,6 +57,11 @@ type Integration struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integration.html#cfn-apigatewayv2-integration-passthroughbehavior
 	PassthroughBehavior string `json:"PassthroughBehavior,omitempty"`
 
+	// PayloadFormatVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integration.html#cfn-apigatewayv2-integration-payloadformatversion
+	PayloadFormatVersion string `json:"PayloadFormatVersion,omitempty"`
+
 	// RequestParameters AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-integration.html#cfn-apigatewayv2-integration-requestparameters

--- a/cloudformation/apigatewayv2/aws-apigatewayv2-stage.go
+++ b/cloudformation/apigatewayv2/aws-apigatewayv2-stage.go
@@ -22,6 +22,11 @@ type Stage struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html#cfn-apigatewayv2-stage-apiid
 	ApiId string `json:"ApiId,omitempty"`
 
+	// AutoDeploy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html#cfn-apigatewayv2-stage-autodeploy
+	AutoDeploy bool `json:"AutoDeploy,omitempty"`
+
 	// ClientCertificateId AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html#cfn-apigatewayv2-stage-clientcertificateid
@@ -33,7 +38,7 @@ type Stage struct {
 	DefaultRouteSettings *Stage_RouteSettings `json:"DefaultRouteSettings,omitempty"`
 
 	// DeploymentId AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-stage.html#cfn-apigatewayv2-stage-deploymentid
 	DeploymentId string `json:"DeploymentId,omitempty"`
 

--- a/cloudformation/eventschemas/aws-eventschemas-discoverer.go
+++ b/cloudformation/eventschemas/aws-eventschemas-discoverer.go
@@ -1,4 +1,4 @@
-package guardduty
+package eventschemas
 
 import (
 	"bytes"
@@ -8,39 +8,24 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
 )
 
-// Filter AWS CloudFormation Resource (AWS::GuardDuty::Filter)
-// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html
-type Filter struct {
-
-	// Action AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action
-	Action string `json:"Action,omitempty"`
+// Discoverer AWS CloudFormation Resource (AWS::EventSchemas::Discoverer)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-discoverer.html
+type Discoverer struct {
 
 	// Description AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-discoverer.html#cfn-eventschemas-discoverer-description
 	Description string `json:"Description,omitempty"`
 
-	// DetectorId AWS CloudFormation Property
+	// SourceArn AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-detectorid
-	DetectorId string `json:"DetectorId,omitempty"`
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-discoverer.html#cfn-eventschemas-discoverer-sourcearn
+	SourceArn string `json:"SourceArn,omitempty"`
 
-	// FindingCriteria AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-findingcriteria
-	FindingCriteria *Filter_FindingCriteria `json:"FindingCriteria,omitempty"`
-
-	// Name AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-name
-	Name string `json:"Name,omitempty"`
-
-	// Rank AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-rank
-	Rank int `json:"Rank"`
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-discoverer.html#cfn-eventschemas-discoverer-tags
+	Tags []Discoverer_TagsEntry `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
@@ -53,14 +38,14 @@ type Filter struct {
 }
 
 // AWSCloudFormationType returns the AWS CloudFormation resource type
-func (r *Filter) AWSCloudFormationType() string {
-	return "AWS::GuardDuty::Filter"
+func (r *Discoverer) AWSCloudFormationType() string {
+	return "AWS::EventSchemas::Discoverer"
 }
 
 // MarshalJSON is a custom JSON marshalling hook that embeds this object into
 // an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
-func (r Filter) MarshalJSON() ([]byte, error) {
-	type Properties Filter
+func (r Discoverer) MarshalJSON() ([]byte, error) {
+	type Properties Discoverer
 	return json.Marshal(&struct {
 		Type           string
 		Properties     Properties
@@ -78,8 +63,8 @@ func (r Filter) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
 // AWS CloudFormation resource object, and just keeps the 'Properties' field.
-func (r *Filter) UnmarshalJSON(b []byte) error {
-	type Properties Filter
+func (r *Discoverer) UnmarshalJSON(b []byte) error {
+	type Properties Discoverer
 	res := &struct {
 		Type           string
 		Properties     *Properties
@@ -98,7 +83,7 @@ func (r *Filter) UnmarshalJSON(b []byte) error {
 
 	// If the resource has no Properties set, it could be nil
 	if res.Properties != nil {
-		*r = Filter(*res.Properties)
+		*r = Discoverer(*res.Properties)
 	}
 	if res.DependsOn != nil {
 		r.AWSCloudFormationDependsOn = res.DependsOn

--- a/cloudformation/eventschemas/aws-eventschemas-discoverer_tagsentry.go
+++ b/cloudformation/eventschemas/aws-eventschemas-discoverer_tagsentry.go
@@ -1,0 +1,34 @@
+package eventschemas
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Discoverer_TagsEntry AWS CloudFormation Resource (AWS::EventSchemas::Discoverer.TagsEntry)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-discoverer-tagsentry.html
+type Discoverer_TagsEntry struct {
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-discoverer-tagsentry.html#cfn-eventschemas-discoverer-tagsentry-key
+	Key string `json:"Key,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-discoverer-tagsentry.html#cfn-eventschemas-discoverer-tagsentry-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Discoverer_TagsEntry) AWSCloudFormationType() string {
+	return "AWS::EventSchemas::Discoverer.TagsEntry"
+}

--- a/cloudformation/eventschemas/aws-eventschemas-registry.go
+++ b/cloudformation/eventschemas/aws-eventschemas-registry.go
@@ -1,4 +1,4 @@
-package guardduty
+package eventschemas
 
 import (
 	"bytes"
@@ -8,39 +8,24 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
 )
 
-// Filter AWS CloudFormation Resource (AWS::GuardDuty::Filter)
-// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html
-type Filter struct {
-
-	// Action AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action
-	Action string `json:"Action,omitempty"`
+// Registry AWS CloudFormation Resource (AWS::EventSchemas::Registry)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registry.html
+type Registry struct {
 
 	// Description AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registry.html#cfn-eventschemas-registry-description
 	Description string `json:"Description,omitempty"`
 
-	// DetectorId AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-detectorid
-	DetectorId string `json:"DetectorId,omitempty"`
+	// RegistryName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registry.html#cfn-eventschemas-registry-registryname
+	RegistryName string `json:"RegistryName,omitempty"`
 
-	// FindingCriteria AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-findingcriteria
-	FindingCriteria *Filter_FindingCriteria `json:"FindingCriteria,omitempty"`
-
-	// Name AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-name
-	Name string `json:"Name,omitempty"`
-
-	// Rank AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-rank
-	Rank int `json:"Rank"`
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-registry.html#cfn-eventschemas-registry-tags
+	Tags []Registry_TagsEntry `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
@@ -53,14 +38,14 @@ type Filter struct {
 }
 
 // AWSCloudFormationType returns the AWS CloudFormation resource type
-func (r *Filter) AWSCloudFormationType() string {
-	return "AWS::GuardDuty::Filter"
+func (r *Registry) AWSCloudFormationType() string {
+	return "AWS::EventSchemas::Registry"
 }
 
 // MarshalJSON is a custom JSON marshalling hook that embeds this object into
 // an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
-func (r Filter) MarshalJSON() ([]byte, error) {
-	type Properties Filter
+func (r Registry) MarshalJSON() ([]byte, error) {
+	type Properties Registry
 	return json.Marshal(&struct {
 		Type           string
 		Properties     Properties
@@ -78,8 +63,8 @@ func (r Filter) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
 // AWS CloudFormation resource object, and just keeps the 'Properties' field.
-func (r *Filter) UnmarshalJSON(b []byte) error {
-	type Properties Filter
+func (r *Registry) UnmarshalJSON(b []byte) error {
+	type Properties Registry
 	res := &struct {
 		Type           string
 		Properties     *Properties
@@ -98,7 +83,7 @@ func (r *Filter) UnmarshalJSON(b []byte) error {
 
 	// If the resource has no Properties set, it could be nil
 	if res.Properties != nil {
-		*r = Filter(*res.Properties)
+		*r = Registry(*res.Properties)
 	}
 	if res.DependsOn != nil {
 		r.AWSCloudFormationDependsOn = res.DependsOn

--- a/cloudformation/eventschemas/aws-eventschemas-registry_tagsentry.go
+++ b/cloudformation/eventschemas/aws-eventschemas-registry_tagsentry.go
@@ -1,0 +1,34 @@
+package eventschemas
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Registry_TagsEntry AWS CloudFormation Resource (AWS::EventSchemas::Registry.TagsEntry)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-registry-tagsentry.html
+type Registry_TagsEntry struct {
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-registry-tagsentry.html#cfn-eventschemas-registry-tagsentry-key
+	Key string `json:"Key,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-registry-tagsentry.html#cfn-eventschemas-registry-tagsentry-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Registry_TagsEntry) AWSCloudFormationType() string {
+	return "AWS::EventSchemas::Registry.TagsEntry"
+}

--- a/cloudformation/eventschemas/aws-eventschemas-schema.go
+++ b/cloudformation/eventschemas/aws-eventschemas-schema.go
@@ -1,4 +1,4 @@
-package guardduty
+package eventschemas
 
 import (
 	"bytes"
@@ -8,39 +8,39 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
 )
 
-// Filter AWS CloudFormation Resource (AWS::GuardDuty::Filter)
-// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html
-type Filter struct {
+// Schema AWS CloudFormation Resource (AWS::EventSchemas::Schema)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html
+type Schema struct {
 
-	// Action AWS CloudFormation Property
+	// Content AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action
-	Action string `json:"Action,omitempty"`
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html#cfn-eventschemas-schema-content
+	Content string `json:"Content,omitempty"`
 
 	// Description AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html#cfn-eventschemas-schema-description
 	Description string `json:"Description,omitempty"`
 
-	// DetectorId AWS CloudFormation Property
+	// RegistryName AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-detectorid
-	DetectorId string `json:"DetectorId,omitempty"`
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html#cfn-eventschemas-schema-registryname
+	RegistryName string `json:"RegistryName,omitempty"`
 
-	// FindingCriteria AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-findingcriteria
-	FindingCriteria *Filter_FindingCriteria `json:"FindingCriteria,omitempty"`
+	// SchemaName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html#cfn-eventschemas-schema-schemaname
+	SchemaName string `json:"SchemaName,omitempty"`
 
-	// Name AWS CloudFormation Property
-	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-name
-	Name string `json:"Name,omitempty"`
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html#cfn-eventschemas-schema-tags
+	Tags []Schema_TagsEntry `json:"Tags,omitempty"`
 
-	// Rank AWS CloudFormation Property
+	// Type AWS CloudFormation Property
 	// Required: true
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-rank
-	Rank int `json:"Rank"`
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eventschemas-schema.html#cfn-eventschemas-schema-type
+	Type string `json:"Type,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
@@ -53,14 +53,14 @@ type Filter struct {
 }
 
 // AWSCloudFormationType returns the AWS CloudFormation resource type
-func (r *Filter) AWSCloudFormationType() string {
-	return "AWS::GuardDuty::Filter"
+func (r *Schema) AWSCloudFormationType() string {
+	return "AWS::EventSchemas::Schema"
 }
 
 // MarshalJSON is a custom JSON marshalling hook that embeds this object into
 // an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
-func (r Filter) MarshalJSON() ([]byte, error) {
-	type Properties Filter
+func (r Schema) MarshalJSON() ([]byte, error) {
+	type Properties Schema
 	return json.Marshal(&struct {
 		Type           string
 		Properties     Properties
@@ -78,8 +78,8 @@ func (r Filter) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
 // AWS CloudFormation resource object, and just keeps the 'Properties' field.
-func (r *Filter) UnmarshalJSON(b []byte) error {
-	type Properties Filter
+func (r *Schema) UnmarshalJSON(b []byte) error {
+	type Properties Schema
 	res := &struct {
 		Type           string
 		Properties     *Properties
@@ -98,7 +98,7 @@ func (r *Filter) UnmarshalJSON(b []byte) error {
 
 	// If the resource has no Properties set, it could be nil
 	if res.Properties != nil {
-		*r = Filter(*res.Properties)
+		*r = Schema(*res.Properties)
 	}
 	if res.DependsOn != nil {
 		r.AWSCloudFormationDependsOn = res.DependsOn

--- a/cloudformation/eventschemas/aws-eventschemas-schema_tagsentry.go
+++ b/cloudformation/eventschemas/aws-eventschemas-schema_tagsentry.go
@@ -1,0 +1,34 @@
+package eventschemas
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Schema_TagsEntry AWS CloudFormation Resource (AWS::EventSchemas::Schema.TagsEntry)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-schema-tagsentry.html
+type Schema_TagsEntry struct {
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-schema-tagsentry.html#cfn-eventschemas-schema-tagsentry-key
+	Key string `json:"Key,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eventschemas-schema-tagsentry.html#cfn-eventschemas-schema-tagsentry-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Schema_TagsEntry) AWSCloudFormationType() string {
+	return "AWS::EventSchemas::Schema.TagsEntry"
+}

--- a/cloudformation/fsx/aws-fsx-filesystem_windowsconfiguration.go
+++ b/cloudformation/fsx/aws-fsx-filesystem_windowsconfiguration.go
@@ -28,6 +28,16 @@ type FileSystem_WindowsConfiguration struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-windowsconfiguration.html#cfn-fsx-filesystem-windowsconfiguration-dailyautomaticbackupstarttime
 	DailyAutomaticBackupStartTime string `json:"DailyAutomaticBackupStartTime,omitempty"`
 
+	// DeploymentType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-windowsconfiguration.html#cfn-fsx-filesystem-windowsconfiguration-deploymenttype
+	DeploymentType string `json:"DeploymentType,omitempty"`
+
+	// PreferredSubnetId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-windowsconfiguration.html#cfn-fsx-filesystem-windowsconfiguration-preferredsubnetid
+	PreferredSubnetId string `json:"PreferredSubnetId,omitempty"`
+
 	// SelfManagedActiveDirectoryConfiguration AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-windowsconfiguration.html#cfn-fsx-filesystem-windowsconfiguration-selfmanagedactivedirectoryconfiguration

--- a/cloudformation/lambda/aws-lambda-alias.go
+++ b/cloudformation/lambda/aws-lambda-alias.go
@@ -32,6 +32,11 @@ type Alias struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-name
 	Name string `json:"Name,omitempty"`
 
+	// ProvisionedConcurrencyConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-provisionedconcurrencyconfig
+	ProvisionedConcurrencyConfig *Alias_ProvisionedConcurrencyConfiguration `json:"ProvisionedConcurrencyConfig,omitempty"`
+
 	// RoutingConfig AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-routingconfig

--- a/cloudformation/lambda/aws-lambda-alias_provisionedconcurrencyconfiguration.go
+++ b/cloudformation/lambda/aws-lambda-alias_provisionedconcurrencyconfiguration.go
@@ -1,0 +1,29 @@
+package lambda
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Alias_ProvisionedConcurrencyConfiguration AWS CloudFormation Resource (AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-alias-provisionedconcurrencyconfiguration.html
+type Alias_ProvisionedConcurrencyConfiguration struct {
+
+	// ProvisionedConcurrentExecutions AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-alias-provisionedconcurrencyconfiguration.html#cfn-lambda-alias-provisionedconcurrencyconfiguration-provisionedconcurrentexecutions
+	ProvisionedConcurrentExecutions int `json:"ProvisionedConcurrentExecutions"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Alias_ProvisionedConcurrencyConfiguration) AWSCloudFormationType() string {
+	return "AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration"
+}

--- a/cloudformation/lambda/aws-lambda-version.go
+++ b/cloudformation/lambda/aws-lambda-version.go
@@ -27,6 +27,11 @@ type Version struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html#cfn-lambda-version-functionname
 	FunctionName string `json:"FunctionName,omitempty"`
 
+	// ProvisionedConcurrencyConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html#cfn-lambda-version-provisionedconcurrencyconfig
+	ProvisionedConcurrencyConfig *Version_ProvisionedConcurrencyConfiguration `json:"ProvisionedConcurrencyConfig,omitempty"`
+
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 

--- a/cloudformation/lambda/aws-lambda-version_provisionedconcurrencyconfiguration.go
+++ b/cloudformation/lambda/aws-lambda-version_provisionedconcurrencyconfiguration.go
@@ -1,0 +1,29 @@
+package lambda
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Version_ProvisionedConcurrencyConfiguration AWS CloudFormation Resource (AWS::Lambda::Version.ProvisionedConcurrencyConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-version-provisionedconcurrencyconfiguration.html
+type Version_ProvisionedConcurrencyConfiguration struct {
+
+	// ProvisionedConcurrentExecutions AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-version-provisionedconcurrencyconfiguration.html#cfn-lambda-version-provisionedconcurrencyconfiguration-provisionedconcurrentexecutions
+	ProvisionedConcurrentExecutions int `json:"ProvisionedConcurrentExecutions"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Version_ProvisionedConcurrencyConfiguration) AWSCloudFormationType() string {
+	return "AWS::Lambda::Version.ProvisionedConcurrencyConfiguration"
+}

--- a/cloudformation/s3/aws-s3-accesspoint.go
+++ b/cloudformation/s3/aws-s3-accesspoint.go
@@ -1,0 +1,123 @@
+package s3
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPoint AWS CloudFormation Resource (AWS::S3::AccessPoint)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html
+type AccessPoint struct {
+
+	// Bucket AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-bucket
+	Bucket string `json:"Bucket,omitempty"`
+
+	// CreationDate AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-creationdate
+	CreationDate string `json:"CreationDate,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-name
+	Name string `json:"Name,omitempty"`
+
+	// NetworkOrigin AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-networkorigin
+	NetworkOrigin string `json:"NetworkOrigin,omitempty"`
+
+	// Policy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-policy
+	Policy interface{} `json:"Policy,omitempty"`
+
+	// PolicyStatus AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-policystatus
+	PolicyStatus interface{} `json:"PolicyStatus,omitempty"`
+
+	// PublicAccessBlockConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-publicaccessblockconfiguration
+	PublicAccessBlockConfiguration *AccessPoint_PublicAccessBlockConfiguration `json:"PublicAccessBlockConfiguration,omitempty"`
+
+	// VpcConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-accesspoint.html#cfn-s3-accesspoint-vpcconfiguration
+	VpcConfiguration *AccessPoint_VpcConfiguration `json:"VpcConfiguration,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPoint) AWSCloudFormationType() string {
+	return "AWS::S3::AccessPoint"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AccessPoint) MarshalJSON() ([]byte, error) {
+	type Properties AccessPoint
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AccessPoint) UnmarshalJSON(b []byte) error {
+	type Properties AccessPoint
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AccessPoint(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	return nil
+}

--- a/cloudformation/s3/aws-s3-accesspoint_publicaccessblockconfiguration.go
+++ b/cloudformation/s3/aws-s3-accesspoint_publicaccessblockconfiguration.go
@@ -1,0 +1,44 @@
+package s3
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPoint_PublicAccessBlockConfiguration AWS CloudFormation Resource (AWS::S3::AccessPoint.PublicAccessBlockConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-publicaccessblockconfiguration.html
+type AccessPoint_PublicAccessBlockConfiguration struct {
+
+	// BlockPublicAcls AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-publicaccessblockconfiguration.html#cfn-s3-accesspoint-publicaccessblockconfiguration-blockpublicacls
+	BlockPublicAcls bool `json:"BlockPublicAcls,omitempty"`
+
+	// BlockPublicPolicy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-publicaccessblockconfiguration.html#cfn-s3-accesspoint-publicaccessblockconfiguration-blockpublicpolicy
+	BlockPublicPolicy bool `json:"BlockPublicPolicy,omitempty"`
+
+	// IgnorePublicAcls AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-publicaccessblockconfiguration.html#cfn-s3-accesspoint-publicaccessblockconfiguration-ignorepublicacls
+	IgnorePublicAcls bool `json:"IgnorePublicAcls,omitempty"`
+
+	// RestrictPublicBuckets AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-publicaccessblockconfiguration.html#cfn-s3-accesspoint-publicaccessblockconfiguration-restrictpublicbuckets
+	RestrictPublicBuckets bool `json:"RestrictPublicBuckets,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPoint_PublicAccessBlockConfiguration) AWSCloudFormationType() string {
+	return "AWS::S3::AccessPoint.PublicAccessBlockConfiguration"
+}

--- a/cloudformation/s3/aws-s3-accesspoint_vpcconfiguration.go
+++ b/cloudformation/s3/aws-s3-accesspoint_vpcconfiguration.go
@@ -1,0 +1,29 @@
+package s3
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPoint_VpcConfiguration AWS CloudFormation Resource (AWS::S3::AccessPoint.VpcConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-vpcconfiguration.html
+type AccessPoint_VpcConfiguration struct {
+
+	// VpcId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-accesspoint-vpcconfiguration.html#cfn-s3-accesspoint-vpcconfiguration-vpcid
+	VpcId string `json:"VpcId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPoint_VpcConfiguration) AWSCloudFormationType() string {
+	return "AWS::S3::AccessPoint.VpcConfiguration"
+}

--- a/cloudformation/stepfunctions/aws-stepfunctions-statemachine.go
+++ b/cloudformation/stepfunctions/aws-stepfunctions-statemachine.go
@@ -17,6 +17,11 @@ type StateMachine struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-definitionstring
 	DefinitionString string `json:"DefinitionString,omitempty"`
 
+	// LoggingConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-loggingconfiguration
+	LoggingConfiguration *StateMachine_LoggingConfiguration `json:"LoggingConfiguration,omitempty"`
+
 	// RoleArn AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-rolearn
@@ -26,6 +31,11 @@ type StateMachine struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-statemachinename
 	StateMachineName string `json:"StateMachineName,omitempty"`
+
+	// StateMachineType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-statemachinetype
+	StateMachineType string `json:"StateMachineType,omitempty"`
 
 	// Tags AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/stepfunctions/aws-stepfunctions-statemachine_cloudwatchlogsloggroup.go
+++ b/cloudformation/stepfunctions/aws-stepfunctions-statemachine_cloudwatchlogsloggroup.go
@@ -1,0 +1,29 @@
+package stepfunctions
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_CloudWatchLogsLogGroup AWS CloudFormation Resource (AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup.html
+type StateMachine_CloudWatchLogsLogGroup struct {
+
+	// LogGroupArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup.html#cfn-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup-loggrouparn
+	LogGroupArn string `json:"LogGroupArn,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_CloudWatchLogsLogGroup) AWSCloudFormationType() string {
+	return "AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup"
+}

--- a/cloudformation/stepfunctions/aws-stepfunctions-statemachine_logdestination.go
+++ b/cloudformation/stepfunctions/aws-stepfunctions-statemachine_logdestination.go
@@ -1,0 +1,29 @@
+package stepfunctions
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_LogDestination AWS CloudFormation Resource (AWS::StepFunctions::StateMachine.LogDestination)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination.html
+type StateMachine_LogDestination struct {
+
+	// CloudWatchLogsLogGroup AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination.html#cfn-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup
+	CloudWatchLogsLogGroup *StateMachine_CloudWatchLogsLogGroup `json:"CloudWatchLogsLogGroup,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_LogDestination) AWSCloudFormationType() string {
+	return "AWS::StepFunctions::StateMachine.LogDestination"
+}

--- a/cloudformation/stepfunctions/aws-stepfunctions-statemachine_loggingconfiguration.go
+++ b/cloudformation/stepfunctions/aws-stepfunctions-statemachine_loggingconfiguration.go
@@ -1,0 +1,39 @@
+package stepfunctions
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_LoggingConfiguration AWS CloudFormation Resource (AWS::StepFunctions::StateMachine.LoggingConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html
+type StateMachine_LoggingConfiguration struct {
+
+	// Destinations AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html#cfn-stepfunctions-statemachine-loggingconfiguration-destinations
+	Destinations []StateMachine_LogDestination `json:"Destinations,omitempty"`
+
+	// IncludeExecutionData AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html#cfn-stepfunctions-statemachine-loggingconfiguration-includeexecutiondata
+	IncludeExecutionData bool `json:"IncludeExecutionData,omitempty"`
+
+	// Level AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html#cfn-stepfunctions-statemachine-loggingconfiguration-level
+	Level string `json:"Level,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_LoggingConfiguration) AWSCloudFormationType() string {
+	return "AWS::StepFunctions::StateMachine.LoggingConfiguration"
+}

--- a/cloudformation/wafv2/aws-wafv2-ipset.go
+++ b/cloudformation/wafv2/aws-wafv2-ipset.go
@@ -27,60 +27,15 @@ type IPSet struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-ipaddressversion
 	IPAddressVersion string `json:"IPAddressVersion,omitempty"`
 
-	// IPSet AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-ipset
-	IPSet *IPSet_IPSet `json:"IPSet,omitempty"`
-
-	// IPSetSummary AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-ipsetsummary
-	IPSetSummary *IPSet_IPSetSummary `json:"IPSetSummary,omitempty"`
-
-	// IPSets AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-ipsets
-	IPSets *IPSet_IPSets `json:"IPSets,omitempty"`
-
-	// Id AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-id
-	Id string `json:"Id,omitempty"`
-
-	// Limit AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-limit
-	Limit int `json:"Limit,omitempty"`
-
-	// LockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-locktoken
-	LockToken string `json:"LockToken,omitempty"`
-
 	// Name AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-name
 	Name string `json:"Name,omitempty"`
 
-	// NextLockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-nextlocktoken
-	NextLockToken string `json:"NextLockToken,omitempty"`
-
-	// NextMarker AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-nextmarker
-	NextMarker string `json:"NextMarker,omitempty"`
-
 	// Scope AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-scope
 	Scope string `json:"Scope,omitempty"`
-
-	// Summary AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-summary
-	Summary *IPSet_IPSetSummary `json:"Summary,omitempty"`
 
 	// Tags AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-regexpatternset.go
+++ b/cloudformation/wafv2/aws-wafv2-regexpatternset.go
@@ -17,45 +17,10 @@ type RegexPatternSet struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-description
 	Description string `json:"Description,omitempty"`
 
-	// Id AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-id
-	Id string `json:"Id,omitempty"`
-
-	// Limit AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-limit
-	Limit int `json:"Limit,omitempty"`
-
-	// LockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-locktoken
-	LockToken string `json:"LockToken,omitempty"`
-
 	// Name AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-name
 	Name string `json:"Name,omitempty"`
-
-	// NextLockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-nextlocktoken
-	NextLockToken string `json:"NextLockToken,omitempty"`
-
-	// NextMarker AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-nextmarker
-	NextMarker string `json:"NextMarker,omitempty"`
-
-	// RegexPatternSet AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-regexpatternset
-	RegexPatternSet *RegexPatternSet_RegexPatternSet `json:"RegexPatternSet,omitempty"`
-
-	// RegexPatternSets AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-regexpatternsets
-	RegexPatternSets *RegexPatternSet_RegexPatternSets `json:"RegexPatternSets,omitempty"`
 
 	// RegularExpressionList AWS CloudFormation Property
 	// Required: false
@@ -66,11 +31,6 @@ type RegexPatternSet struct {
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-scope
 	Scope string `json:"Scope,omitempty"`
-
-	// Summary AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-summary
-	Summary *RegexPatternSet_RegexPatternSetSummary `json:"Summary,omitempty"`
 
 	// Tags AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-rulegroup.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup.go
@@ -22,50 +22,10 @@ type RuleGroup struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-description
 	Description string `json:"Description,omitempty"`
 
-	// Id AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-id
-	Id string `json:"Id,omitempty"`
-
-	// Limit AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-limit
-	Limit int `json:"Limit,omitempty"`
-
-	// LockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-locktoken
-	LockToken string `json:"LockToken,omitempty"`
-
 	// Name AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-name
 	Name string `json:"Name,omitempty"`
-
-	// NextLockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-nextlocktoken
-	NextLockToken string `json:"NextLockToken,omitempty"`
-
-	// NextMarker AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-nextmarker
-	NextMarker string `json:"NextMarker,omitempty"`
-
-	// RuleGroup AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-rulegroup
-	RuleGroup *RuleGroup_RuleGroup `json:"RuleGroup,omitempty"`
-
-	// RuleGroupSummary AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-rulegroupsummary
-	RuleGroupSummary *RuleGroup_RuleGroupSummary `json:"RuleGroupSummary,omitempty"`
-
-	// RuleGroups AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-rulegroups
-	RuleGroups *RuleGroup_RuleGroups `json:"RuleGroups,omitempty"`
 
 	// Rules AWS CloudFormation Property
 	// Required: false
@@ -76,16 +36,6 @@ type RuleGroup struct {
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-scope
 	Scope string `json:"Scope,omitempty"`
-
-	// Statement AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-statement
-	Statement *RuleGroup_StatementOne `json:"Statement,omitempty"`
-
-	// Summary AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-summary
-	Summary *RuleGroup_RuleGroupSummary `json:"Summary,omitempty"`
 
 	// Tags AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_ipsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_ipsetreferencestatement.go
@@ -8,10 +8,10 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ipsetreferencestatement.html
 type RuleGroup_IPSetReferenceStatement struct {
 
-	// ARN AWS CloudFormation Property
+	// Arn AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ipsetreferencestatement.html#cfn-wafv2-rulegroup-ipsetreferencestatement-arn
-	ARN string `json:"ARN,omitempty"`
+	Arn string `json:"Arn,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_regexpatternsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_regexpatternsetreferencestatement.go
@@ -8,10 +8,10 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-regexpatternsetreferencestatement.html
 type RuleGroup_RegexPatternSetReferenceStatement struct {
 
-	// ARN AWS CloudFormation Property
+	// Arn AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-regexpatternsetreferencestatement.html#cfn-wafv2-rulegroup-regexpatternsetreferencestatement-arn
-	ARN string `json:"ARN,omitempty"`
+	Arn string `json:"Arn,omitempty"`
 
 	// FieldToMatch AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-webacl.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl.go
@@ -22,35 +22,10 @@ type WebACL struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-description
 	Description string `json:"Description,omitempty"`
 
-	// Id AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-id
-	Id string `json:"Id,omitempty"`
-
-	// Limit AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-limit
-	Limit int `json:"Limit,omitempty"`
-
-	// LockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-locktoken
-	LockToken string `json:"LockToken,omitempty"`
-
 	// Name AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-name
 	Name string `json:"Name,omitempty"`
-
-	// NextLockToken AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-nextlocktoken
-	NextLockToken string `json:"NextLockToken,omitempty"`
-
-	// NextMarker AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-nextmarker
-	NextMarker string `json:"NextMarker,omitempty"`
 
 	// Rules AWS CloudFormation Property
 	// Required: false
@@ -62,11 +37,6 @@ type WebACL struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-scope
 	Scope string `json:"Scope,omitempty"`
 
-	// Summary AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-summary
-	Summary *WebACL_WebACLSummary `json:"Summary,omitempty"`
-
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-tags
@@ -76,16 +46,6 @@ type WebACL struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-visibilityconfig
 	VisibilityConfig *WebACL_VisibilityConfig `json:"VisibilityConfig,omitempty"`
-
-	// WebACL AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-webacl
-	WebACL *WebACL_WebACL `json:"WebACL,omitempty"`
-
-	// WebACLs AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-webacls
-	WebACLs *WebACL_WebACLs `json:"WebACLs,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_ipsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_ipsetreferencestatement.go
@@ -8,10 +8,10 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ipsetreferencestatement.html
 type WebACL_IPSetReferenceStatement struct {
 
-	// ARN AWS CloudFormation Property
+	// Arn AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ipsetreferencestatement.html#cfn-wafv2-webacl-ipsetreferencestatement-arn
-	ARN string `json:"ARN,omitempty"`
+	Arn string `json:"Arn,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_regexpatternsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_regexpatternsetreferencestatement.go
@@ -8,10 +8,10 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-regexpatternsetreferencestatement.html
 type WebACL_RegexPatternSetReferenceStatement struct {
 
-	// ARN AWS CloudFormation Property
+	// Arn AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-regexpatternsetreferencestatement.html#cfn-wafv2-webacl-regexpatternsetreferencestatement-arn
-	ARN string `json:"ARN,omitempty"`
+	Arn string `json:"Arn,omitempty"`
 
 	// FieldToMatch AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-webacl_rulegroupreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_rulegroupreferencestatement.go
@@ -8,10 +8,10 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rulegroupreferencestatement.html
 type WebACL_RuleGroupReferenceStatement struct {
 
-	// ARN AWS CloudFormation Property
+	// Arn AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rulegroupreferencestatement.html#cfn-wafv2-webacl-rulegroupreferencestatement-arn
-	ARN string `json:"ARN,omitempty"`
+	Arn string `json:"Arn,omitempty"`
 
 	// ExcludedRules AWS CloudFormation Property
 	// Required: false

--- a/schema/cloudformation.go
+++ b/schema/cloudformation.go
@@ -5,6 +5,127 @@ var CloudformationSchema = `{
     "$id": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "definitions": {
+        "AWS::AccessAnalyzer::Analyzer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AnalyzerName": {
+                            "type": "string"
+                        },
+                        "ArchiveRules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.ArchiveRule"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AccessAnalyzer::Analyzer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.ArchiveRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Filter": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.Filter"
+                    },
+                    "type": "array"
+                },
+                "RuleName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Filter",
+                "RuleName"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Contains": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Eq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Exists": {
+                    "type": "boolean"
+                },
+                "Neq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Property": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Property"
+            ],
+            "type": "object"
+        },
         "AWS::AmazonMQ::Broker": {
             "additionalProperties": false,
             "properties": {
@@ -2692,10 +2813,28 @@ var CloudformationSchema = `{
                         "ApiKeySelectionExpression": {
                             "type": "string"
                         },
+                        "BasePath": {
+                            "type": "string"
+                        },
+                        "Body": {
+                            "type": "object"
+                        },
+                        "BodyS3Location": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.BodyS3Location"
+                        },
+                        "CorsConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.Cors"
+                        },
+                        "CredentialsArn": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
                         "DisableSchemaValidation": {
+                            "type": "boolean"
+                        },
+                        "FailOnWarnings": {
                             "type": "boolean"
                         },
                         "Name": {
@@ -2704,21 +2843,22 @@ var CloudformationSchema = `{
                         "ProtocolType": {
                             "type": "string"
                         },
+                        "RouteKey": {
+                            "type": "string"
+                        },
                         "RouteSelectionExpression": {
                             "type": "string"
                         },
                         "Tags": {
                             "type": "object"
                         },
+                        "Target": {
+                            "type": "string"
+                        },
                         "Version": {
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "Name",
-                        "ProtocolType",
-                        "RouteSelectionExpression"
-                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -2729,9 +2869,62 @@ var CloudformationSchema = `{
                 }
             },
             "required": [
-                "Type",
-                "Properties"
+                "Type"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.BodyS3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Etag": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.Cors": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCredentials": {
+                    "type": "boolean"
+                },
+                "AllowHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowOrigins": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ExposeHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxAge": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::ApiMapping": {
@@ -2855,6 +3048,9 @@ var CloudformationSchema = `{
                         "IdentityValidationExpression": {
                             "type": "string"
                         },
+                        "JwtConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Authorizer.JWTConfiguration"
+                        },
                         "Name": {
                             "type": "string"
                         }
@@ -2862,7 +3058,6 @@ var CloudformationSchema = `{
                     "required": [
                         "ApiId",
                         "AuthorizerType",
-                        "AuthorizerUri",
                         "IdentitySource",
                         "Name"
                     ],
@@ -2879,6 +3074,21 @@ var CloudformationSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Authorizer.JWTConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Audience": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Issuer": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::Deployment": {
@@ -3076,6 +3286,9 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "PassthroughBehavior": {
+                            "type": "string"
+                        },
+                        "PayloadFormatVersion": {
                             "type": "string"
                         },
                         "RequestParameters": {
@@ -3476,6 +3689,9 @@ var CloudformationSchema = `{
                         "ApiId": {
                             "type": "string"
                         },
+                        "AutoDeploy": {
+                            "type": "boolean"
+                        },
                         "ClientCertificateId": {
                             "type": "string"
                         },
@@ -3503,7 +3719,6 @@ var CloudformationSchema = `{
                     },
                     "required": [
                         "ApiId",
-                        "DeploymentId",
                         "StageName"
                     ],
                     "type": "object"
@@ -27654,6 +27869,250 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::EventSchemas::Discoverer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SourceArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Discoverer.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SourceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Discoverer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Discoverer.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Registry.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Registry"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Content": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "SchemaName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Schema.TagsEntry"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Content",
+                        "RegistryName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Schema"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::Events::EventBus": {
             "additionalProperties": false,
             "properties": {
@@ -28236,6 +28695,12 @@ var CloudformationSchema = `{
                     "type": "boolean"
                 },
                 "DailyAutomaticBackupStartTime": {
+                    "type": "string"
+                },
+                "DeploymentType": {
+                    "type": "string"
+                },
+                "PreferredSubnetId": {
                     "type": "string"
                 },
                 "SelfManagedActiveDirectoryConfiguration": {
@@ -32730,6 +33195,7 @@ var CloudformationSchema = `{
                         "Description",
                         "DetectorId",
                         "FindingCriteria",
+                        "Name",
                         "Rank"
                     ],
                     "type": "object"
@@ -38851,6 +39317,9 @@ var CloudformationSchema = `{
                         "Name": {
                             "type": "string"
                         },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration"
+                        },
                         "RoutingConfig": {
                             "$ref": "#/definitions/AWS::Lambda::Alias.AliasRoutingConfiguration"
                         }
@@ -38887,6 +39356,18 @@ var CloudformationSchema = `{
             },
             "required": [
                 "AdditionalVersionWeights"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -39563,6 +40044,9 @@ var CloudformationSchema = `{
                         },
                         "FunctionName": {
                             "type": "string"
+                        },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Version.ProvisionedConcurrencyConfiguration"
                         }
                     },
                     "required": [
@@ -39580,6 +40064,18 @@ var CloudformationSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Version.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -48099,6 +48595,108 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::S3::AccessPoint": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Bucket": {
+                            "type": "string"
+                        },
+                        "CreationDate": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NetworkOrigin": {
+                            "type": "string"
+                        },
+                        "Policy": {
+                            "type": "object"
+                        },
+                        "PolicyStatus": {
+                            "type": "object"
+                        },
+                        "PublicAccessBlockConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.PublicAccessBlockConfiguration"
+                        },
+                        "VpcConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.VpcConfiguration"
+                        }
+                    },
+                    "required": [
+                        "Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::AccessPoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.PublicAccessBlockConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockPublicAcls": {
+                    "type": "boolean"
+                },
+                "BlockPublicPolicy": {
+                    "type": "boolean"
+                },
+                "IgnorePublicAcls": {
+                    "type": "boolean"
+                },
+                "RestrictPublicBuckets": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.VpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "VpcId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::S3::Bucket": {
             "additionalProperties": false,
             "properties": {
@@ -53570,10 +54168,16 @@ var CloudformationSchema = `{
                         "DefinitionString": {
                             "type": "string"
                         },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LoggingConfiguration"
+                        },
                         "RoleArn": {
                             "type": "string"
                         },
                         "StateMachineName": {
+                            "type": "string"
+                        },
+                        "StateMachineType": {
                             "type": "string"
                         },
                         "Tags": {
@@ -53600,6 +54204,45 @@ var CloudformationSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "LogGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LogGroupArn"
+            ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LogDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogsLogGroup": {
+                    "$ref": "#/definitions/AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destinations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LogDestination"
+                    },
+                    "type": "array"
+                },
+                "IncludeExecutionData": {
+                    "type": "boolean"
+                },
+                "Level": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::StepFunctions::StateMachine.TagsEntry": {
@@ -55412,38 +56055,11 @@ var CloudformationSchema = `{
                         "IPAddressVersion": {
                             "type": "string"
                         },
-                        "IPSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSet"
-                        },
-                        "IPSetSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
-                        },
-                        "IPSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSets"
-                        },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
@@ -55474,63 +56090,6 @@ var CloudformationSchema = `{
                 "IPAddresses": {
                     "items": {
                         "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Addresses": {
-                    "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "IPAddressVersion": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSets": {
-            "additionalProperties": false,
-            "properties": {
-                "IPSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                     },
                     "type": "array"
                 }
@@ -55584,38 +56143,14 @@ var CloudformationSchema = `{
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RegexPatternSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSet"
-                        },
-                        "RegexPatternSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSets"
                         },
                         "RegularExpressionList": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
@@ -55645,60 +56180,6 @@ var CloudformationSchema = `{
             "properties": {
                 "RegexString": {
                     "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "RegularExpressionList": {
-                    "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSets": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexPatternSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -55765,44 +56246,14 @@ var CloudformationSchema = `{
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RuleGroup": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroup"
-                        },
-                        "RuleGroupSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                        },
-                        "RuleGroups": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroups"
                         },
                         "Rules": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Statement": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementOne"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
@@ -55945,7 +56396,7 @@ var CloudformationSchema = `{
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -56030,7 +56481,7 @@ var CloudformationSchema = `{
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -56074,66 +56525,6 @@ var CloudformationSchema = `{
                 },
                 "Count": {
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroup": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroupSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroups": {
-            "additionalProperties": false,
-            "properties": {
-                "RuleGroups": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -56433,22 +56824,7 @@ var CloudformationSchema = `{
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Rules": {
@@ -56457,20 +56833,11 @@ var CloudformationSchema = `{
                         "Scope": {
                             "type": "string"
                         },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                        },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                        },
-                        "WebACL": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACL"
-                        },
-                        "WebACLs": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLs"
                         }
                     },
                     "required": [
@@ -56640,7 +57007,7 @@ var CloudformationSchema = `{
         "AWS::WAFv2::WebACL.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -56757,7 +57124,7 @@ var CloudformationSchema = `{
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -56811,7 +57178,7 @@ var CloudformationSchema = `{
         "AWS::WAFv2::WebACL.RuleGroupReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "ExcludedRules": {
@@ -57079,69 +57446,6 @@ var CloudformationSchema = `{
                 },
                 "SampledRequestsEnabled": {
                     "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACL": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "DefaultAction": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.DefaultAction"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLs": {
-            "additionalProperties": false,
-            "properties": {
-                "WebACLs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -57544,6 +57848,9 @@ var CloudformationSchema = `{
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                     "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer"
+                        },
                         {
                             "$ref": "#/definitions/AWS::AmazonMQ::Broker"
                         },
@@ -58217,6 +58524,15 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Elasticsearch::Domain"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EventSchemas::Discoverer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Registry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Schema"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Events::EventBus"
                         },
                         {
@@ -58743,6 +59059,9 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Route53Resolver::ResolverRuleAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint"
                         },
                         {
                             "$ref": "#/definitions/AWS::S3::Bucket"

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -2,6 +2,127 @@
     "$id": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "definitions": {
+        "AWS::AccessAnalyzer::Analyzer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AnalyzerName": {
+                            "type": "string"
+                        },
+                        "ArchiveRules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.ArchiveRule"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AccessAnalyzer::Analyzer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.ArchiveRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Filter": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.Filter"
+                    },
+                    "type": "array"
+                },
+                "RuleName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Filter",
+                "RuleName"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Contains": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Eq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Exists": {
+                    "type": "boolean"
+                },
+                "Neq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Property": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Property"
+            ],
+            "type": "object"
+        },
         "AWS::AmazonMQ::Broker": {
             "additionalProperties": false,
             "properties": {
@@ -2689,10 +2810,28 @@
                         "ApiKeySelectionExpression": {
                             "type": "string"
                         },
+                        "BasePath": {
+                            "type": "string"
+                        },
+                        "Body": {
+                            "type": "object"
+                        },
+                        "BodyS3Location": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.BodyS3Location"
+                        },
+                        "CorsConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.Cors"
+                        },
+                        "CredentialsArn": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
                         "DisableSchemaValidation": {
+                            "type": "boolean"
+                        },
+                        "FailOnWarnings": {
                             "type": "boolean"
                         },
                         "Name": {
@@ -2701,21 +2840,22 @@
                         "ProtocolType": {
                             "type": "string"
                         },
+                        "RouteKey": {
+                            "type": "string"
+                        },
                         "RouteSelectionExpression": {
                             "type": "string"
                         },
                         "Tags": {
                             "type": "object"
                         },
+                        "Target": {
+                            "type": "string"
+                        },
                         "Version": {
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "Name",
-                        "ProtocolType",
-                        "RouteSelectionExpression"
-                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -2726,9 +2866,62 @@
                 }
             },
             "required": [
-                "Type",
-                "Properties"
+                "Type"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.BodyS3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Etag": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.Cors": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCredentials": {
+                    "type": "boolean"
+                },
+                "AllowHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowOrigins": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ExposeHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxAge": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::ApiMapping": {
@@ -2852,6 +3045,9 @@
                         "IdentityValidationExpression": {
                             "type": "string"
                         },
+                        "JwtConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Authorizer.JWTConfiguration"
+                        },
                         "Name": {
                             "type": "string"
                         }
@@ -2859,7 +3055,6 @@
                     "required": [
                         "ApiId",
                         "AuthorizerType",
-                        "AuthorizerUri",
                         "IdentitySource",
                         "Name"
                     ],
@@ -2876,6 +3071,21 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Authorizer.JWTConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Audience": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Issuer": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::Deployment": {
@@ -3073,6 +3283,9 @@
                             "type": "string"
                         },
                         "PassthroughBehavior": {
+                            "type": "string"
+                        },
+                        "PayloadFormatVersion": {
                             "type": "string"
                         },
                         "RequestParameters": {
@@ -3473,6 +3686,9 @@
                         "ApiId": {
                             "type": "string"
                         },
+                        "AutoDeploy": {
+                            "type": "boolean"
+                        },
                         "ClientCertificateId": {
                             "type": "string"
                         },
@@ -3500,7 +3716,6 @@
                     },
                     "required": [
                         "ApiId",
-                        "DeploymentId",
                         "StageName"
                     ],
                     "type": "object"
@@ -27651,6 +27866,250 @@
             },
             "type": "object"
         },
+        "AWS::EventSchemas::Discoverer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SourceArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Discoverer.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SourceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Discoverer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Discoverer.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Registry.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Registry"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Content": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "SchemaName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Schema.TagsEntry"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Content",
+                        "RegistryName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Schema"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::Events::EventBus": {
             "additionalProperties": false,
             "properties": {
@@ -28233,6 +28692,12 @@
                     "type": "boolean"
                 },
                 "DailyAutomaticBackupStartTime": {
+                    "type": "string"
+                },
+                "DeploymentType": {
+                    "type": "string"
+                },
+                "PreferredSubnetId": {
                     "type": "string"
                 },
                 "SelfManagedActiveDirectoryConfiguration": {
@@ -32727,6 +33192,7 @@
                         "Description",
                         "DetectorId",
                         "FindingCriteria",
+                        "Name",
                         "Rank"
                     ],
                     "type": "object"
@@ -38848,6 +39314,9 @@
                         "Name": {
                             "type": "string"
                         },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration"
+                        },
                         "RoutingConfig": {
                             "$ref": "#/definitions/AWS::Lambda::Alias.AliasRoutingConfiguration"
                         }
@@ -38884,6 +39353,18 @@
             },
             "required": [
                 "AdditionalVersionWeights"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -39560,6 +40041,9 @@
                         },
                         "FunctionName": {
                             "type": "string"
+                        },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Version.ProvisionedConcurrencyConfiguration"
                         }
                     },
                     "required": [
@@ -39577,6 +40061,18 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Version.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -48096,6 +48592,108 @@
             ],
             "type": "object"
         },
+        "AWS::S3::AccessPoint": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Bucket": {
+                            "type": "string"
+                        },
+                        "CreationDate": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NetworkOrigin": {
+                            "type": "string"
+                        },
+                        "Policy": {
+                            "type": "object"
+                        },
+                        "PolicyStatus": {
+                            "type": "object"
+                        },
+                        "PublicAccessBlockConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.PublicAccessBlockConfiguration"
+                        },
+                        "VpcConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.VpcConfiguration"
+                        }
+                    },
+                    "required": [
+                        "Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::AccessPoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.PublicAccessBlockConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockPublicAcls": {
+                    "type": "boolean"
+                },
+                "BlockPublicPolicy": {
+                    "type": "boolean"
+                },
+                "IgnorePublicAcls": {
+                    "type": "boolean"
+                },
+                "RestrictPublicBuckets": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.VpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "VpcId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::S3::Bucket": {
             "additionalProperties": false,
             "properties": {
@@ -53567,10 +54165,16 @@
                         "DefinitionString": {
                             "type": "string"
                         },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LoggingConfiguration"
+                        },
                         "RoleArn": {
                             "type": "string"
                         },
                         "StateMachineName": {
+                            "type": "string"
+                        },
+                        "StateMachineType": {
                             "type": "string"
                         },
                         "Tags": {
@@ -53597,6 +54201,45 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "LogGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LogGroupArn"
+            ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LogDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogsLogGroup": {
+                    "$ref": "#/definitions/AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destinations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LogDestination"
+                    },
+                    "type": "array"
+                },
+                "IncludeExecutionData": {
+                    "type": "boolean"
+                },
+                "Level": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::StepFunctions::StateMachine.TagsEntry": {
@@ -55409,38 +56052,11 @@
                         "IPAddressVersion": {
                             "type": "string"
                         },
-                        "IPSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSet"
-                        },
-                        "IPSetSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
-                        },
-                        "IPSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSets"
-                        },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
@@ -55471,63 +56087,6 @@
                 "IPAddresses": {
                     "items": {
                         "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Addresses": {
-                    "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "IPAddressVersion": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSets": {
-            "additionalProperties": false,
-            "properties": {
-                "IPSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                     },
                     "type": "array"
                 }
@@ -55581,38 +56140,14 @@
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RegexPatternSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSet"
-                        },
-                        "RegexPatternSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSets"
                         },
                         "RegularExpressionList": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
@@ -55642,60 +56177,6 @@
             "properties": {
                 "RegexString": {
                     "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "RegularExpressionList": {
-                    "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSets": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexPatternSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -55762,44 +56243,14 @@
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RuleGroup": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroup"
-                        },
-                        "RuleGroupSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                        },
-                        "RuleGroups": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroups"
                         },
                         "Rules": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Statement": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementOne"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
@@ -55942,7 +56393,7 @@
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -56027,7 +56478,7 @@
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -56071,66 +56522,6 @@
                 },
                 "Count": {
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroup": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroupSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroups": {
-            "additionalProperties": false,
-            "properties": {
-                "RuleGroups": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -56430,22 +56821,7 @@
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Rules": {
@@ -56454,20 +56830,11 @@
                         "Scope": {
                             "type": "string"
                         },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                        },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                        },
-                        "WebACL": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACL"
-                        },
-                        "WebACLs": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLs"
                         }
                     },
                     "required": [
@@ -56637,7 +57004,7 @@
         "AWS::WAFv2::WebACL.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -56754,7 +57121,7 @@
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -56808,7 +57175,7 @@
         "AWS::WAFv2::WebACL.RuleGroupReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "ExcludedRules": {
@@ -57076,69 +57443,6 @@
                 },
                 "SampledRequestsEnabled": {
                     "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACL": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "DefaultAction": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.DefaultAction"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLs": {
-            "additionalProperties": false,
-            "properties": {
-                "WebACLs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -57541,6 +57845,9 @@
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                     "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer"
+                        },
                         {
                             "$ref": "#/definitions/AWS::AmazonMQ::Broker"
                         },
@@ -58214,6 +58521,15 @@
                             "$ref": "#/definitions/AWS::Elasticsearch::Domain"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EventSchemas::Discoverer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Registry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Schema"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Events::EventBus"
                         },
                         {
@@ -58740,6 +59056,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Route53Resolver::ResolverRuleAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint"
                         },
                         {
                             "$ref": "#/definitions/AWS::S3::Bucket"

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -5,6 +5,127 @@ var SamSchema = `{
     "$id": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "definitions": {
+        "AWS::AccessAnalyzer::Analyzer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AnalyzerName": {
+                            "type": "string"
+                        },
+                        "ArchiveRules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.ArchiveRule"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AccessAnalyzer::Analyzer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.ArchiveRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Filter": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.Filter"
+                    },
+                    "type": "array"
+                },
+                "RuleName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Filter",
+                "RuleName"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Contains": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Eq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Exists": {
+                    "type": "boolean"
+                },
+                "Neq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Property": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Property"
+            ],
+            "type": "object"
+        },
         "AWS::AmazonMQ::Broker": {
             "additionalProperties": false,
             "properties": {
@@ -2692,10 +2813,28 @@ var SamSchema = `{
                         "ApiKeySelectionExpression": {
                             "type": "string"
                         },
+                        "BasePath": {
+                            "type": "string"
+                        },
+                        "Body": {
+                            "type": "object"
+                        },
+                        "BodyS3Location": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.BodyS3Location"
+                        },
+                        "CorsConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.Cors"
+                        },
+                        "CredentialsArn": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
                         "DisableSchemaValidation": {
+                            "type": "boolean"
+                        },
+                        "FailOnWarnings": {
                             "type": "boolean"
                         },
                         "Name": {
@@ -2704,21 +2843,22 @@ var SamSchema = `{
                         "ProtocolType": {
                             "type": "string"
                         },
+                        "RouteKey": {
+                            "type": "string"
+                        },
                         "RouteSelectionExpression": {
                             "type": "string"
                         },
                         "Tags": {
                             "type": "object"
                         },
+                        "Target": {
+                            "type": "string"
+                        },
                         "Version": {
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "Name",
-                        "ProtocolType",
-                        "RouteSelectionExpression"
-                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -2729,9 +2869,62 @@ var SamSchema = `{
                 }
             },
             "required": [
-                "Type",
-                "Properties"
+                "Type"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.BodyS3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Etag": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.Cors": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCredentials": {
+                    "type": "boolean"
+                },
+                "AllowHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowOrigins": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ExposeHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxAge": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::ApiMapping": {
@@ -2855,6 +3048,9 @@ var SamSchema = `{
                         "IdentityValidationExpression": {
                             "type": "string"
                         },
+                        "JwtConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Authorizer.JWTConfiguration"
+                        },
                         "Name": {
                             "type": "string"
                         }
@@ -2862,7 +3058,6 @@ var SamSchema = `{
                     "required": [
                         "ApiId",
                         "AuthorizerType",
-                        "AuthorizerUri",
                         "IdentitySource",
                         "Name"
                     ],
@@ -2879,6 +3074,21 @@ var SamSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Authorizer.JWTConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Audience": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Issuer": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::Deployment": {
@@ -3076,6 +3286,9 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "PassthroughBehavior": {
+                            "type": "string"
+                        },
+                        "PayloadFormatVersion": {
                             "type": "string"
                         },
                         "RequestParameters": {
@@ -3476,6 +3689,9 @@ var SamSchema = `{
                         "ApiId": {
                             "type": "string"
                         },
+                        "AutoDeploy": {
+                            "type": "boolean"
+                        },
                         "ClientCertificateId": {
                             "type": "string"
                         },
@@ -3503,7 +3719,6 @@ var SamSchema = `{
                     },
                     "required": [
                         "ApiId",
-                        "DeploymentId",
                         "StageName"
                     ],
                     "type": "object"
@@ -27654,6 +27869,250 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::EventSchemas::Discoverer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SourceArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Discoverer.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SourceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Discoverer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Discoverer.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Registry.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Registry"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Content": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "SchemaName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Schema.TagsEntry"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Content",
+                        "RegistryName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Schema"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::Events::EventBus": {
             "additionalProperties": false,
             "properties": {
@@ -28236,6 +28695,12 @@ var SamSchema = `{
                     "type": "boolean"
                 },
                 "DailyAutomaticBackupStartTime": {
+                    "type": "string"
+                },
+                "DeploymentType": {
+                    "type": "string"
+                },
+                "PreferredSubnetId": {
                     "type": "string"
                 },
                 "SelfManagedActiveDirectoryConfiguration": {
@@ -32730,6 +33195,7 @@ var SamSchema = `{
                         "Description",
                         "DetectorId",
                         "FindingCriteria",
+                        "Name",
                         "Rank"
                     ],
                     "type": "object"
@@ -38851,6 +39317,9 @@ var SamSchema = `{
                         "Name": {
                             "type": "string"
                         },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration"
+                        },
                         "RoutingConfig": {
                             "$ref": "#/definitions/AWS::Lambda::Alias.AliasRoutingConfiguration"
                         }
@@ -38887,6 +39356,18 @@ var SamSchema = `{
             },
             "required": [
                 "AdditionalVersionWeights"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -39563,6 +40044,9 @@ var SamSchema = `{
                         },
                         "FunctionName": {
                             "type": "string"
+                        },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Version.ProvisionedConcurrencyConfiguration"
                         }
                     },
                     "required": [
@@ -39580,6 +40064,18 @@ var SamSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Version.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -48099,6 +48595,108 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::S3::AccessPoint": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Bucket": {
+                            "type": "string"
+                        },
+                        "CreationDate": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NetworkOrigin": {
+                            "type": "string"
+                        },
+                        "Policy": {
+                            "type": "object"
+                        },
+                        "PolicyStatus": {
+                            "type": "object"
+                        },
+                        "PublicAccessBlockConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.PublicAccessBlockConfiguration"
+                        },
+                        "VpcConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.VpcConfiguration"
+                        }
+                    },
+                    "required": [
+                        "Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::AccessPoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.PublicAccessBlockConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockPublicAcls": {
+                    "type": "boolean"
+                },
+                "BlockPublicPolicy": {
+                    "type": "boolean"
+                },
+                "IgnorePublicAcls": {
+                    "type": "boolean"
+                },
+                "RestrictPublicBuckets": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.VpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "VpcId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::S3::Bucket": {
             "additionalProperties": false,
             "properties": {
@@ -54864,10 +55462,16 @@ var SamSchema = `{
                         "DefinitionString": {
                             "type": "string"
                         },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LoggingConfiguration"
+                        },
                         "RoleArn": {
                             "type": "string"
                         },
                         "StateMachineName": {
+                            "type": "string"
+                        },
+                        "StateMachineType": {
                             "type": "string"
                         },
                         "Tags": {
@@ -54894,6 +55498,45 @@ var SamSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "LogGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LogGroupArn"
+            ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LogDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogsLogGroup": {
+                    "$ref": "#/definitions/AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destinations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LogDestination"
+                    },
+                    "type": "array"
+                },
+                "IncludeExecutionData": {
+                    "type": "boolean"
+                },
+                "Level": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::StepFunctions::StateMachine.TagsEntry": {
@@ -56706,38 +57349,11 @@ var SamSchema = `{
                         "IPAddressVersion": {
                             "type": "string"
                         },
-                        "IPSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSet"
-                        },
-                        "IPSetSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
-                        },
-                        "IPSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSets"
-                        },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
@@ -56768,63 +57384,6 @@ var SamSchema = `{
                 "IPAddresses": {
                     "items": {
                         "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Addresses": {
-                    "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "IPAddressVersion": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSets": {
-            "additionalProperties": false,
-            "properties": {
-                "IPSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                     },
                     "type": "array"
                 }
@@ -56878,38 +57437,14 @@ var SamSchema = `{
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RegexPatternSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSet"
-                        },
-                        "RegexPatternSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSets"
                         },
                         "RegularExpressionList": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
@@ -56939,60 +57474,6 @@ var SamSchema = `{
             "properties": {
                 "RegexString": {
                     "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "RegularExpressionList": {
-                    "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSets": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexPatternSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -57059,44 +57540,14 @@ var SamSchema = `{
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RuleGroup": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroup"
-                        },
-                        "RuleGroupSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                        },
-                        "RuleGroups": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroups"
                         },
                         "Rules": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Statement": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementOne"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
@@ -57239,7 +57690,7 @@ var SamSchema = `{
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -57324,7 +57775,7 @@ var SamSchema = `{
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -57368,66 +57819,6 @@ var SamSchema = `{
                 },
                 "Count": {
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroup": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroupSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroups": {
-            "additionalProperties": false,
-            "properties": {
-                "RuleGroups": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -57727,22 +58118,7 @@ var SamSchema = `{
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Rules": {
@@ -57751,20 +58127,11 @@ var SamSchema = `{
                         "Scope": {
                             "type": "string"
                         },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                        },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                        },
-                        "WebACL": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACL"
-                        },
-                        "WebACLs": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLs"
                         }
                     },
                     "required": [
@@ -57934,7 +58301,7 @@ var SamSchema = `{
         "AWS::WAFv2::WebACL.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -58051,7 +58418,7 @@ var SamSchema = `{
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -58105,7 +58472,7 @@ var SamSchema = `{
         "AWS::WAFv2::WebACL.RuleGroupReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "ExcludedRules": {
@@ -58373,69 +58740,6 @@ var SamSchema = `{
                 },
                 "SampledRequestsEnabled": {
                     "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACL": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "DefaultAction": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.DefaultAction"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLs": {
-            "additionalProperties": false,
-            "properties": {
-                "WebACLs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -58838,6 +59142,9 @@ var SamSchema = `{
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                     "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer"
+                        },
                         {
                             "$ref": "#/definitions/AWS::AmazonMQ::Broker"
                         },
@@ -59511,6 +59818,15 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Elasticsearch::Domain"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EventSchemas::Discoverer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Registry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Schema"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Events::EventBus"
                         },
                         {
@@ -60037,6 +60353,9 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Route53Resolver::ResolverRuleAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint"
                         },
                         {
                             "$ref": "#/definitions/AWS::S3::Bucket"

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -2,6 +2,127 @@
     "$id": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "definitions": {
+        "AWS::AccessAnalyzer::Analyzer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AnalyzerName": {
+                            "type": "string"
+                        },
+                        "ArchiveRules": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.ArchiveRule"
+                            },
+                            "type": "array"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AccessAnalyzer::Analyzer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.ArchiveRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Filter": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer.Filter"
+                    },
+                    "type": "array"
+                },
+                "RuleName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Filter",
+                "RuleName"
+            ],
+            "type": "object"
+        },
+        "AWS::AccessAnalyzer::Analyzer.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Contains": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Eq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Exists": {
+                    "type": "boolean"
+                },
+                "Neq": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Property": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Property"
+            ],
+            "type": "object"
+        },
         "AWS::AmazonMQ::Broker": {
             "additionalProperties": false,
             "properties": {
@@ -2689,10 +2810,28 @@
                         "ApiKeySelectionExpression": {
                             "type": "string"
                         },
+                        "BasePath": {
+                            "type": "string"
+                        },
+                        "Body": {
+                            "type": "object"
+                        },
+                        "BodyS3Location": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.BodyS3Location"
+                        },
+                        "CorsConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Api.Cors"
+                        },
+                        "CredentialsArn": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
                         "DisableSchemaValidation": {
+                            "type": "boolean"
+                        },
+                        "FailOnWarnings": {
                             "type": "boolean"
                         },
                         "Name": {
@@ -2701,21 +2840,22 @@
                         "ProtocolType": {
                             "type": "string"
                         },
+                        "RouteKey": {
+                            "type": "string"
+                        },
                         "RouteSelectionExpression": {
                             "type": "string"
                         },
                         "Tags": {
                             "type": "object"
                         },
+                        "Target": {
+                            "type": "string"
+                        },
                         "Version": {
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "Name",
-                        "ProtocolType",
-                        "RouteSelectionExpression"
-                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -2726,9 +2866,62 @@
                 }
             },
             "required": [
-                "Type",
-                "Properties"
+                "Type"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.BodyS3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Etag": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Api.Cors": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCredentials": {
+                    "type": "boolean"
+                },
+                "AllowHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AllowOrigins": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ExposeHeaders": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "MaxAge": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::ApiMapping": {
@@ -2852,6 +3045,9 @@
                         "IdentityValidationExpression": {
                             "type": "string"
                         },
+                        "JwtConfiguration": {
+                            "$ref": "#/definitions/AWS::ApiGatewayV2::Authorizer.JWTConfiguration"
+                        },
                         "Name": {
                             "type": "string"
                         }
@@ -2859,7 +3055,6 @@
                     "required": [
                         "ApiId",
                         "AuthorizerType",
-                        "AuthorizerUri",
                         "IdentitySource",
                         "Name"
                     ],
@@ -2876,6 +3071,21 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ApiGatewayV2::Authorizer.JWTConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Audience": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Issuer": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApiGatewayV2::Deployment": {
@@ -3073,6 +3283,9 @@
                             "type": "string"
                         },
                         "PassthroughBehavior": {
+                            "type": "string"
+                        },
+                        "PayloadFormatVersion": {
                             "type": "string"
                         },
                         "RequestParameters": {
@@ -3473,6 +3686,9 @@
                         "ApiId": {
                             "type": "string"
                         },
+                        "AutoDeploy": {
+                            "type": "boolean"
+                        },
                         "ClientCertificateId": {
                             "type": "string"
                         },
@@ -3500,7 +3716,6 @@
                     },
                     "required": [
                         "ApiId",
-                        "DeploymentId",
                         "StageName"
                     ],
                     "type": "object"
@@ -27651,6 +27866,250 @@
             },
             "type": "object"
         },
+        "AWS::EventSchemas::Discoverer": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "SourceArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Discoverer.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "SourceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Discoverer"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Discoverer.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Registry.TagsEntry"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Registry"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Registry.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Content": {
+                            "type": "string"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "RegistryName": {
+                            "type": "string"
+                        },
+                        "SchemaName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::EventSchemas::Schema.TagsEntry"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Content",
+                        "RegistryName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EventSchemas::Schema"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EventSchemas::Schema.TagsEntry": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
         "AWS::Events::EventBus": {
             "additionalProperties": false,
             "properties": {
@@ -28233,6 +28692,12 @@
                     "type": "boolean"
                 },
                 "DailyAutomaticBackupStartTime": {
+                    "type": "string"
+                },
+                "DeploymentType": {
+                    "type": "string"
+                },
+                "PreferredSubnetId": {
                     "type": "string"
                 },
                 "SelfManagedActiveDirectoryConfiguration": {
@@ -32727,6 +33192,7 @@
                         "Description",
                         "DetectorId",
                         "FindingCriteria",
+                        "Name",
                         "Rank"
                     ],
                     "type": "object"
@@ -38848,6 +39314,9 @@
                         "Name": {
                             "type": "string"
                         },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration"
+                        },
                         "RoutingConfig": {
                             "$ref": "#/definitions/AWS::Lambda::Alias.AliasRoutingConfiguration"
                         }
@@ -38884,6 +39353,18 @@
             },
             "required": [
                 "AdditionalVersionWeights"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -39560,6 +40041,9 @@
                         },
                         "FunctionName": {
                             "type": "string"
+                        },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Version.ProvisionedConcurrencyConfiguration"
                         }
                     },
                     "required": [
@@ -39577,6 +40061,18 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Lambda::Version.ProvisionedConcurrencyConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -48096,6 +48592,108 @@
             ],
             "type": "object"
         },
+        "AWS::S3::AccessPoint": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Bucket": {
+                            "type": "string"
+                        },
+                        "CreationDate": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NetworkOrigin": {
+                            "type": "string"
+                        },
+                        "Policy": {
+                            "type": "object"
+                        },
+                        "PolicyStatus": {
+                            "type": "object"
+                        },
+                        "PublicAccessBlockConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.PublicAccessBlockConfiguration"
+                        },
+                        "VpcConfiguration": {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint.VpcConfiguration"
+                        }
+                    },
+                    "required": [
+                        "Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::S3::AccessPoint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.PublicAccessBlockConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlockPublicAcls": {
+                    "type": "boolean"
+                },
+                "BlockPublicPolicy": {
+                    "type": "boolean"
+                },
+                "IgnorePublicAcls": {
+                    "type": "boolean"
+                },
+                "RestrictPublicBuckets": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::S3::AccessPoint.VpcConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "VpcId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::S3::Bucket": {
             "additionalProperties": false,
             "properties": {
@@ -54861,10 +55459,16 @@
                         "DefinitionString": {
                             "type": "string"
                         },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LoggingConfiguration"
+                        },
                         "RoleArn": {
                             "type": "string"
                         },
                         "StateMachineName": {
+                            "type": "string"
+                        },
+                        "StateMachineType": {
                             "type": "string"
                         },
                         "Tags": {
@@ -54891,6 +55495,45 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "LogGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LogGroupArn"
+            ],
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LogDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogsLogGroup": {
+                    "$ref": "#/definitions/AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::StepFunctions::StateMachine.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destinations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::StepFunctions::StateMachine.LogDestination"
+                    },
+                    "type": "array"
+                },
+                "IncludeExecutionData": {
+                    "type": "boolean"
+                },
+                "Level": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::StepFunctions::StateMachine.TagsEntry": {
@@ -56703,38 +57346,11 @@
                         "IPAddressVersion": {
                             "type": "string"
                         },
-                        "IPSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSet"
-                        },
-                        "IPSetSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
-                        },
-                        "IPSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSets"
-                        },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
@@ -56765,63 +57381,6 @@
                 "IPAddresses": {
                     "items": {
                         "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Addresses": {
-                    "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "IPAddressVersion": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPSets": {
-            "additionalProperties": false,
-            "properties": {
-                "IPSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::IPSet.IPSetSummary"
                     },
                     "type": "array"
                 }
@@ -56875,38 +57434,14 @@
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RegexPatternSet": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSet"
-                        },
-                        "RegexPatternSets": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSets"
                         },
                         "RegularExpressionList": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
@@ -56936,60 +57471,6 @@
             "properties": {
                 "RegexString": {
                     "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSet": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "RegularExpressionList": {
-                    "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegexPatternSets": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexPatternSets": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegexPatternSetSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -57056,44 +57537,14 @@
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
                             "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
-                            "type": "string"
-                        },
-                        "RuleGroup": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroup"
-                        },
-                        "RuleGroupSummary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                        },
-                        "RuleGroups": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroups"
                         },
                         "Rules": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
                         },
                         "Scope": {
                             "type": "string"
-                        },
-                        "Statement": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementOne"
-                        },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
@@ -57236,7 +57687,7 @@
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -57321,7 +57772,7 @@
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -57365,66 +57816,6 @@
                 },
                 "Count": {
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroup": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroupSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.RuleGroups": {
-            "additionalProperties": false,
-            "properties": {
-                "RuleGroups": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.RuleGroupSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -57724,22 +58115,7 @@
                         "Description": {
                             "type": "string"
                         },
-                        "Id": {
-                            "type": "string"
-                        },
-                        "Limit": {
-                            "type": "number"
-                        },
-                        "LockToken": {
-                            "type": "string"
-                        },
                         "Name": {
-                            "type": "string"
-                        },
-                        "NextLockToken": {
-                            "type": "string"
-                        },
-                        "NextMarker": {
                             "type": "string"
                         },
                         "Rules": {
@@ -57748,20 +58124,11 @@
                         "Scope": {
                             "type": "string"
                         },
-                        "Summary": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                        },
                         "Tags": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                        },
-                        "WebACL": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACL"
-                        },
-                        "WebACLs": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLs"
                         }
                     },
                     "required": [
@@ -57931,7 +58298,7 @@
         "AWS::WAFv2::WebACL.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 }
             },
@@ -58048,7 +58415,7 @@
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "FieldToMatch": {
@@ -58102,7 +58469,7 @@
         "AWS::WAFv2::WebACL.RuleGroupReferenceStatement": {
             "additionalProperties": false,
             "properties": {
-                "ARN": {
+                "Arn": {
                     "type": "string"
                 },
                 "ExcludedRules": {
@@ -58370,69 +58737,6 @@
                 },
                 "SampledRequestsEnabled": {
                     "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACL": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Capacity": {
-                    "type": "number"
-                },
-                "DefaultAction": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.DefaultAction"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                },
-                "Rules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
-                },
-                "VisibilityConfig": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLSummary": {
-            "additionalProperties": false,
-            "properties": {
-                "ARN": {
-                    "type": "string"
-                },
-                "Description": {
-                    "type": "string"
-                },
-                "Id": {
-                    "type": "string"
-                },
-                "LockToken": {
-                    "type": "string"
-                },
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.WebACLs": {
-            "additionalProperties": false,
-            "properties": {
-                "WebACLs": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.WebACLSummary"
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
@@ -58835,6 +59139,9 @@
             "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                     "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::AccessAnalyzer::Analyzer"
+                        },
                         {
                             "$ref": "#/definitions/AWS::AmazonMQ::Broker"
                         },
@@ -59508,6 +59815,15 @@
                             "$ref": "#/definitions/AWS::Elasticsearch::Domain"
                         },
                         {
+                            "$ref": "#/definitions/AWS::EventSchemas::Discoverer"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Registry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EventSchemas::Schema"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Events::EventBus"
                         },
                         {
@@ -60034,6 +60350,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Route53Resolver::ResolverRuleAssociation"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::S3::AccessPoint"
                         },
                         {
                             "$ref": "#/definitions/AWS::S3::Bucket"


### PR DESCRIPTION
Updated the following AWS CloudFormation resources:

 - AWS::ApiGatewayV2::Stage
 - AWS::ApiGatewayV2::Api
 - AWS::S3::AccessPoint
 - AWS::EventSchemas::Schema
 - AWS::GuardDuty::Filter
 - AWS::WAFv2::RuleGroup
 - AWS::StepFunctions::StateMachine
 - AWS::ApiGatewayV2::Integration
 - AWS::WAFv2::RegexPatternSet
 - AWS::EventSchemas::Registry
 - AWS::Lambda::Alias
 - AWS::EventSchemas::Discoverer
 - AWS::Lambda::Version
 - AWS::ApiGatewayV2::Authorizer
 - AWS::WAFv2::WebACL
 - AWS::AccessAnalyzer::Analyzer
 - AWS::WAFv2::IPSet
 - AWS::EventSchemas::Registry.TagsEntry
 - AWS::StepFunctions::StateMachine.LoggingConfiguration
 - AWS::WAFv2::RuleGroup.IPSetReferenceStatement
 - AWS::Lambda::Alias.ProvisionedConcurrencyConfiguration
 - AWS::FSx::FileSystem.WindowsConfiguration
 - AWS::WAFv2::WebACL.IPSetReferenceStatement
 - AWS::S3::AccessPoint.VpcConfiguration
 - AWS::AccessAnalyzer::Analyzer.Filter
 - AWS::S3::AccessPoint.PublicAccessBlockConfiguration
 - AWS::WAFv2::WebACL.RuleGroupReferenceStatement
 - AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement
 - AWS::ApiGatewayV2::Api.Cors
 - AWS::EventSchemas::Schema.TagsEntry
 - AWS::ApiGatewayV2::Authorizer.JWTConfiguration
 - AWS::EventSchemas::Discoverer.TagsEntry
 - AWS::StepFunctions::StateMachine.LogDestination
 - AWS::Lambda::Version.ProvisionedConcurrencyConfiguration
 - AWS::StepFunctions::StateMachine.CloudWatchLogsLogGroup
 - AWS::AccessAnalyzer::Analyzer.ArchiveRule
 - AWS::ApiGatewayV2::Api.BodyS3Location
 - AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
