### PR TITLE
Align Transform field format with actual Cloudformation support

### DIFF
--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -134,6 +134,16 @@ func (t *Transform) UnmarshalJSON(b []byte) error {
 
 	case []string:
 		t.StringArray = &val
+
+	case []interface{}:
+		var strslice []string
+		for _, i := range val {
+			switch str := i.(type) {
+				case string:
+					strslice = append(strslice, str)
+			}
+		}
+		t.StringArray = &strslice
 	}
 
 	return nil

--- a/generate/templates/schema.template
+++ b/generate/templates/schema.template
@@ -27,7 +27,10 @@
                 "{{.ResourceSpecificationTransform}}"
             ]
         {{else}}
-            "type": ["object","string"]
+            "oneOf": [
+                {"type": ["string"]},
+                {"type": "array", "items": {"type": "string"}}
+            ]
         {{end}}
         },
 

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -758,6 +758,42 @@ var _ = Describe("Goformation", func() {
 
 	})
 
+	Context("with a YAML template with single transform macro", func() {
+		template, err := goformation.Open("test/yaml/transform-single.yaml")
+
+		It("should parse the template successfully", func() {
+			Expect(template).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		It("should parse transform macro into String field", func() {
+			Expect(*template.Transform.String).To(Equal("MyTranformMacro"))
+		})
+
+		It("should StringArray remain nil", func() {
+			Expect(template.Transform.StringArray).To(BeNil())
+		})
+
+	})
+
+	Context("with a YAML template with multiple transform macros", func() {
+		template, err := goformation.Open("test/yaml/transform-multiple.yaml")
+
+		It("should parse the template successfully", func() {
+			Expect(template).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		It("should parse transform macro into StringArray field", func() {
+			Expect(*template.Transform.StringArray).To(Equal([]string{"FirstMacro", "SecondMacro"}))
+		})
+
+		It("should String remain nil", func() {
+			Expect(template.Transform.String).To(BeNil())
+		})
+
+	})
+
 	Context("with a YAML template with paramter overrides", func() {
 
 		template, err := goformation.OpenWithOptions("test/yaml/aws-serverless-function-env-vars.yaml", &intrinsics.ProcessorOptions{

--- a/schema/cloudformation.go
+++ b/schema/cloudformation.go
@@ -60700,9 +60700,18 @@ var CloudformationSchema = `{
             "type": "object"
         },
         "Transform": {
-            "type": [
-                "object",
-                "string"
+            "oneOf": [
+                {
+                    "type": [
+                        "string"
+                    ]
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
             ]
         }
     },

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -60697,9 +60697,18 @@
             "type": "object"
         },
         "Transform": {
-            "type": [
-                "object",
-                "string"
+            "oneOf": [
+                {
+                    "type": [
+                        "string"
+                    ]
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
             ]
         }
     },

--- a/test/yaml/transform-multiple.yaml
+++ b/test/yaml/transform-multiple.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  ExampleTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: example
+
+Transform:
+  - FirstMacro
+  - SecondMacro

--- a/test/yaml/transform-single.yaml
+++ b/test/yaml/transform-single.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  ExampleTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: example
+
+Transform: MyTranformMacro


### PR DESCRIPTION
*Issue #, if available:* 
#267

*Description of changes:*
Transform field can be String or Array of Strings, this fixes json schema and UnmarshalJSON.
UnmarshalJSON needs fix because it receives []interface{} instead of []string. Added additional case to handle this issue. Covered by two YAML template tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
