### PR TITLE
do not omit `ReturnData` in CloudWatch Data Metrics

### DIFF
--- a/cloudformation/cloudwatch/aws-cloudwatch-alarm_metricdataquery.go
+++ b/cloudformation/cloudwatch/aws-cloudwatch-alarm_metricdataquery.go
@@ -31,7 +31,7 @@ type Alarm_MetricDataQuery struct {
 	// ReturnData AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudwatch-alarm-metricdataquery.html#cfn-cloudwatch-alarm-metricdataquery-returndata
-	ReturnData bool `json:"ReturnData,omitempty"`
+	ReturnData bool `json:"ReturnData"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`


### PR DESCRIPTION
If it is omitted CloudFormation template update with fail with the error: `Exactly one element of the metrics list should return data`, because  all the omitted values assumed as `True`

From the [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudwatch-alarm-metricdataquery.html):

**ReturnData**
This option indicates whether to return the timestamps and raw data values of this metric. If you are performing this call just to do math expressions and do not also need the raw data returned, you can specify False. **If you omit this, the default of True is used.**

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
