### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/test/json/invalid-sam-template-wrong-transform.json
+++ b/test/json/invalid-sam-template-wrong-transform.json
@@ -8,7 +8,7 @@
       "Properties": {
         "Handler": "index.handler",
         "CodeUri": "s3://testBucket/mySourceCode.zip",
-        "Runtime": "nodejs4.3"
+        "Runtime": "nodejs10.x"
       }
     }
   }

--- a/test/json/valid-sam-template.json
+++ b/test/json/valid-sam-template.json
@@ -8,7 +8,7 @@
       "Properties": {
         "Handler": "index.handler",
         "CodeUri": "s3://testBucket/mySourceCode.zip",
-        "Runtime": "nodejs4.3"
+        "Runtime": "nodejs10.x"
       }
     },
     "MySNSTopic" : {

--- a/test/json/valid-template-with-fns.json
+++ b/test/json/valid-template-with-fns.json
@@ -13,7 +13,7 @@
         "Role": {
           "Fn::GetAtt": ["FunctionNameRole", "Arn"]
         },
-        "Runtime": "nodejs4.3"
+        "Runtime": "nodejs10.x"
       }
     },
     "FunctionNameRole": {

--- a/test/yaml/aws-serverless-function-api-event.yaml
+++ b/test/yaml/aws-serverless-function-api-event.yaml
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.put
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/api_backend.zip
       Policies: AmazonDynamoDBFullAccess
       Environment:
@@ -39,7 +39,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.delete
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/api_backend.zip
       Policies: AmazonDynamoDBFullAccess
       Environment:

--- a/test/yaml/codestar/nodejs.yml
+++ b/test/yaml/codestar/nodejs.yml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.get
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Role:
         Fn::ImportValue:
           !Join ['-', [!Ref 'ProjectId', !Ref 'AWS::Region', 'LambdaTrustRole']]

--- a/test/yaml/sam-official-samples/alexa_skill/template.yaml
+++ b/test/yaml/sam-official-samples/alexa_skill/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: s3://<bucket>/alexa_skill.zip
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill

--- a/test/yaml/sam-official-samples/api_backend/template.yaml
+++ b/test/yaml/sam-official-samples/api_backend/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.get
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/api_backend.zip
       Policies: AmazonDynamoDBReadOnlyAccess
       Environment:
@@ -23,7 +23,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.put
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/api_backend.zip
       Policies: AmazonDynamoDBFullAccess
       Environment:
@@ -40,7 +40,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.delete
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/api_backend.zip
       Policies: AmazonDynamoDBFullAccess
       Environment:

--- a/test/yaml/sam-official-samples/api_swagger_cors/template.yaml
+++ b/test/yaml/sam-official-samples/api_swagger_cors/template.yaml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       CodeUri: s3://<bucket>/api_swagger_cors.zip
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Events:
         ProxyApiRoot:
           Type: Api

--- a/test/yaml/sam-official-samples/codestar-node4.3.yaml
+++ b/test/yaml/sam-official-samples/codestar-node4.3.yaml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.get
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Role:
         Fn::ImportValue:
           !Join ['-', [!Ref 'ProjectId', !Ref 'AWS::Region', 'LambdaTrustRole']]

--- a/test/yaml/sam-official-samples/inline_swagger/template.yaml
+++ b/test/yaml/sam-official-samples/inline_swagger/template.yaml
@@ -28,7 +28,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/inline_swagger.zip
       Events:
         GetApi:

--- a/test/yaml/sam-official-samples/iot_backend/template.yaml
+++ b/test/yaml/sam-official-samples/iot_backend/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties: 
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/iot_backend.zip
       Policies: AmazonDynamoDBFullAccess
       Environment: 

--- a/test/yaml/sam-official-samples/schedule/template.yaml
+++ b/test/yaml/sam-official-samples/schedule/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/schedule.zip
       Events:
         Timer:

--- a/test/yaml/sam-official-samples/stream_processor/template.yaml
+++ b/test/yaml/sam-official-samples/stream_processor/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: s3://<bucket>/stream_processor.zip
       Events:
         Stream:

--- a/test/yaml/sam-official-samples/templates/basic.yaml
+++ b/test/yaml/sam-official-samples/templates/basic.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: s3://<bucket>/alexa_skill.zip
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill

--- a/test/yaml/sam-official-samples/templates/wrong.yaml
+++ b/test/yaml/sam-official-samples/templates/wrong.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill


### PR DESCRIPTION
CloudFormation templates in goformation have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.