### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/test/yaml/aws-serverless-function-env-vars.yaml
+++ b/test/yaml/aws-serverless-function-env-vars.yaml
@@ -19,7 +19,7 @@ Resources:
   EnvironmentVariableTestFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Handler: filename.method
       Environment:
         Variables:
@@ -34,7 +34,7 @@ Resources:
   NoValueEnvironmentVariableTestFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Handler: filename.method
       Environment:
         Variables:
@@ -50,7 +50,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: sub
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Handler: filename.method
       Environment:
         Variables:
@@ -66,7 +66,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: sub
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Handler: filename.method
       Environment:
         Variables:
@@ -81,7 +81,7 @@ Resources:
   IntrinsicEnvironmentVariableTestFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Handler: filename.method
       Environment:
         Variables:

--- a/test/yaml/sam-official-samples/s3_processor/template.yaml
+++ b/test/yaml/sam-official-samples/s3_processor/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Policies: AmazonS3ReadOnlyAccess
       Events:


### PR DESCRIPTION
CloudFormation templates in goformation have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.