### PR TITLE
feat(schema): CloudFormation Updates (2020-02-22)

### DIFF
--- a/cloudformation/all.go
+++ b/cloudformation/all.go
@@ -54,6 +54,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/emr"
 	"github.com/awslabs/goformation/v4/cloudformation/events"
 	"github.com/awslabs/goformation/v4/cloudformation/eventschemas"
+	"github.com/awslabs/goformation/v4/cloudformation/fms"
 	"github.com/awslabs/goformation/v4/cloudformation/fsx"
 	"github.com/awslabs/goformation/v4/cloudformation/gamelift"
 	"github.com/awslabs/goformation/v4/cloudformation/glue"
@@ -237,8 +238,10 @@ func AllResources() map[string]Resource {
 		"AWS::Config::ConfigRule":                                     &config.ConfigRule{},
 		"AWS::Config::ConfigurationAggregator":                        &config.ConfigurationAggregator{},
 		"AWS::Config::ConfigurationRecorder":                          &config.ConfigurationRecorder{},
+		"AWS::Config::ConformancePack":                                &config.ConformancePack{},
 		"AWS::Config::DeliveryChannel":                                &config.DeliveryChannel{},
 		"AWS::Config::OrganizationConfigRule":                         &config.OrganizationConfigRule{},
+		"AWS::Config::OrganizationConformancePack":                    &config.OrganizationConformancePack{},
 		"AWS::Config::RemediationConfiguration":                       &config.RemediationConfiguration{},
 		"AWS::DAX::Cluster":                                           &dax.Cluster{},
 		"AWS::DAX::ParameterGroup":                                    &dax.ParameterGroup{},
@@ -275,6 +278,8 @@ func AllResources() map[string]Resource {
 		"AWS::EC2::Instance":                                          &ec2.Instance{},
 		"AWS::EC2::InternetGateway":                                   &ec2.InternetGateway{},
 		"AWS::EC2::LaunchTemplate":                                    &ec2.LaunchTemplate{},
+		"AWS::EC2::LocalGatewayRoute":                                 &ec2.LocalGatewayRoute{},
+		"AWS::EC2::LocalGatewayRouteTableVPCAssociation":              &ec2.LocalGatewayRouteTableVPCAssociation{},
 		"AWS::EC2::NatGateway":                                        &ec2.NatGateway{},
 		"AWS::EC2::NetworkAcl":                                        &ec2.NetworkAcl{},
 		"AWS::EC2::NetworkAclEntry":                                   &ec2.NetworkAclEntry{},
@@ -355,6 +360,8 @@ func AllResources() map[string]Resource {
 		"AWS::Events::EventBus":                                       &events.EventBus{},
 		"AWS::Events::EventBusPolicy":                                 &events.EventBusPolicy{},
 		"AWS::Events::Rule":                                           &events.Rule{},
+		"AWS::FMS::NotificationChannel":                               &fms.NotificationChannel{},
+		"AWS::FMS::Policy":                                            &fms.Policy{},
 		"AWS::FSx::FileSystem":                                        &fsx.FileSystem{},
 		"AWS::GameLift::Alias":                                        &gamelift.Alias{},
 		"AWS::GameLift::Build":                                        &gamelift.Build{},
@@ -3571,6 +3578,30 @@ func (t *Template) GetConfigConfigurationRecorderWithName(name string) (*config.
 	return nil, fmt.Errorf("resource %q of type config.ConfigurationRecorder not found", name)
 }
 
+// GetAllConfigConformancePackResources retrieves all config.ConformancePack items from an AWS CloudFormation template
+func (t *Template) GetAllConfigConformancePackResources() map[string]*config.ConformancePack {
+	results := map[string]*config.ConformancePack{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *config.ConformancePack:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetConfigConformancePackWithName retrieves all config.ConformancePack items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetConfigConformancePackWithName(name string) (*config.ConformancePack, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *config.ConformancePack:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type config.ConformancePack not found", name)
+}
+
 // GetAllConfigDeliveryChannelResources retrieves all config.DeliveryChannel items from an AWS CloudFormation template
 func (t *Template) GetAllConfigDeliveryChannelResources() map[string]*config.DeliveryChannel {
 	results := map[string]*config.DeliveryChannel{}
@@ -3617,6 +3648,30 @@ func (t *Template) GetConfigOrganizationConfigRuleWithName(name string) (*config
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type config.OrganizationConfigRule not found", name)
+}
+
+// GetAllConfigOrganizationConformancePackResources retrieves all config.OrganizationConformancePack items from an AWS CloudFormation template
+func (t *Template) GetAllConfigOrganizationConformancePackResources() map[string]*config.OrganizationConformancePack {
+	results := map[string]*config.OrganizationConformancePack{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *config.OrganizationConformancePack:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetConfigOrganizationConformancePackWithName retrieves all config.OrganizationConformancePack items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetConfigOrganizationConformancePackWithName(name string) (*config.OrganizationConformancePack, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *config.OrganizationConformancePack:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type config.OrganizationConformancePack not found", name)
 }
 
 // GetAllConfigRemediationConfigurationResources retrieves all config.RemediationConfiguration items from an AWS CloudFormation template
@@ -4481,6 +4536,54 @@ func (t *Template) GetEC2LaunchTemplateWithName(name string) (*ec2.LaunchTemplat
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type ec2.LaunchTemplate not found", name)
+}
+
+// GetAllEC2LocalGatewayRouteResources retrieves all ec2.LocalGatewayRoute items from an AWS CloudFormation template
+func (t *Template) GetAllEC2LocalGatewayRouteResources() map[string]*ec2.LocalGatewayRoute {
+	results := map[string]*ec2.LocalGatewayRoute{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *ec2.LocalGatewayRoute:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEC2LocalGatewayRouteWithName retrieves all ec2.LocalGatewayRoute items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEC2LocalGatewayRouteWithName(name string) (*ec2.LocalGatewayRoute, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *ec2.LocalGatewayRoute:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type ec2.LocalGatewayRoute not found", name)
+}
+
+// GetAllEC2LocalGatewayRouteTableVPCAssociationResources retrieves all ec2.LocalGatewayRouteTableVPCAssociation items from an AWS CloudFormation template
+func (t *Template) GetAllEC2LocalGatewayRouteTableVPCAssociationResources() map[string]*ec2.LocalGatewayRouteTableVPCAssociation {
+	results := map[string]*ec2.LocalGatewayRouteTableVPCAssociation{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *ec2.LocalGatewayRouteTableVPCAssociation:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEC2LocalGatewayRouteTableVPCAssociationWithName retrieves all ec2.LocalGatewayRouteTableVPCAssociation items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEC2LocalGatewayRouteTableVPCAssociationWithName(name string) (*ec2.LocalGatewayRouteTableVPCAssociation, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *ec2.LocalGatewayRouteTableVPCAssociation:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type ec2.LocalGatewayRouteTableVPCAssociation not found", name)
 }
 
 // GetAllEC2NatGatewayResources retrieves all ec2.NatGateway items from an AWS CloudFormation template
@@ -6401,6 +6504,54 @@ func (t *Template) GetEventsRuleWithName(name string) (*events.Rule, error) {
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type events.Rule not found", name)
+}
+
+// GetAllFMSNotificationChannelResources retrieves all fms.NotificationChannel items from an AWS CloudFormation template
+func (t *Template) GetAllFMSNotificationChannelResources() map[string]*fms.NotificationChannel {
+	results := map[string]*fms.NotificationChannel{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *fms.NotificationChannel:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetFMSNotificationChannelWithName retrieves all fms.NotificationChannel items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetFMSNotificationChannelWithName(name string) (*fms.NotificationChannel, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *fms.NotificationChannel:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type fms.NotificationChannel not found", name)
+}
+
+// GetAllFMSPolicyResources retrieves all fms.Policy items from an AWS CloudFormation template
+func (t *Template) GetAllFMSPolicyResources() map[string]*fms.Policy {
+	results := map[string]*fms.Policy{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *fms.Policy:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetFMSPolicyWithName retrieves all fms.Policy items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetFMSPolicyWithName(name string) (*fms.Policy, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *fms.Policy:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type fms.Policy not found", name)
 }
 
 // GetAllFSxFileSystemResources retrieves all fsx.FileSystem items from an AWS CloudFormation template

--- a/cloudformation/codebuild/aws-codebuild-project.go
+++ b/cloudformation/codebuild/aws-codebuild-project.go
@@ -43,6 +43,11 @@ type Project struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-environment
 	Environment *Project_Environment `json:"Environment,omitempty"`
 
+	// FileSystemLocations AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-filesystemlocations
+	FileSystemLocations []Project_ProjectFileSystemLocation `json:"FileSystemLocations,omitempty"`
+
 	// LogsConfig AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-logsconfig

--- a/cloudformation/codebuild/aws-codebuild-project_projectfilesystemlocation.go
+++ b/cloudformation/codebuild/aws-codebuild-project_projectfilesystemlocation.go
@@ -1,0 +1,52 @@
+package codebuild
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Project_ProjectFileSystemLocation AWS CloudFormation Resource (AWS::CodeBuild::Project.ProjectFileSystemLocation)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html
+type Project_ProjectFileSystemLocation struct {
+
+	// Identifier AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html#cfn-codebuild-project-projectfilesystemlocation-identifier
+	Identifier string `json:"Identifier,omitempty"`
+
+	// Location AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html#cfn-codebuild-project-projectfilesystemlocation-location
+	Location string `json:"Location,omitempty"`
+
+	// MountOptions AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html#cfn-codebuild-project-projectfilesystemlocation-mountoptions
+	MountOptions string `json:"MountOptions,omitempty"`
+
+	// MountPoint AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html#cfn-codebuild-project-projectfilesystemlocation-mountpoint
+	MountPoint string `json:"MountPoint,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectfilesystemlocation.html#cfn-codebuild-project-projectfilesystemlocation-type
+	Type string `json:"Type,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Project_ProjectFileSystemLocation) AWSCloudFormationType() string {
+	return "AWS::CodeBuild::Project.ProjectFileSystemLocation"
+}

--- a/cloudformation/cognito/aws-cognito-userpool.go
+++ b/cloudformation/cognito/aws-cognito-userpool.go
@@ -112,6 +112,11 @@ type UserPool struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-usernameattributes
 	UsernameAttributes []string `json:"UsernameAttributes,omitempty"`
 
+	// UsernameConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-usernameconfiguration
+	UsernameConfiguration *UserPool_UsernameConfiguration `json:"UsernameConfiguration,omitempty"`
+
 	// VerificationMessageTemplate AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-verificationmessagetemplate

--- a/cloudformation/cognito/aws-cognito-userpool_usernameconfiguration.go
+++ b/cloudformation/cognito/aws-cognito-userpool_usernameconfiguration.go
@@ -1,0 +1,32 @@
+package cognito
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserPool_UsernameConfiguration AWS CloudFormation Resource (AWS::Cognito::UserPool.UsernameConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-usernameconfiguration.html
+type UserPool_UsernameConfiguration struct {
+
+	// CaseSensitive AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-usernameconfiguration.html#cfn-cognito-userpool-usernameconfiguration-casesensitive
+	CaseSensitive bool `json:"CaseSensitive,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserPool_UsernameConfiguration) AWSCloudFormationType() string {
+	return "AWS::Cognito::UserPool.UsernameConfiguration"
+}

--- a/cloudformation/config/aws-config-aggregationauthorization.go
+++ b/cloudformation/config/aws-config-aggregationauthorization.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // AggregationAuthorization AWS CloudFormation Resource (AWS::Config::AggregationAuthorization)
@@ -21,6 +22,11 @@ type AggregationAuthorization struct {
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-aggregationauthorization.html#cfn-config-aggregationauthorization-authorizedawsregion
 	AuthorizedAwsRegion string `json:"AuthorizedAwsRegion,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-aggregationauthorization.html#cfn-config-aggregationauthorization-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/config/aws-config-configurationaggregator.go
+++ b/cloudformation/config/aws-config-configurationaggregator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // ConfigurationAggregator AWS CloudFormation Resource (AWS::Config::ConfigurationAggregator)
@@ -26,6 +27,11 @@ type ConfigurationAggregator struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationaggregator.html#cfn-config-configurationaggregator-organizationaggregationsource
 	OrganizationAggregationSource *ConfigurationAggregator_OrganizationAggregationSource `json:"OrganizationAggregationSource,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationaggregator.html#cfn-config-configurationaggregator-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/config/aws-config-conformancepack.go
+++ b/cloudformation/config/aws-config-conformancepack.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ConformancePack AWS CloudFormation Resource (AWS::Config::ConformancePack)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html
+type ConformancePack struct {
+
+	// ConformancePackInputParameters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html#cfn-config-conformancepack-conformancepackinputparameters
+	ConformancePackInputParameters []ConformancePack_ConformancePackInputParameter `json:"ConformancePackInputParameters,omitempty"`
+
+	// ConformancePackName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html#cfn-config-conformancepack-conformancepackname
+	ConformancePackName string `json:"ConformancePackName,omitempty"`
+
+	// DeliveryS3Bucket AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html#cfn-config-conformancepack-deliverys3bucket
+	DeliveryS3Bucket string `json:"DeliveryS3Bucket,omitempty"`
+
+	// DeliveryS3KeyPrefix AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html#cfn-config-conformancepack-deliverys3keyprefix
+	DeliveryS3KeyPrefix string `json:"DeliveryS3KeyPrefix,omitempty"`
+
+	// TemplateBody AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html#cfn-config-conformancepack-templatebody
+	TemplateBody string `json:"TemplateBody,omitempty"`
+
+	// TemplateS3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-conformancepack.html#cfn-config-conformancepack-templates3uri
+	TemplateS3Uri string `json:"TemplateS3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ConformancePack) AWSCloudFormationType() string {
+	return "AWS::Config::ConformancePack"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ConformancePack) MarshalJSON() ([]byte, error) {
+	type Properties ConformancePack
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		Condition      string                  `json:"Condition,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		Condition:      r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ConformancePack) UnmarshalJSON(b []byte) error {
+	type Properties ConformancePack
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+		Condition      string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ConformancePack(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/config/aws-config-conformancepack_conformancepackinputparameter.go
+++ b/cloudformation/config/aws-config-conformancepack_conformancepackinputparameter.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ConformancePack_ConformancePackInputParameter AWS CloudFormation Resource (AWS::Config::ConformancePack.ConformancePackInputParameter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-conformancepack-conformancepackinputparameter.html
+type ConformancePack_ConformancePackInputParameter struct {
+
+	// ParameterName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-conformancepack-conformancepackinputparameter.html#cfn-config-conformancepack-conformancepackinputparameter-parametername
+	ParameterName string `json:"ParameterName,omitempty"`
+
+	// ParameterValue AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-conformancepack-conformancepackinputparameter.html#cfn-config-conformancepack-conformancepackinputparameter-parametervalue
+	ParameterValue string `json:"ParameterValue,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ConformancePack_ConformancePackInputParameter) AWSCloudFormationType() string {
+	return "AWS::Config::ConformancePack.ConformancePackInputParameter"
+}

--- a/cloudformation/config/aws-config-organizationconformancepack.go
+++ b/cloudformation/config/aws-config-organizationconformancepack.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// OrganizationConformancePack AWS CloudFormation Resource (AWS::Config::OrganizationConformancePack)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html
+type OrganizationConformancePack struct {
+
+	// ConformancePackInputParameters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-conformancepackinputparameters
+	ConformancePackInputParameters []OrganizationConformancePack_ConformancePackInputParameter `json:"ConformancePackInputParameters,omitempty"`
+
+	// DeliveryS3Bucket AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-deliverys3bucket
+	DeliveryS3Bucket string `json:"DeliveryS3Bucket,omitempty"`
+
+	// DeliveryS3KeyPrefix AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-deliverys3keyprefix
+	DeliveryS3KeyPrefix string `json:"DeliveryS3KeyPrefix,omitempty"`
+
+	// ExcludedAccounts AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-excludedaccounts
+	ExcludedAccounts []string `json:"ExcludedAccounts,omitempty"`
+
+	// OrganizationConformancePackName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-organizationconformancepackname
+	OrganizationConformancePackName string `json:"OrganizationConformancePackName,omitempty"`
+
+	// TemplateBody AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-templatebody
+	TemplateBody string `json:"TemplateBody,omitempty"`
+
+	// TemplateS3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-organizationconformancepack.html#cfn-config-organizationconformancepack-templates3uri
+	TemplateS3Uri string `json:"TemplateS3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *OrganizationConformancePack) AWSCloudFormationType() string {
+	return "AWS::Config::OrganizationConformancePack"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r OrganizationConformancePack) MarshalJSON() ([]byte, error) {
+	type Properties OrganizationConformancePack
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		Condition      string                  `json:"Condition,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		Condition:      r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *OrganizationConformancePack) UnmarshalJSON(b []byte) error {
+	type Properties OrganizationConformancePack
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+		Condition      string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = OrganizationConformancePack(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/config/aws-config-organizationconformancepack_conformancepackinputparameter.go
+++ b/cloudformation/config/aws-config-organizationconformancepack_conformancepackinputparameter.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// OrganizationConformancePack_ConformancePackInputParameter AWS CloudFormation Resource (AWS::Config::OrganizationConformancePack.ConformancePackInputParameter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconformancepack-conformancepackinputparameter.html
+type OrganizationConformancePack_ConformancePackInputParameter struct {
+
+	// ParameterName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconformancepack-conformancepackinputparameter.html#cfn-config-organizationconformancepack-conformancepackinputparameter-parametername
+	ParameterName string `json:"ParameterName,omitempty"`
+
+	// ParameterValue AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-organizationconformancepack-conformancepackinputparameter.html#cfn-config-organizationconformancepack-conformancepackinputparameter-parametervalue
+	ParameterValue string `json:"ParameterValue,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *OrganizationConformancePack_ConformancePackInputParameter) AWSCloudFormationType() string {
+	return "AWS::Config::OrganizationConformancePack.ConformancePackInputParameter"
+}

--- a/cloudformation/ec2/aws-ec2-localgatewayroute.go
+++ b/cloudformation/ec2/aws-ec2-localgatewayroute.go
@@ -1,0 +1,107 @@
+package ec2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// LocalGatewayRoute AWS CloudFormation Resource (AWS::EC2::LocalGatewayRoute)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroute.html
+type LocalGatewayRoute struct {
+
+	// DestinationCidrBlock AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroute.html#cfn-ec2-localgatewayroute-destinationcidrblock
+	DestinationCidrBlock string `json:"DestinationCidrBlock,omitempty"`
+
+	// LocalGatewayRouteTableId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroute.html#cfn-ec2-localgatewayroute-localgatewayroutetableid
+	LocalGatewayRouteTableId string `json:"LocalGatewayRouteTableId,omitempty"`
+
+	// LocalGatewayVirtualInterfaceGroupId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroute.html#cfn-ec2-localgatewayroute-localgatewayvirtualinterfacegroupid
+	LocalGatewayVirtualInterfaceGroupId string `json:"LocalGatewayVirtualInterfaceGroupId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *LocalGatewayRoute) AWSCloudFormationType() string {
+	return "AWS::EC2::LocalGatewayRoute"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r LocalGatewayRoute) MarshalJSON() ([]byte, error) {
+	type Properties LocalGatewayRoute
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		Condition      string                  `json:"Condition,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		Condition:      r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *LocalGatewayRoute) UnmarshalJSON(b []byte) error {
+	type Properties LocalGatewayRoute
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+		Condition      string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = LocalGatewayRoute(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/ec2/aws-ec2-localgatewayroutetablevpcassociation.go
+++ b/cloudformation/ec2/aws-ec2-localgatewayroutetablevpcassociation.go
@@ -1,0 +1,107 @@
+package ec2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// LocalGatewayRouteTableVPCAssociation AWS CloudFormation Resource (AWS::EC2::LocalGatewayRouteTableVPCAssociation)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroutetablevpcassociation.html
+type LocalGatewayRouteTableVPCAssociation struct {
+
+	// LocalGatewayRouteTableId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroutetablevpcassociation.html#cfn-ec2-localgatewayroutetablevpcassociation-localgatewayroutetableid
+	LocalGatewayRouteTableId string `json:"LocalGatewayRouteTableId,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroutetablevpcassociation.html#cfn-ec2-localgatewayroutetablevpcassociation-tags
+	Tags *LocalGatewayRouteTableVPCAssociation_Tags `json:"Tags,omitempty"`
+
+	// VpcId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-localgatewayroutetablevpcassociation.html#cfn-ec2-localgatewayroutetablevpcassociation-vpcid
+	VpcId string `json:"VpcId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *LocalGatewayRouteTableVPCAssociation) AWSCloudFormationType() string {
+	return "AWS::EC2::LocalGatewayRouteTableVPCAssociation"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r LocalGatewayRouteTableVPCAssociation) MarshalJSON() ([]byte, error) {
+	type Properties LocalGatewayRouteTableVPCAssociation
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		Condition      string                  `json:"Condition,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		Condition:      r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *LocalGatewayRouteTableVPCAssociation) UnmarshalJSON(b []byte) error {
+	type Properties LocalGatewayRouteTableVPCAssociation
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+		Condition      string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = LocalGatewayRouteTableVPCAssociation(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/ec2/aws-ec2-localgatewayroutetablevpcassociation_tags.go
+++ b/cloudformation/ec2/aws-ec2-localgatewayroutetablevpcassociation_tags.go
@@ -1,0 +1,33 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// LocalGatewayRouteTableVPCAssociation_Tags AWS CloudFormation Resource (AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-localgatewayroutetablevpcassociation-tags.html
+type LocalGatewayRouteTableVPCAssociation_Tags struct {
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-localgatewayroutetablevpcassociation-tags.html#cfn-ec2-localgatewayroutetablevpcassociation-tags-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *LocalGatewayRouteTableVPCAssociation_Tags) AWSCloudFormationType() string {
+	return "AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags"
+}

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_action.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_action.go
@@ -23,6 +23,11 @@ type Listener_Action struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-defaultactions.html#cfn-elasticloadbalancingv2-listener-action-fixedresponseconfig
 	FixedResponseConfig *Listener_FixedResponseConfig `json:"FixedResponseConfig,omitempty"`
 
+	// ForwardConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-defaultactions.html#cfn-elasticloadbalancingv2-listener-action-forwardconfig
+	ForwardConfig *Listener_ForwardConfig `json:"ForwardConfig,omitempty"`
+
 	// Order AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-defaultactions.html#cfn-elasticloadbalancingv2-listener-action-order

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_forwardconfig.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_forwardconfig.go
@@ -1,0 +1,37 @@
+package elasticloadbalancingv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Listener_ForwardConfig AWS CloudFormation Resource (AWS::ElasticLoadBalancingV2::Listener.ForwardConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-forwardconfig.html
+type Listener_ForwardConfig struct {
+
+	// TargetGroupStickinessConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-forwardconfig.html#cfn-elasticloadbalancingv2-listener-forwardconfig-targetgroupstickinessconfig
+	TargetGroupStickinessConfig *Listener_TargetGroupStickinessConfig `json:"TargetGroupStickinessConfig,omitempty"`
+
+	// TargetGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-forwardconfig.html#cfn-elasticloadbalancingv2-listener-forwardconfig-targetgroups
+	TargetGroups []Listener_TargetGroupTuple `json:"TargetGroups,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Listener_ForwardConfig) AWSCloudFormationType() string {
+	return "AWS::ElasticLoadBalancingV2::Listener.ForwardConfig"
+}

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_targetgroupstickinessconfig.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_targetgroupstickinessconfig.go
@@ -1,0 +1,37 @@
+package elasticloadbalancingv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Listener_TargetGroupStickinessConfig AWS CloudFormation Resource (AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-targetgroupstickinessconfig.html
+type Listener_TargetGroupStickinessConfig struct {
+
+	// DurationSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-targetgroupstickinessconfig.html#cfn-elasticloadbalancingv2-listener-targetgroupstickinessconfig-durationseconds
+	DurationSeconds int `json:"DurationSeconds,omitempty"`
+
+	// Enabled AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-targetgroupstickinessconfig.html#cfn-elasticloadbalancingv2-listener-targetgroupstickinessconfig-enabled
+	Enabled bool `json:"Enabled,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Listener_TargetGroupStickinessConfig) AWSCloudFormationType() string {
+	return "AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig"
+}

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_targetgrouptuple.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listener_targetgrouptuple.go
@@ -1,0 +1,37 @@
+package elasticloadbalancingv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Listener_TargetGroupTuple AWS CloudFormation Resource (AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-targetgrouptuple.html
+type Listener_TargetGroupTuple struct {
+
+	// TargetGroupArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-targetgrouptuple.html#cfn-elasticloadbalancingv2-listener-targetgrouptuple-targetgrouparn
+	TargetGroupArn string `json:"TargetGroupArn,omitempty"`
+
+	// Weight AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-targetgrouptuple.html#cfn-elasticloadbalancingv2-listener-targetgrouptuple-weight
+	Weight int `json:"Weight,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Listener_TargetGroupTuple) AWSCloudFormationType() string {
+	return "AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple"
+}

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_action.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_action.go
@@ -23,6 +23,11 @@ type ListenerRule_Action struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-actions.html#cfn-elasticloadbalancingv2-listenerrule-action-fixedresponseconfig
 	FixedResponseConfig *ListenerRule_FixedResponseConfig `json:"FixedResponseConfig,omitempty"`
 
+	// ForwardConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-actions.html#cfn-elasticloadbalancingv2-listenerrule-action-forwardconfig
+	ForwardConfig *ListenerRule_ForwardConfig `json:"ForwardConfig,omitempty"`
+
 	// Order AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-actions.html#cfn-elasticloadbalancingv2-listenerrule-action-order

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_forwardconfig.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_forwardconfig.go
@@ -1,0 +1,37 @@
+package elasticloadbalancingv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ListenerRule_ForwardConfig AWS CloudFormation Resource (AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-forwardconfig.html
+type ListenerRule_ForwardConfig struct {
+
+	// TargetGroupStickinessConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-forwardconfig.html#cfn-elasticloadbalancingv2-listenerrule-forwardconfig-targetgroupstickinessconfig
+	TargetGroupStickinessConfig *ListenerRule_TargetGroupStickinessConfig `json:"TargetGroupStickinessConfig,omitempty"`
+
+	// TargetGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-forwardconfig.html#cfn-elasticloadbalancingv2-listenerrule-forwardconfig-targetgroups
+	TargetGroups []ListenerRule_TargetGroupTuple `json:"TargetGroups,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ListenerRule_ForwardConfig) AWSCloudFormationType() string {
+	return "AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig"
+}

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_targetgroupstickinessconfig.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_targetgroupstickinessconfig.go
@@ -1,0 +1,37 @@
+package elasticloadbalancingv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ListenerRule_TargetGroupStickinessConfig AWS CloudFormation Resource (AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-targetgroupstickinessconfig.html
+type ListenerRule_TargetGroupStickinessConfig struct {
+
+	// DurationSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-targetgroupstickinessconfig.html#cfn-elasticloadbalancingv2-listenerrule-targetgroupstickinessconfig-durationseconds
+	DurationSeconds int `json:"DurationSeconds,omitempty"`
+
+	// Enabled AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-targetgroupstickinessconfig.html#cfn-elasticloadbalancingv2-listenerrule-targetgroupstickinessconfig-enabled
+	Enabled bool `json:"Enabled,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ListenerRule_TargetGroupStickinessConfig) AWSCloudFormationType() string {
+	return "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig"
+}

--- a/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_targetgrouptuple.go
+++ b/cloudformation/elasticloadbalancingv2/aws-elasticloadbalancingv2-listenerrule_targetgrouptuple.go
@@ -1,0 +1,37 @@
+package elasticloadbalancingv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ListenerRule_TargetGroupTuple AWS CloudFormation Resource (AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-targetgrouptuple.html
+type ListenerRule_TargetGroupTuple struct {
+
+	// TargetGroupArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-targetgrouptuple.html#cfn-elasticloadbalancingv2-listenerrule-targetgrouptuple-targetgrouparn
+	TargetGroupArn string `json:"TargetGroupArn,omitempty"`
+
+	// Weight AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-targetgrouptuple.html#cfn-elasticloadbalancingv2-listenerrule-targetgrouptuple-weight
+	Weight int `json:"Weight,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ListenerRule_TargetGroupTuple) AWSCloudFormationType() string {
+	return "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple"
+}

--- a/cloudformation/fms/aws-fms-notificationchannel.go
+++ b/cloudformation/fms/aws-fms-notificationchannel.go
@@ -1,0 +1,102 @@
+package fms
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NotificationChannel AWS CloudFormation Resource (AWS::FMS::NotificationChannel)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-notificationchannel.html
+type NotificationChannel struct {
+
+	// SnsRoleName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-notificationchannel.html#cfn-fms-notificationchannel-snsrolename
+	SnsRoleName string `json:"SnsRoleName,omitempty"`
+
+	// SnsTopicArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-notificationchannel.html#cfn-fms-notificationchannel-snstopicarn
+	SnsTopicArn string `json:"SnsTopicArn,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NotificationChannel) AWSCloudFormationType() string {
+	return "AWS::FMS::NotificationChannel"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r NotificationChannel) MarshalJSON() ([]byte, error) {
+	type Properties NotificationChannel
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		Condition      string                  `json:"Condition,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		Condition:      r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *NotificationChannel) UnmarshalJSON(b []byte) error {
+	type Properties NotificationChannel
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+		Condition      string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = NotificationChannel(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/fms/aws-fms-policy.go
+++ b/cloudformation/fms/aws-fms-policy.go
@@ -1,0 +1,147 @@
+package fms
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Policy AWS CloudFormation Resource (AWS::FMS::Policy)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html
+type Policy struct {
+
+	// DeleteAllPolicyResources AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-deleteallpolicyresources
+	DeleteAllPolicyResources bool `json:"DeleteAllPolicyResources,omitempty"`
+
+	// ExcludeMap AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-excludemap
+	ExcludeMap *Policy_IEMap `json:"ExcludeMap,omitempty"`
+
+	// ExcludeResourceTags AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-excluderesourcetags
+	ExcludeResourceTags bool `json:"ExcludeResourceTags"`
+
+	// IncludeMap AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-includemap
+	IncludeMap *Policy_IEMap `json:"IncludeMap,omitempty"`
+
+	// PolicyName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-policyname
+	PolicyName string `json:"PolicyName,omitempty"`
+
+	// RemediationEnabled AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-remediationenabled
+	RemediationEnabled bool `json:"RemediationEnabled"`
+
+	// ResourceTags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-resourcetags
+	ResourceTags []Policy_ResourceTag `json:"ResourceTags,omitempty"`
+
+	// ResourceType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-resourcetype
+	ResourceType string `json:"ResourceType,omitempty"`
+
+	// ResourceTypeList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-resourcetypelist
+	ResourceTypeList []string `json:"ResourceTypeList,omitempty"`
+
+	// SecurityServicePolicyData AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-securityservicepolicydata
+	SecurityServicePolicyData interface{} `json:"SecurityServicePolicyData,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fms-policy.html#cfn-fms-policy-tags
+	Tags []Policy_PolicyTag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Policy) AWSCloudFormationType() string {
+	return "AWS::FMS::Policy"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Policy) MarshalJSON() ([]byte, error) {
+	type Properties Policy
+	return json.Marshal(&struct {
+		Type           string
+		Properties     Properties
+		DependsOn      []string                `json:"DependsOn,omitempty"`
+		Metadata       map[string]interface{}  `json:"Metadata,omitempty"`
+		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		Condition      string                  `json:"Condition,omitempty"`
+	}{
+		Type:           r.AWSCloudFormationType(),
+		Properties:     (Properties)(r),
+		DependsOn:      r.AWSCloudFormationDependsOn,
+		Metadata:       r.AWSCloudFormationMetadata,
+		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		Condition:      r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Policy) UnmarshalJSON(b []byte) error {
+	type Properties Policy
+	res := &struct {
+		Type           string
+		Properties     *Properties
+		DependsOn      []string
+		Metadata       map[string]interface{}
+		DeletionPolicy string
+		Condition      string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Policy(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/fms/aws-fms-policy_iemap.go
+++ b/cloudformation/fms/aws-fms-policy_iemap.go
@@ -1,0 +1,32 @@
+package fms
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Policy_IEMap AWS CloudFormation Resource (AWS::FMS::Policy.IEMap)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-iemap.html
+type Policy_IEMap struct {
+
+	// ACCOUNT AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-iemap.html#cfn-fms-policy-iemap-account
+	ACCOUNT []string `json:"ACCOUNT,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Policy_IEMap) AWSCloudFormationType() string {
+	return "AWS::FMS::Policy.IEMap"
+}

--- a/cloudformation/fms/aws-fms-policy_policytag.go
+++ b/cloudformation/fms/aws-fms-policy_policytag.go
@@ -1,0 +1,37 @@
+package fms
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Policy_PolicyTag AWS CloudFormation Resource (AWS::FMS::Policy.PolicyTag)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-policytag.html
+type Policy_PolicyTag struct {
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-policytag.html#cfn-fms-policy-policytag-key
+	Key string `json:"Key,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-policytag.html#cfn-fms-policy-policytag-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Policy_PolicyTag) AWSCloudFormationType() string {
+	return "AWS::FMS::Policy.PolicyTag"
+}

--- a/cloudformation/fms/aws-fms-policy_resourcetag.go
+++ b/cloudformation/fms/aws-fms-policy_resourcetag.go
@@ -1,0 +1,37 @@
+package fms
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Policy_ResourceTag AWS CloudFormation Resource (AWS::FMS::Policy.ResourceTag)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-resourcetag.html
+type Policy_ResourceTag struct {
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-resourcetag.html#cfn-fms-policy-resourcetag-key
+	Key string `json:"Key,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fms-policy-resourcetag.html#cfn-fms-policy-resourcetag-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Policy_ResourceTag) AWSCloudFormationType() string {
+	return "AWS::FMS::Policy.ResourceTag"
+}

--- a/cloudformation/fsx/aws-fsx-filesystem_lustreconfiguration.go
+++ b/cloudformation/fsx/aws-fsx-filesystem_lustreconfiguration.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html
 type FileSystem_LustreConfiguration struct {
 
+	// DeploymentType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-deploymenttype
+	DeploymentType string `json:"DeploymentType,omitempty"`
+
 	// ExportPath AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-exportpath
@@ -22,6 +27,11 @@ type FileSystem_LustreConfiguration struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-importedfilechunksize
 	ImportedFileChunkSize int `json:"ImportedFileChunkSize,omitempty"`
+
+	// PerUnitStorageThroughput AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-perunitstoragethroughput
+	PerUnitStorageThroughput int `json:"PerUnitStorageThroughput,omitempty"`
 
 	// WeeklyMaintenanceStartTime AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/neptune/aws-neptune-dbcluster.go
+++ b/cloudformation/neptune/aws-neptune-dbcluster.go
@@ -38,10 +38,20 @@ type DBCluster struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-dbsubnetgroupname
 	DBSubnetGroupName string `json:"DBSubnetGroupName,omitempty"`
 
+	// DeletionProtection AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-deletionprotection
+	DeletionProtection bool `json:"DeletionProtection,omitempty"`
+
 	// EnableCloudwatchLogsExports AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-enablecloudwatchlogsexports
 	EnableCloudwatchLogsExports []string `json:"EnableCloudwatchLogsExports,omitempty"`
+
+	// EngineVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-engineversion
+	EngineVersion string `json:"EngineVersion,omitempty"`
 
 	// IamAuthEnabled AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-ipset.go
+++ b/cloudformation/wafv2/aws-wafv2-ipset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // IPSet AWS CloudFormation Resource (AWS::WAFv2::IPSet)
@@ -15,7 +16,7 @@ type IPSet struct {
 	// Addresses AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-addresses
-	Addresses *IPSet_IPAddresses `json:"Addresses,omitempty"`
+	Addresses []string `json:"Addresses,omitempty"`
 
 	// Description AWS CloudFormation Property
 	// Required: false
@@ -40,7 +41,7 @@ type IPSet struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-ipset.html#cfn-wafv2-ipset-tags
-	Tags *IPSet_TagList `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-regexpatternset.go
+++ b/cloudformation/wafv2/aws-wafv2-regexpatternset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // RegexPatternSet AWS CloudFormation Resource (AWS::WAFv2::RegexPatternSet)
@@ -25,7 +26,7 @@ type RegexPatternSet struct {
 	// RegularExpressionList AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-regularexpressionlist
-	RegularExpressionList *RegexPatternSet_RegularExpressionList `json:"RegularExpressionList,omitempty"`
+	RegularExpressionList []string `json:"RegularExpressionList,omitempty"`
 
 	// Scope AWS CloudFormation Property
 	// Required: true
@@ -35,7 +36,7 @@ type RegexPatternSet struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-tags
-	Tags *RegexPatternSet_TagList `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // RuleGroup AWS CloudFormation Resource (AWS::WAFv2::RuleGroup)
@@ -30,7 +31,7 @@ type RuleGroup struct {
 	// Rules AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-rules
-	Rules *RuleGroup_Rules `json:"Rules,omitempty"`
+	Rules []RuleGroup_Rule `json:"Rules,omitempty"`
 
 	// Scope AWS CloudFormation Property
 	// Required: true
@@ -40,7 +41,7 @@ type RuleGroup struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-rulegroup.html#cfn-wafv2-rulegroup-tags
-	Tags *RuleGroup_TagList `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// VisibilityConfig AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_andstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_andstatementone.go
@@ -9,9 +9,9 @@ import (
 type RuleGroup_AndStatementOne struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-andstatementone.html#cfn-wafv2-rulegroup-andstatementone-statements
-	Statements *RuleGroup_StatementTwos `json:"Statements,omitempty"`
+	Statements []RuleGroup_StatementTwo `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_andstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_andstatementtwo.go
@@ -9,9 +9,9 @@ import (
 type RuleGroup_AndStatementTwo struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-andstatementtwo.html#cfn-wafv2-rulegroup-andstatementtwo-statements
-	Statements *RuleGroup_StatementThrees `json:"Statements,omitempty"`
+	Statements []RuleGroup_StatementThree `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_bytematchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_bytematchstatement.go
@@ -9,17 +9,17 @@ import (
 type RuleGroup_ByteMatchStatement struct {
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-bytematchstatement.html#cfn-wafv2-rulegroup-bytematchstatement-fieldtomatch
 	FieldToMatch *RuleGroup_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// PositionalConstraint AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-bytematchstatement.html#cfn-wafv2-rulegroup-bytematchstatement-positionalconstraint
 	PositionalConstraint string `json:"PositionalConstraint,omitempty"`
 
 	// SearchString AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-bytematchstatement.html#cfn-wafv2-rulegroup-bytematchstatement-searchstring
 	SearchString string `json:"SearchString,omitempty"`
 
@@ -29,9 +29,9 @@ type RuleGroup_ByteMatchStatement struct {
 	SearchStringBase64 string `json:"SearchStringBase64,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-bytematchstatement.html#cfn-wafv2-rulegroup-bytematchstatement-texttransformations
-	TextTransformations *RuleGroup_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []RuleGroup_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_fieldtomatch.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_fieldtomatch.go
@@ -11,37 +11,37 @@ type RuleGroup_FieldToMatch struct {
 	// AllQueryArguments AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-allqueryarguments
-	AllQueryArguments *RuleGroup_AllQueryArguments `json:"AllQueryArguments,omitempty"`
+	AllQueryArguments interface{} `json:"AllQueryArguments,omitempty"`
 
 	// Body AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-body
-	Body *RuleGroup_Body `json:"Body,omitempty"`
+	Body interface{} `json:"Body,omitempty"`
 
 	// Method AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-method
-	Method *RuleGroup_Method `json:"Method,omitempty"`
+	Method interface{} `json:"Method,omitempty"`
 
 	// QueryString AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-querystring
-	QueryString *RuleGroup_QueryString `json:"QueryString,omitempty"`
+	QueryString interface{} `json:"QueryString,omitempty"`
 
 	// SingleHeader AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-singleheader
-	SingleHeader *RuleGroup_SingleHeader `json:"SingleHeader,omitempty"`
+	SingleHeader interface{} `json:"SingleHeader,omitempty"`
 
 	// SingleQueryArgument AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-singlequeryargument
-	SingleQueryArgument *RuleGroup_SingleQueryArgument `json:"SingleQueryArgument,omitempty"`
+	SingleQueryArgument interface{} `json:"SingleQueryArgument,omitempty"`
 
 	// UriPath AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-fieldtomatch.html#cfn-wafv2-rulegroup-fieldtomatch-uripath
-	UriPath *RuleGroup_UriPath `json:"UriPath,omitempty"`
+	UriPath interface{} `json:"UriPath,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_geomatchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_geomatchstatement.go
@@ -11,7 +11,7 @@ type RuleGroup_GeoMatchStatement struct {
 	// CountryCodes AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-geomatchstatement.html#cfn-wafv2-rulegroup-geomatchstatement-countrycodes
-	CountryCodes *RuleGroup_CountryCodes `json:"CountryCodes,omitempty"`
+	CountryCodes []string `json:"CountryCodes,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_ipsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_ipsetreferencestatement.go
@@ -9,7 +9,7 @@ import (
 type RuleGroup_IPSetReferenceStatement struct {
 
 	// Arn AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ipsetreferencestatement.html#cfn-wafv2-rulegroup-ipsetreferencestatement-arn
 	Arn string `json:"Arn,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_notstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_notstatementone.go
@@ -9,7 +9,7 @@ import (
 type RuleGroup_NotStatementOne struct {
 
 	// Statement AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-notstatementone.html#cfn-wafv2-rulegroup-notstatementone-statement
 	Statement *RuleGroup_StatementTwo `json:"Statement,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_notstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_notstatementtwo.go
@@ -9,7 +9,7 @@ import (
 type RuleGroup_NotStatementTwo struct {
 
 	// Statement AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-notstatementtwo.html#cfn-wafv2-rulegroup-notstatementtwo-statement
 	Statement *RuleGroup_StatementThree `json:"Statement,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_orstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_orstatementone.go
@@ -9,9 +9,9 @@ import (
 type RuleGroup_OrStatementOne struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-orstatementone.html#cfn-wafv2-rulegroup-orstatementone-statements
-	Statements *RuleGroup_StatementTwos `json:"Statements,omitempty"`
+	Statements []RuleGroup_StatementTwo `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_orstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_orstatementtwo.go
@@ -9,9 +9,9 @@ import (
 type RuleGroup_OrStatementTwo struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-orstatementtwo.html#cfn-wafv2-rulegroup-orstatementtwo-statements
-	Statements *RuleGroup_StatementThrees `json:"Statements,omitempty"`
+	Statements []RuleGroup_StatementThree `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_ratebasedstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_ratebasedstatementone.go
@@ -9,14 +9,14 @@ import (
 type RuleGroup_RateBasedStatementOne struct {
 
 	// AggregateKeyType AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ratebasedstatementone.html#cfn-wafv2-rulegroup-ratebasedstatementone-aggregatekeytype
 	AggregateKeyType string `json:"AggregateKeyType,omitempty"`
 
 	// Limit AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ratebasedstatementone.html#cfn-wafv2-rulegroup-ratebasedstatementone-limit
-	Limit int `json:"Limit,omitempty"`
+	Limit int `json:"Limit"`
 
 	// ScopeDownStatement AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_ratebasedstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_ratebasedstatementtwo.go
@@ -9,14 +9,14 @@ import (
 type RuleGroup_RateBasedStatementTwo struct {
 
 	// AggregateKeyType AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ratebasedstatementtwo.html#cfn-wafv2-rulegroup-ratebasedstatementtwo-aggregatekeytype
 	AggregateKeyType string `json:"AggregateKeyType,omitempty"`
 
 	// Limit AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ratebasedstatementtwo.html#cfn-wafv2-rulegroup-ratebasedstatementtwo-limit
-	Limit int `json:"Limit,omitempty"`
+	Limit int `json:"Limit"`
 
 	// ScopeDownStatement AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_regexpatternsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_regexpatternsetreferencestatement.go
@@ -9,19 +9,19 @@ import (
 type RuleGroup_RegexPatternSetReferenceStatement struct {
 
 	// Arn AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-regexpatternsetreferencestatement.html#cfn-wafv2-rulegroup-regexpatternsetreferencestatement-arn
 	Arn string `json:"Arn,omitempty"`
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-regexpatternsetreferencestatement.html#cfn-wafv2-rulegroup-regexpatternsetreferencestatement-fieldtomatch
 	FieldToMatch *RuleGroup_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-regexpatternsetreferencestatement.html#cfn-wafv2-rulegroup-regexpatternsetreferencestatement-texttransformations
-	TextTransformations *RuleGroup_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []RuleGroup_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_rule.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_rule.go
@@ -14,22 +14,22 @@ type RuleGroup_Rule struct {
 	Action *RuleGroup_RuleAction `json:"Action,omitempty"`
 
 	// Name AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-rule.html#cfn-wafv2-rulegroup-rule-name
 	Name string `json:"Name,omitempty"`
 
 	// Priority AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-rule.html#cfn-wafv2-rulegroup-rule-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// Statement AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-rule.html#cfn-wafv2-rulegroup-rule-statement
 	Statement *RuleGroup_StatementOne `json:"Statement,omitempty"`
 
 	// VisibilityConfig AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-rule.html#cfn-wafv2-rulegroup-rule-visibilityconfig
 	VisibilityConfig *RuleGroup_VisibilityConfig `json:"VisibilityConfig,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_ruleaction.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_ruleaction.go
@@ -11,17 +11,17 @@ type RuleGroup_RuleAction struct {
 	// Allow AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ruleaction.html#cfn-wafv2-rulegroup-ruleaction-allow
-	Allow *RuleGroup_AllowAction `json:"Allow,omitempty"`
+	Allow interface{} `json:"Allow,omitempty"`
 
 	// Block AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ruleaction.html#cfn-wafv2-rulegroup-ruleaction-block
-	Block *RuleGroup_BlockAction `json:"Block,omitempty"`
+	Block interface{} `json:"Block,omitempty"`
 
 	// Count AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ruleaction.html#cfn-wafv2-rulegroup-ruleaction-count
-	Count *RuleGroup_CountAction `json:"Count,omitempty"`
+	Count interface{} `json:"Count,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_sizeconstraintstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_sizeconstraintstatement.go
@@ -9,24 +9,24 @@ import (
 type RuleGroup_SizeConstraintStatement struct {
 
 	// ComparisonOperator AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-sizeconstraintstatement.html#cfn-wafv2-rulegroup-sizeconstraintstatement-comparisonoperator
 	ComparisonOperator string `json:"ComparisonOperator,omitempty"`
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-sizeconstraintstatement.html#cfn-wafv2-rulegroup-sizeconstraintstatement-fieldtomatch
 	FieldToMatch *RuleGroup_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// Size AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-sizeconstraintstatement.html#cfn-wafv2-rulegroup-sizeconstraintstatement-size
-	Size int `json:"Size,omitempty"`
+	Size int `json:"Size"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-sizeconstraintstatement.html#cfn-wafv2-rulegroup-sizeconstraintstatement-texttransformations
-	TextTransformations *RuleGroup_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []RuleGroup_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_sqlimatchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_sqlimatchstatement.go
@@ -9,14 +9,14 @@ import (
 type RuleGroup_SqliMatchStatement struct {
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-sqlimatchstatement.html#cfn-wafv2-rulegroup-sqlimatchstatement-fieldtomatch
 	FieldToMatch *RuleGroup_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-sqlimatchstatement.html#cfn-wafv2-rulegroup-sqlimatchstatement-texttransformations
-	TextTransformations *RuleGroup_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []RuleGroup_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_texttransformation.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_texttransformation.go
@@ -9,12 +9,12 @@ import (
 type RuleGroup_TextTransformation struct {
 
 	// Priority AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-texttransformation.html#cfn-wafv2-rulegroup-texttransformation-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// Type AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-texttransformation.html#cfn-wafv2-rulegroup-texttransformation-type
 	Type string `json:"Type,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_visibilityconfig.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_visibilityconfig.go
@@ -9,19 +9,19 @@ import (
 type RuleGroup_VisibilityConfig struct {
 
 	// CloudWatchMetricsEnabled AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-visibilityconfig.html#cfn-wafv2-rulegroup-visibilityconfig-cloudwatchmetricsenabled
-	CloudWatchMetricsEnabled bool `json:"CloudWatchMetricsEnabled,omitempty"`
+	CloudWatchMetricsEnabled bool `json:"CloudWatchMetricsEnabled"`
 
 	// MetricName AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-visibilityconfig.html#cfn-wafv2-rulegroup-visibilityconfig-metricname
 	MetricName string `json:"MetricName,omitempty"`
 
 	// SampledRequestsEnabled AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-visibilityconfig.html#cfn-wafv2-rulegroup-visibilityconfig-sampledrequestsenabled
-	SampledRequestsEnabled bool `json:"SampledRequestsEnabled,omitempty"`
+	SampledRequestsEnabled bool `json:"SampledRequestsEnabled"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-rulegroup_xssmatchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-rulegroup_xssmatchstatement.go
@@ -9,14 +9,14 @@ import (
 type RuleGroup_XssMatchStatement struct {
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-xssmatchstatement.html#cfn-wafv2-rulegroup-xssmatchstatement-fieldtomatch
 	FieldToMatch *RuleGroup_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-xssmatchstatement.html#cfn-wafv2-rulegroup-xssmatchstatement-texttransformations
-	TextTransformations *RuleGroup_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []RuleGroup_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // WebACL AWS CloudFormation Resource (AWS::WAFv2::WebACL)
@@ -30,7 +31,7 @@ type WebACL struct {
 	// Rules AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-rules
-	Rules *WebACL_Rules `json:"Rules,omitempty"`
+	Rules []WebACL_Rule `json:"Rules,omitempty"`
 
 	// Scope AWS CloudFormation Property
 	// Required: true
@@ -40,7 +41,7 @@ type WebACL struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html#cfn-wafv2-webacl-tags
-	Tags *WebACL_TagList `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// VisibilityConfig AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/wafv2/aws-wafv2-webacl_andstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_andstatementone.go
@@ -9,9 +9,9 @@ import (
 type WebACL_AndStatementOne struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-andstatementone.html#cfn-wafv2-webacl-andstatementone-statements
-	Statements *WebACL_StatementTwos `json:"Statements,omitempty"`
+	Statements []WebACL_StatementTwo `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_andstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_andstatementtwo.go
@@ -9,9 +9,9 @@ import (
 type WebACL_AndStatementTwo struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-andstatementtwo.html#cfn-wafv2-webacl-andstatementtwo-statements
-	Statements *WebACL_StatementThrees `json:"Statements,omitempty"`
+	Statements []WebACL_StatementThree `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_bytematchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_bytematchstatement.go
@@ -9,17 +9,17 @@ import (
 type WebACL_ByteMatchStatement struct {
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-bytematchstatement.html#cfn-wafv2-webacl-bytematchstatement-fieldtomatch
 	FieldToMatch *WebACL_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// PositionalConstraint AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-bytematchstatement.html#cfn-wafv2-webacl-bytematchstatement-positionalconstraint
 	PositionalConstraint string `json:"PositionalConstraint,omitempty"`
 
 	// SearchString AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-bytematchstatement.html#cfn-wafv2-webacl-bytematchstatement-searchstring
 	SearchString string `json:"SearchString,omitempty"`
 
@@ -29,9 +29,9 @@ type WebACL_ByteMatchStatement struct {
 	SearchStringBase64 string `json:"SearchStringBase64,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-bytematchstatement.html#cfn-wafv2-webacl-bytematchstatement-texttransformations
-	TextTransformations *WebACL_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []WebACL_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_defaultaction.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_defaultaction.go
@@ -11,12 +11,12 @@ type WebACL_DefaultAction struct {
 	// Allow AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-defaultaction.html#cfn-wafv2-webacl-defaultaction-allow
-	Allow *WebACL_AllowAction `json:"Allow,omitempty"`
+	Allow interface{} `json:"Allow,omitempty"`
 
 	// Block AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-defaultaction.html#cfn-wafv2-webacl-defaultaction-block
-	Block *WebACL_BlockAction `json:"Block,omitempty"`
+	Block interface{} `json:"Block,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_excludedrule.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_excludedrule.go
@@ -9,7 +9,7 @@ import (
 type WebACL_ExcludedRule struct {
 
 	// Name AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-excludedrule.html#cfn-wafv2-webacl-excludedrule-name
 	Name string `json:"Name,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_fieldtomatch.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_fieldtomatch.go
@@ -11,37 +11,37 @@ type WebACL_FieldToMatch struct {
 	// AllQueryArguments AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-allqueryarguments
-	AllQueryArguments *WebACL_AllQueryArguments `json:"AllQueryArguments,omitempty"`
+	AllQueryArguments interface{} `json:"AllQueryArguments,omitempty"`
 
 	// Body AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-body
-	Body *WebACL_Body `json:"Body,omitempty"`
+	Body interface{} `json:"Body,omitempty"`
 
 	// Method AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-method
-	Method *WebACL_Method `json:"Method,omitempty"`
+	Method interface{} `json:"Method,omitempty"`
 
 	// QueryString AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-querystring
-	QueryString *WebACL_QueryString `json:"QueryString,omitempty"`
+	QueryString interface{} `json:"QueryString,omitempty"`
 
 	// SingleHeader AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-singleheader
-	SingleHeader *WebACL_SingleHeader `json:"SingleHeader,omitempty"`
+	SingleHeader interface{} `json:"SingleHeader,omitempty"`
 
 	// SingleQueryArgument AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-singlequeryargument
-	SingleQueryArgument *WebACL_SingleQueryArgument `json:"SingleQueryArgument,omitempty"`
+	SingleQueryArgument interface{} `json:"SingleQueryArgument,omitempty"`
 
 	// UriPath AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-fieldtomatch.html#cfn-wafv2-webacl-fieldtomatch-uripath
-	UriPath *WebACL_UriPath `json:"UriPath,omitempty"`
+	UriPath interface{} `json:"UriPath,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_geomatchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_geomatchstatement.go
@@ -11,7 +11,7 @@ type WebACL_GeoMatchStatement struct {
 	// CountryCodes AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-geomatchstatement.html#cfn-wafv2-webacl-geomatchstatement-countrycodes
-	CountryCodes *WebACL_CountryCodes `json:"CountryCodes,omitempty"`
+	CountryCodes []string `json:"CountryCodes,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_ipsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_ipsetreferencestatement.go
@@ -9,7 +9,7 @@ import (
 type WebACL_IPSetReferenceStatement struct {
 
 	// Arn AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ipsetreferencestatement.html#cfn-wafv2-webacl-ipsetreferencestatement-arn
 	Arn string `json:"Arn,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_managedrulegroupstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_managedrulegroupstatement.go
@@ -11,15 +11,15 @@ type WebACL_ManagedRuleGroupStatement struct {
 	// ExcludedRules AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-managedrulegroupstatement.html#cfn-wafv2-webacl-managedrulegroupstatement-excludedrules
-	ExcludedRules *WebACL_ExcludedRules `json:"ExcludedRules,omitempty"`
+	ExcludedRules []WebACL_ExcludedRule `json:"ExcludedRules,omitempty"`
 
 	// Name AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-managedrulegroupstatement.html#cfn-wafv2-webacl-managedrulegroupstatement-name
 	Name string `json:"Name,omitempty"`
 
 	// VendorName AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-managedrulegroupstatement.html#cfn-wafv2-webacl-managedrulegroupstatement-vendorname
 	VendorName string `json:"VendorName,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_notstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_notstatementone.go
@@ -9,7 +9,7 @@ import (
 type WebACL_NotStatementOne struct {
 
 	// Statement AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-notstatementone.html#cfn-wafv2-webacl-notstatementone-statement
 	Statement *WebACL_StatementTwo `json:"Statement,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_notstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_notstatementtwo.go
@@ -9,7 +9,7 @@ import (
 type WebACL_NotStatementTwo struct {
 
 	// Statement AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-notstatementtwo.html#cfn-wafv2-webacl-notstatementtwo-statement
 	Statement *WebACL_StatementThree `json:"Statement,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_orstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_orstatementone.go
@@ -9,9 +9,9 @@ import (
 type WebACL_OrStatementOne struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-orstatementone.html#cfn-wafv2-webacl-orstatementone-statements
-	Statements *WebACL_StatementTwos `json:"Statements,omitempty"`
+	Statements []WebACL_StatementTwo `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_orstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_orstatementtwo.go
@@ -9,9 +9,9 @@ import (
 type WebACL_OrStatementTwo struct {
 
 	// Statements AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-orstatementtwo.html#cfn-wafv2-webacl-orstatementtwo-statements
-	Statements *WebACL_StatementThrees `json:"Statements,omitempty"`
+	Statements []WebACL_StatementThree `json:"Statements,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_overrideaction.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_overrideaction.go
@@ -11,12 +11,12 @@ type WebACL_OverrideAction struct {
 	// Count AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-overrideaction.html#cfn-wafv2-webacl-overrideaction-count
-	Count *WebACL_CountAction `json:"Count,omitempty"`
+	Count interface{} `json:"Count,omitempty"`
 
 	// None AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-overrideaction.html#cfn-wafv2-webacl-overrideaction-none
-	None *WebACL_NoneAction `json:"None,omitempty"`
+	None interface{} `json:"None,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_ratebasedstatementone.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_ratebasedstatementone.go
@@ -9,14 +9,14 @@ import (
 type WebACL_RateBasedStatementOne struct {
 
 	// AggregateKeyType AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ratebasedstatementone.html#cfn-wafv2-webacl-ratebasedstatementone-aggregatekeytype
 	AggregateKeyType string `json:"AggregateKeyType,omitempty"`
 
 	// Limit AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ratebasedstatementone.html#cfn-wafv2-webacl-ratebasedstatementone-limit
-	Limit int `json:"Limit,omitempty"`
+	Limit int `json:"Limit"`
 
 	// ScopeDownStatement AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-webacl_ratebasedstatementtwo.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_ratebasedstatementtwo.go
@@ -9,14 +9,14 @@ import (
 type WebACL_RateBasedStatementTwo struct {
 
 	// AggregateKeyType AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ratebasedstatementtwo.html#cfn-wafv2-webacl-ratebasedstatementtwo-aggregatekeytype
 	AggregateKeyType string `json:"AggregateKeyType,omitempty"`
 
 	// Limit AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ratebasedstatementtwo.html#cfn-wafv2-webacl-ratebasedstatementtwo-limit
-	Limit int `json:"Limit,omitempty"`
+	Limit int `json:"Limit"`
 
 	// ScopeDownStatement AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/wafv2/aws-wafv2-webacl_regexpatternsetreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_regexpatternsetreferencestatement.go
@@ -9,19 +9,19 @@ import (
 type WebACL_RegexPatternSetReferenceStatement struct {
 
 	// Arn AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-regexpatternsetreferencestatement.html#cfn-wafv2-webacl-regexpatternsetreferencestatement-arn
 	Arn string `json:"Arn,omitempty"`
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-regexpatternsetreferencestatement.html#cfn-wafv2-webacl-regexpatternsetreferencestatement-fieldtomatch
 	FieldToMatch *WebACL_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-regexpatternsetreferencestatement.html#cfn-wafv2-webacl-regexpatternsetreferencestatement-texttransformations
-	TextTransformations *WebACL_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []WebACL_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_rule.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_rule.go
@@ -14,7 +14,7 @@ type WebACL_Rule struct {
 	Action *WebACL_RuleAction `json:"Action,omitempty"`
 
 	// Name AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rule.html#cfn-wafv2-webacl-rule-name
 	Name string `json:"Name,omitempty"`
 
@@ -24,17 +24,17 @@ type WebACL_Rule struct {
 	OverrideAction *WebACL_OverrideAction `json:"OverrideAction,omitempty"`
 
 	// Priority AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rule.html#cfn-wafv2-webacl-rule-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// Statement AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rule.html#cfn-wafv2-webacl-rule-statement
 	Statement *WebACL_StatementOne `json:"Statement,omitempty"`
 
 	// VisibilityConfig AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rule.html#cfn-wafv2-webacl-rule-visibilityconfig
 	VisibilityConfig *WebACL_VisibilityConfig `json:"VisibilityConfig,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_ruleaction.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_ruleaction.go
@@ -11,17 +11,17 @@ type WebACL_RuleAction struct {
 	// Allow AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ruleaction.html#cfn-wafv2-webacl-ruleaction-allow
-	Allow *WebACL_AllowAction `json:"Allow,omitempty"`
+	Allow interface{} `json:"Allow,omitempty"`
 
 	// Block AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ruleaction.html#cfn-wafv2-webacl-ruleaction-block
-	Block *WebACL_BlockAction `json:"Block,omitempty"`
+	Block interface{} `json:"Block,omitempty"`
 
 	// Count AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-ruleaction.html#cfn-wafv2-webacl-ruleaction-count
-	Count *WebACL_CountAction `json:"Count,omitempty"`
+	Count interface{} `json:"Count,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_rulegroupreferencestatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_rulegroupreferencestatement.go
@@ -9,14 +9,14 @@ import (
 type WebACL_RuleGroupReferenceStatement struct {
 
 	// Arn AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rulegroupreferencestatement.html#cfn-wafv2-webacl-rulegroupreferencestatement-arn
 	Arn string `json:"Arn,omitempty"`
 
 	// ExcludedRules AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rulegroupreferencestatement.html#cfn-wafv2-webacl-rulegroupreferencestatement-excludedrules
-	ExcludedRules *WebACL_ExcludedRules `json:"ExcludedRules,omitempty"`
+	ExcludedRules []WebACL_ExcludedRule `json:"ExcludedRules,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_sizeconstraintstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_sizeconstraintstatement.go
@@ -9,24 +9,24 @@ import (
 type WebACL_SizeConstraintStatement struct {
 
 	// ComparisonOperator AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-sizeconstraintstatement.html#cfn-wafv2-webacl-sizeconstraintstatement-comparisonoperator
 	ComparisonOperator string `json:"ComparisonOperator,omitempty"`
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-sizeconstraintstatement.html#cfn-wafv2-webacl-sizeconstraintstatement-fieldtomatch
 	FieldToMatch *WebACL_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// Size AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-sizeconstraintstatement.html#cfn-wafv2-webacl-sizeconstraintstatement-size
-	Size int `json:"Size,omitempty"`
+	Size int `json:"Size"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-sizeconstraintstatement.html#cfn-wafv2-webacl-sizeconstraintstatement-texttransformations
-	TextTransformations *WebACL_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []WebACL_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_sqlimatchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_sqlimatchstatement.go
@@ -9,14 +9,14 @@ import (
 type WebACL_SqliMatchStatement struct {
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-sqlimatchstatement.html#cfn-wafv2-webacl-sqlimatchstatement-fieldtomatch
 	FieldToMatch *WebACL_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-sqlimatchstatement.html#cfn-wafv2-webacl-sqlimatchstatement-texttransformations
-	TextTransformations *WebACL_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []WebACL_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_texttransformation.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_texttransformation.go
@@ -9,12 +9,12 @@ import (
 type WebACL_TextTransformation struct {
 
 	// Priority AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-texttransformation.html#cfn-wafv2-webacl-texttransformation-priority
-	Priority int `json:"Priority,omitempty"`
+	Priority int `json:"Priority"`
 
 	// Type AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-texttransformation.html#cfn-wafv2-webacl-texttransformation-type
 	Type string `json:"Type,omitempty"`
 

--- a/cloudformation/wafv2/aws-wafv2-webacl_visibilityconfig.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_visibilityconfig.go
@@ -9,19 +9,19 @@ import (
 type WebACL_VisibilityConfig struct {
 
 	// CloudWatchMetricsEnabled AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-visibilityconfig.html#cfn-wafv2-webacl-visibilityconfig-cloudwatchmetricsenabled
-	CloudWatchMetricsEnabled bool `json:"CloudWatchMetricsEnabled,omitempty"`
+	CloudWatchMetricsEnabled bool `json:"CloudWatchMetricsEnabled"`
 
 	// MetricName AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-visibilityconfig.html#cfn-wafv2-webacl-visibilityconfig-metricname
 	MetricName string `json:"MetricName,omitempty"`
 
 	// SampledRequestsEnabled AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-visibilityconfig.html#cfn-wafv2-webacl-visibilityconfig-sampledrequestsenabled
-	SampledRequestsEnabled bool `json:"SampledRequestsEnabled,omitempty"`
+	SampledRequestsEnabled bool `json:"SampledRequestsEnabled"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/wafv2/aws-wafv2-webacl_xssmatchstatement.go
+++ b/cloudformation/wafv2/aws-wafv2-webacl_xssmatchstatement.go
@@ -9,14 +9,14 @@ import (
 type WebACL_XssMatchStatement struct {
 
 	// FieldToMatch AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-xssmatchstatement.html#cfn-wafv2-webacl-xssmatchstatement-fieldtomatch
 	FieldToMatch *WebACL_FieldToMatch `json:"FieldToMatch,omitempty"`
 
 	// TextTransformations AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-xssmatchstatement.html#cfn-wafv2-webacl-xssmatchstatement-texttransformations
-	TextTransformations *WebACL_TextTransformations `json:"TextTransformations,omitempty"`
+	TextTransformations []WebACL_TextTransformation `json:"TextTransformations,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/schema/cloudformation.go
+++ b/schema/cloudformation.go
@@ -11507,6 +11507,12 @@ var CloudformationSchema = `{
                         "Environment": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
                         },
+                        "FileSystemLocations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeBuild::Project.ProjectFileSystemLocation"
+                            },
+                            "type": "array"
+                        },
                         "LogsConfig": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.LogsConfig"
                         },
@@ -11737,6 +11743,33 @@ var CloudformationSchema = `{
                 }
             },
             "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.ProjectFileSystemLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "Identifier": {
+                    "type": "string"
+                },
+                "Location": {
+                    "type": "string"
+                },
+                "MountOptions": {
+                    "type": "string"
+                },
+                "MountPoint": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Identifier",
+                "Location",
+                "MountPoint",
                 "Type"
             ],
             "type": "object"
@@ -13800,6 +13833,9 @@ var CloudformationSchema = `{
                             },
                             "type": "array"
                         },
+                        "UsernameConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.UsernameConfiguration"
+                        },
                         "VerificationMessageTemplate": {
                             "$ref": "#/definitions/AWS::Cognito::UserPool.VerificationMessageTemplate"
                         }
@@ -14042,6 +14078,15 @@ var CloudformationSchema = `{
             "properties": {
                 "AdvancedSecurityMode": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.UsernameConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CaseSensitive": {
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -14967,6 +15012,12 @@ var CloudformationSchema = `{
                         },
                         "AuthorizedAwsRegion": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15162,6 +15213,12 @@ var CloudformationSchema = `{
                         },
                         "OrganizationAggregationSource": {
                             "$ref": "#/definitions/AWS::Config::ConfigurationAggregator.OrganizationAggregationSource"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15303,6 +15360,95 @@ var CloudformationSchema = `{
                     "type": "array"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::ConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "ConformancePackName": {
+                            "type": "string"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConformancePackName",
+                        "DeliveryS3Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
+            ],
             "type": "object"
         },
         "AWS::Config::DeliveryChannel": {
@@ -15522,6 +15668,101 @@ var CloudformationSchema = `{
             },
             "required": [
                 "RuleIdentifier"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::OrganizationConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConformancePackName": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeliveryS3Bucket",
+                        "OrganizationConformancePackName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
             ],
             "type": "object"
         },
@@ -19916,6 +20157,141 @@ var CloudformationSchema = `{
                 "ResourceType": {
                     "type": "string"
                 },
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "LocalGatewayVirtualInterfaceGroupId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationCidrBlock",
+                        "LocalGatewayRouteTableId",
+                        "LocalGatewayVirtualInterfaceGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRoute"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LocalGatewayRouteTableId",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRouteTableVPCAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags": {
+            "additionalProperties": false,
+            "properties": {
                 "Tags": {
                     "items": {
                         "$ref": "#/definitions/Tag"
@@ -27850,6 +28226,9 @@ var CloudformationSchema = `{
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -27989,6 +28368,21 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::ElasticLoadBalancingV2::Listener.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::ElasticLoadBalancingV2::Listener.RedirectConfig": {
             "additionalProperties": false,
             "properties": {
@@ -28014,6 +28408,30 @@ var CloudformationSchema = `{
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
@@ -28170,6 +28588,9 @@ var CloudformationSchema = `{
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -28298,6 +28719,21 @@ var CloudformationSchema = `{
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule.HostHeaderConfig": {
@@ -28443,6 +28879,30 @@ var CloudformationSchema = `{
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -29626,6 +30086,204 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::FMS::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "SnsRoleName": {
+                            "type": "string"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "SnsRoleName",
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::NotificationChannel"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeleteAllPolicyResources": {
+                            "type": "boolean"
+                        },
+                        "ExcludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "ExcludeResourceTags": {
+                            "type": "boolean"
+                        },
+                        "IncludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "RemediationEnabled": {
+                            "type": "boolean"
+                        },
+                        "ResourceTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.ResourceTag"
+                            },
+                            "type": "array"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "ResourceTypeList": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityServicePolicyData": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.PolicyTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ExcludeResourceTags",
+                        "PolicyName",
+                        "RemediationEnabled",
+                        "ResourceType",
+                        "SecurityServicePolicyData"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::Policy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.IEMap": {
+            "additionalProperties": false,
+            "properties": {
+                "ACCOUNT": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::FMS::Policy.PolicyTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.ResourceTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::FSx::FileSystem": {
             "additionalProperties": false,
             "properties": {
@@ -29717,6 +30375,9 @@ var CloudformationSchema = `{
         "AWS::FSx::FileSystem.LustreConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentType": {
+                    "type": "string"
+                },
                 "ExportPath": {
                     "type": "string"
                 },
@@ -29724,6 +30385,9 @@ var CloudformationSchema = `{
                     "type": "string"
                 },
                 "ImportedFileChunkSize": {
+                    "type": "number"
+                },
+                "PerUnitStorageThroughput": {
                     "type": "number"
                 },
                 "WeeklyMaintenanceStartTime": {
@@ -43006,11 +43670,17 @@ var CloudformationSchema = `{
                         "DBSubnetGroupName": {
                             "type": "string"
                         },
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
                         "EnableCloudwatchLogsExports": {
                             "items": {
                                 "type": "string"
                             },
                             "type": "array"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -57341,7 +58011,10 @@ var CloudformationSchema = `{
                     "additionalProperties": false,
                     "properties": {
                         "Addresses": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Description": {
                             "type": "string"
@@ -57356,7 +58029,10 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -57377,30 +58053,6 @@ var CloudformationSchema = `{
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPAddresses": {
-            "additionalProperties": false,
-            "properties": {
-                "IPAddresses": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RegexPatternSet": {
@@ -57442,13 +58094,19 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "RegularExpressionList": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -57468,39 +58126,6 @@ var CloudformationSchema = `{
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.Regex": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexString": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegularExpressionList": {
-            "additionalProperties": false,
-            "properties": {
-                "RegularExpressionList": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.Regex"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup": {
@@ -57545,13 +58170,19 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
@@ -57577,42 +58208,34 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.ByteMatchStatement": {
@@ -57631,17 +58254,48 @@ var CloudformationSchema = `{
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFv2::RuleGroup.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "AllQueryArguments": {
+                    "type": "object"
+                },
+                "Body": {
+                    "type": "object"
+                },
+                "Method": {
+                    "type": "object"
+                },
+                "QueryString": {
+                    "type": "object"
+                },
+                "SingleHeader": {
+                    "type": "object"
+                },
+                "SingleQueryArgument": {
+                    "type": "object"
+                },
+                "UriPath": {
+                    "type": "object"
                 }
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.CountryCodes": {
+        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
@@ -57653,42 +58307,6 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.FieldToMatch": {
-            "additionalProperties": false,
-            "properties": {
-                "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllQueryArguments"
-                },
-                "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Body"
-                },
-                "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Method"
-                },
-                "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.QueryString"
-                },
-                "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleHeader"
-                },
-                "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleQueryArgument"
-                },
-                "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.UriPath"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountryCodes"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
@@ -57696,11 +58314,9 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Method": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementOne": {
@@ -57710,6 +58326,9 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementTwo": {
@@ -57719,29 +58338,39 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementOne": {
@@ -57757,6 +58386,10 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementTwo": {
@@ -57772,6 +58405,10 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
@@ -57784,9 +58421,17 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.Rule": {
@@ -57808,49 +58453,25 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -57868,9 +58489,18 @@ var CloudformationSchema = `{
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.SqliMatchStatement": {
@@ -57880,9 +58510,16 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.StatementOne": {
@@ -57951,18 +58588,6 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -58002,30 +58627,6 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -58036,23 +58637,10 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.VisibilityConfig": {
@@ -58068,6 +58656,11 @@ var CloudformationSchema = `{
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.XssMatchStatement": {
@@ -58077,9 +58670,16 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL": {
@@ -58124,13 +58724,19 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
@@ -58156,42 +58762,34 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ByteMatchStatement": {
@@ -58210,36 +58808,28 @@ var CloudformationSchema = `{
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountryCodes": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
                     },
                     "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.DefaultAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -58251,43 +58841,34 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.ExcludedRules": {
-            "additionalProperties": false,
-            "properties": {
-                "ExcludedRules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
-                    },
-                    "type": "array"
-                }
-            },
+            "required": [
+                "Name"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.FieldToMatch": {
             "additionalProperties": false,
             "properties": {
                 "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllQueryArguments"
+                    "type": "object"
                 },
                 "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Body"
+                    "type": "object"
                 },
                 "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Method"
+                    "type": "object"
                 },
                 "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.QueryString"
+                    "type": "object"
                 },
                 "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleHeader"
+                    "type": "object"
                 },
                 "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleQueryArgument"
+                    "type": "object"
                 },
                 "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.UriPath"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -58296,7 +58877,10 @@ var CloudformationSchema = `{
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountryCodes"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 }
             },
             "type": "object"
@@ -58308,13 +58892,19 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ManagedRuleGroupStatement": {
             "additionalProperties": false,
             "properties": {
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
+                    },
+                    "type": "array"
                 },
                 "Name": {
                     "type": "string"
@@ -58323,16 +58913,10 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Method": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.NoneAction": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Name",
+                "VendorName"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementOne": {
@@ -58342,6 +58926,9 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementTwo": {
@@ -58351,41 +58938,51 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OverrideAction": {
             "additionalProperties": false,
             "properties": {
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 },
                 "None": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.NoneAction"
+                    "type": "object"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementOne": {
@@ -58401,6 +58998,10 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementTwo": {
@@ -58416,6 +59017,10 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
@@ -58428,9 +59033,17 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.Rule": {
@@ -58455,19 +59068,25 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -58479,39 +59098,15 @@ var CloudformationSchema = `{
                     "type": "string"
                 },
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
                     "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
                     },
                     "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SizeConstraintStatement": {
@@ -58527,9 +59122,18 @@ var CloudformationSchema = `{
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SqliMatchStatement": {
@@ -58539,9 +59143,16 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.StatementOne": {
@@ -58622,18 +59233,6 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -58679,30 +59278,6 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -58713,23 +59288,10 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.VisibilityConfig": {
@@ -58745,6 +59307,11 @@ var CloudformationSchema = `{
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.XssMatchStatement": {
@@ -58754,9 +59321,16 @@ var CloudformationSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACLAssociation": {
@@ -59573,10 +60147,16 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Config::ConfigurationRecorder"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::ConformancePack"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConformancePack"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
@@ -59685,6 +60265,12 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::LaunchTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRoute"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NatGateway"
@@ -59925,6 +60511,12 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Events::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::Policy"
                         },
                         {
                             "$ref": "#/definitions/AWS::FSx::FileSystem"

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -11504,6 +11504,12 @@
                         "Environment": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
                         },
+                        "FileSystemLocations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeBuild::Project.ProjectFileSystemLocation"
+                            },
+                            "type": "array"
+                        },
                         "LogsConfig": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.LogsConfig"
                         },
@@ -11734,6 +11740,33 @@
                 }
             },
             "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.ProjectFileSystemLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "Identifier": {
+                    "type": "string"
+                },
+                "Location": {
+                    "type": "string"
+                },
+                "MountOptions": {
+                    "type": "string"
+                },
+                "MountPoint": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Identifier",
+                "Location",
+                "MountPoint",
                 "Type"
             ],
             "type": "object"
@@ -13797,6 +13830,9 @@
                             },
                             "type": "array"
                         },
+                        "UsernameConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.UsernameConfiguration"
+                        },
                         "VerificationMessageTemplate": {
                             "$ref": "#/definitions/AWS::Cognito::UserPool.VerificationMessageTemplate"
                         }
@@ -14039,6 +14075,15 @@
             "properties": {
                 "AdvancedSecurityMode": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.UsernameConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CaseSensitive": {
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -14964,6 +15009,12 @@
                         },
                         "AuthorizedAwsRegion": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15159,6 +15210,12 @@
                         },
                         "OrganizationAggregationSource": {
                             "$ref": "#/definitions/AWS::Config::ConfigurationAggregator.OrganizationAggregationSource"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15300,6 +15357,95 @@
                     "type": "array"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::ConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "ConformancePackName": {
+                            "type": "string"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConformancePackName",
+                        "DeliveryS3Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
+            ],
             "type": "object"
         },
         "AWS::Config::DeliveryChannel": {
@@ -15519,6 +15665,101 @@
             },
             "required": [
                 "RuleIdentifier"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::OrganizationConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConformancePackName": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeliveryS3Bucket",
+                        "OrganizationConformancePackName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
             ],
             "type": "object"
         },
@@ -19913,6 +20154,141 @@
                 "ResourceType": {
                     "type": "string"
                 },
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "LocalGatewayVirtualInterfaceGroupId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationCidrBlock",
+                        "LocalGatewayRouteTableId",
+                        "LocalGatewayVirtualInterfaceGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRoute"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LocalGatewayRouteTableId",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRouteTableVPCAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags": {
+            "additionalProperties": false,
+            "properties": {
                 "Tags": {
                     "items": {
                         "$ref": "#/definitions/Tag"
@@ -27847,6 +28223,9 @@
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -27986,6 +28365,21 @@
             ],
             "type": "object"
         },
+        "AWS::ElasticLoadBalancingV2::Listener.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::ElasticLoadBalancingV2::Listener.RedirectConfig": {
             "additionalProperties": false,
             "properties": {
@@ -28011,6 +28405,30 @@
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
@@ -28167,6 +28585,9 @@
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -28295,6 +28716,21 @@
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule.HostHeaderConfig": {
@@ -28440,6 +28876,30 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -29623,6 +30083,204 @@
             ],
             "type": "object"
         },
+        "AWS::FMS::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "SnsRoleName": {
+                            "type": "string"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "SnsRoleName",
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::NotificationChannel"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeleteAllPolicyResources": {
+                            "type": "boolean"
+                        },
+                        "ExcludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "ExcludeResourceTags": {
+                            "type": "boolean"
+                        },
+                        "IncludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "RemediationEnabled": {
+                            "type": "boolean"
+                        },
+                        "ResourceTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.ResourceTag"
+                            },
+                            "type": "array"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "ResourceTypeList": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityServicePolicyData": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.PolicyTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ExcludeResourceTags",
+                        "PolicyName",
+                        "RemediationEnabled",
+                        "ResourceType",
+                        "SecurityServicePolicyData"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::Policy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.IEMap": {
+            "additionalProperties": false,
+            "properties": {
+                "ACCOUNT": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::FMS::Policy.PolicyTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.ResourceTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::FSx::FileSystem": {
             "additionalProperties": false,
             "properties": {
@@ -29714,6 +30372,9 @@
         "AWS::FSx::FileSystem.LustreConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentType": {
+                    "type": "string"
+                },
                 "ExportPath": {
                     "type": "string"
                 },
@@ -29721,6 +30382,9 @@
                     "type": "string"
                 },
                 "ImportedFileChunkSize": {
+                    "type": "number"
+                },
+                "PerUnitStorageThroughput": {
                     "type": "number"
                 },
                 "WeeklyMaintenanceStartTime": {
@@ -43003,11 +43667,17 @@
                         "DBSubnetGroupName": {
                             "type": "string"
                         },
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
                         "EnableCloudwatchLogsExports": {
                             "items": {
                                 "type": "string"
                             },
                             "type": "array"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -57338,7 +58008,10 @@
                     "additionalProperties": false,
                     "properties": {
                         "Addresses": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Description": {
                             "type": "string"
@@ -57353,7 +58026,10 @@
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -57374,30 +58050,6 @@
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPAddresses": {
-            "additionalProperties": false,
-            "properties": {
-                "IPAddresses": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RegexPatternSet": {
@@ -57439,13 +58091,19 @@
                             "type": "string"
                         },
                         "RegularExpressionList": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -57465,39 +58123,6 @@
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.Regex": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexString": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegularExpressionList": {
-            "additionalProperties": false,
-            "properties": {
-                "RegularExpressionList": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.Regex"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup": {
@@ -57542,13 +58167,19 @@
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
@@ -57574,42 +58205,34 @@
             ],
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.ByteMatchStatement": {
@@ -57628,17 +58251,48 @@
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFv2::RuleGroup.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "AllQueryArguments": {
+                    "type": "object"
+                },
+                "Body": {
+                    "type": "object"
+                },
+                "Method": {
+                    "type": "object"
+                },
+                "QueryString": {
+                    "type": "object"
+                },
+                "SingleHeader": {
+                    "type": "object"
+                },
+                "SingleQueryArgument": {
+                    "type": "object"
+                },
+                "UriPath": {
+                    "type": "object"
                 }
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.CountryCodes": {
+        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
@@ -57650,42 +58304,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.FieldToMatch": {
-            "additionalProperties": false,
-            "properties": {
-                "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllQueryArguments"
-                },
-                "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Body"
-                },
-                "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Method"
-                },
-                "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.QueryString"
-                },
-                "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleHeader"
-                },
-                "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleQueryArgument"
-                },
-                "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.UriPath"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountryCodes"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
@@ -57693,11 +58311,9 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Method": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementOne": {
@@ -57707,6 +58323,9 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementTwo": {
@@ -57716,29 +58335,39 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementOne": {
@@ -57754,6 +58383,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementTwo": {
@@ -57769,6 +58402,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
@@ -57781,9 +58418,17 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.Rule": {
@@ -57805,49 +58450,25 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -57865,9 +58486,18 @@
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.SqliMatchStatement": {
@@ -57877,9 +58507,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.StatementOne": {
@@ -57948,18 +58585,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -57999,30 +58624,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -58033,23 +58634,10 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.VisibilityConfig": {
@@ -58065,6 +58653,11 @@
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.XssMatchStatement": {
@@ -58074,9 +58667,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL": {
@@ -58121,13 +58721,19 @@
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
@@ -58153,42 +58759,34 @@
             ],
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ByteMatchStatement": {
@@ -58207,36 +58805,28 @@
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountryCodes": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
                     },
                     "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.DefaultAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -58248,43 +58838,34 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.ExcludedRules": {
-            "additionalProperties": false,
-            "properties": {
-                "ExcludedRules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
-                    },
-                    "type": "array"
-                }
-            },
+            "required": [
+                "Name"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.FieldToMatch": {
             "additionalProperties": false,
             "properties": {
                 "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllQueryArguments"
+                    "type": "object"
                 },
                 "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Body"
+                    "type": "object"
                 },
                 "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Method"
+                    "type": "object"
                 },
                 "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.QueryString"
+                    "type": "object"
                 },
                 "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleHeader"
+                    "type": "object"
                 },
                 "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleQueryArgument"
+                    "type": "object"
                 },
                 "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.UriPath"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -58293,7 +58874,10 @@
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountryCodes"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 }
             },
             "type": "object"
@@ -58305,13 +58889,19 @@
                     "type": "string"
                 }
             },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ManagedRuleGroupStatement": {
             "additionalProperties": false,
             "properties": {
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
+                    },
+                    "type": "array"
                 },
                 "Name": {
                     "type": "string"
@@ -58320,16 +58910,10 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Method": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.NoneAction": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Name",
+                "VendorName"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementOne": {
@@ -58339,6 +58923,9 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementTwo": {
@@ -58348,41 +58935,51 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OverrideAction": {
             "additionalProperties": false,
             "properties": {
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 },
                 "None": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.NoneAction"
+                    "type": "object"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementOne": {
@@ -58398,6 +58995,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementTwo": {
@@ -58413,6 +59014,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
@@ -58425,9 +59030,17 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.Rule": {
@@ -58452,19 +59065,25 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -58476,39 +59095,15 @@
                     "type": "string"
                 },
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
                     "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
                     },
                     "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SizeConstraintStatement": {
@@ -58524,9 +59119,18 @@
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SqliMatchStatement": {
@@ -58536,9 +59140,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.StatementOne": {
@@ -58619,18 +59230,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -58676,30 +59275,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -58710,23 +59285,10 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.VisibilityConfig": {
@@ -58742,6 +59304,11 @@
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.XssMatchStatement": {
@@ -58751,9 +59318,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACLAssociation": {
@@ -59570,10 +60144,16 @@
                             "$ref": "#/definitions/AWS::Config::ConfigurationRecorder"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::ConformancePack"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConformancePack"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
@@ -59682,6 +60262,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::LaunchTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRoute"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NatGateway"
@@ -59922,6 +60508,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Events::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::Policy"
                         },
                         {
                             "$ref": "#/definitions/AWS::FSx::FileSystem"

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -11507,6 +11507,12 @@ var SamSchema = `{
                         "Environment": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
                         },
+                        "FileSystemLocations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeBuild::Project.ProjectFileSystemLocation"
+                            },
+                            "type": "array"
+                        },
                         "LogsConfig": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.LogsConfig"
                         },
@@ -11737,6 +11743,33 @@ var SamSchema = `{
                 }
             },
             "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.ProjectFileSystemLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "Identifier": {
+                    "type": "string"
+                },
+                "Location": {
+                    "type": "string"
+                },
+                "MountOptions": {
+                    "type": "string"
+                },
+                "MountPoint": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Identifier",
+                "Location",
+                "MountPoint",
                 "Type"
             ],
             "type": "object"
@@ -13800,6 +13833,9 @@ var SamSchema = `{
                             },
                             "type": "array"
                         },
+                        "UsernameConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.UsernameConfiguration"
+                        },
                         "VerificationMessageTemplate": {
                             "$ref": "#/definitions/AWS::Cognito::UserPool.VerificationMessageTemplate"
                         }
@@ -14042,6 +14078,15 @@ var SamSchema = `{
             "properties": {
                 "AdvancedSecurityMode": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.UsernameConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CaseSensitive": {
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -14967,6 +15012,12 @@ var SamSchema = `{
                         },
                         "AuthorizedAwsRegion": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15162,6 +15213,12 @@ var SamSchema = `{
                         },
                         "OrganizationAggregationSource": {
                             "$ref": "#/definitions/AWS::Config::ConfigurationAggregator.OrganizationAggregationSource"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15303,6 +15360,95 @@ var SamSchema = `{
                     "type": "array"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::ConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "ConformancePackName": {
+                            "type": "string"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConformancePackName",
+                        "DeliveryS3Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
+            ],
             "type": "object"
         },
         "AWS::Config::DeliveryChannel": {
@@ -15522,6 +15668,101 @@ var SamSchema = `{
             },
             "required": [
                 "RuleIdentifier"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::OrganizationConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConformancePackName": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeliveryS3Bucket",
+                        "OrganizationConformancePackName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
             ],
             "type": "object"
         },
@@ -19916,6 +20157,141 @@ var SamSchema = `{
                 "ResourceType": {
                     "type": "string"
                 },
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "LocalGatewayVirtualInterfaceGroupId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationCidrBlock",
+                        "LocalGatewayRouteTableId",
+                        "LocalGatewayVirtualInterfaceGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRoute"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LocalGatewayRouteTableId",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRouteTableVPCAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags": {
+            "additionalProperties": false,
+            "properties": {
                 "Tags": {
                     "items": {
                         "$ref": "#/definitions/Tag"
@@ -27850,6 +28226,9 @@ var SamSchema = `{
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -27989,6 +28368,21 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::ElasticLoadBalancingV2::Listener.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::ElasticLoadBalancingV2::Listener.RedirectConfig": {
             "additionalProperties": false,
             "properties": {
@@ -28014,6 +28408,30 @@ var SamSchema = `{
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
@@ -28170,6 +28588,9 @@ var SamSchema = `{
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -28298,6 +28719,21 @@ var SamSchema = `{
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule.HostHeaderConfig": {
@@ -28443,6 +28879,30 @@ var SamSchema = `{
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -29626,6 +30086,204 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::FMS::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "SnsRoleName": {
+                            "type": "string"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "SnsRoleName",
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::NotificationChannel"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeleteAllPolicyResources": {
+                            "type": "boolean"
+                        },
+                        "ExcludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "ExcludeResourceTags": {
+                            "type": "boolean"
+                        },
+                        "IncludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "RemediationEnabled": {
+                            "type": "boolean"
+                        },
+                        "ResourceTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.ResourceTag"
+                            },
+                            "type": "array"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "ResourceTypeList": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityServicePolicyData": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.PolicyTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ExcludeResourceTags",
+                        "PolicyName",
+                        "RemediationEnabled",
+                        "ResourceType",
+                        "SecurityServicePolicyData"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::Policy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.IEMap": {
+            "additionalProperties": false,
+            "properties": {
+                "ACCOUNT": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::FMS::Policy.PolicyTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.ResourceTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::FSx::FileSystem": {
             "additionalProperties": false,
             "properties": {
@@ -29717,6 +30375,9 @@ var SamSchema = `{
         "AWS::FSx::FileSystem.LustreConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentType": {
+                    "type": "string"
+                },
                 "ExportPath": {
                     "type": "string"
                 },
@@ -29724,6 +30385,9 @@ var SamSchema = `{
                     "type": "string"
                 },
                 "ImportedFileChunkSize": {
+                    "type": "number"
+                },
+                "PerUnitStorageThroughput": {
                     "type": "number"
                 },
                 "WeeklyMaintenanceStartTime": {
@@ -43006,11 +43670,17 @@ var SamSchema = `{
                         "DBSubnetGroupName": {
                             "type": "string"
                         },
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
                         "EnableCloudwatchLogsExports": {
                             "items": {
                                 "type": "string"
                             },
                             "type": "array"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -58635,7 +59305,10 @@ var SamSchema = `{
                     "additionalProperties": false,
                     "properties": {
                         "Addresses": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Description": {
                             "type": "string"
@@ -58650,7 +59323,10 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -58671,30 +59347,6 @@ var SamSchema = `{
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPAddresses": {
-            "additionalProperties": false,
-            "properties": {
-                "IPAddresses": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RegexPatternSet": {
@@ -58736,13 +59388,19 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "RegularExpressionList": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -58762,39 +59420,6 @@ var SamSchema = `{
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.Regex": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexString": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegularExpressionList": {
-            "additionalProperties": false,
-            "properties": {
-                "RegularExpressionList": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.Regex"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup": {
@@ -58839,13 +59464,19 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
@@ -58871,42 +59502,34 @@ var SamSchema = `{
             ],
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.ByteMatchStatement": {
@@ -58925,17 +59548,48 @@ var SamSchema = `{
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFv2::RuleGroup.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "AllQueryArguments": {
+                    "type": "object"
+                },
+                "Body": {
+                    "type": "object"
+                },
+                "Method": {
+                    "type": "object"
+                },
+                "QueryString": {
+                    "type": "object"
+                },
+                "SingleHeader": {
+                    "type": "object"
+                },
+                "SingleQueryArgument": {
+                    "type": "object"
+                },
+                "UriPath": {
+                    "type": "object"
                 }
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.CountryCodes": {
+        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
@@ -58947,42 +59601,6 @@ var SamSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.FieldToMatch": {
-            "additionalProperties": false,
-            "properties": {
-                "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllQueryArguments"
-                },
-                "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Body"
-                },
-                "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Method"
-                },
-                "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.QueryString"
-                },
-                "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleHeader"
-                },
-                "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleQueryArgument"
-                },
-                "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.UriPath"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountryCodes"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
@@ -58990,11 +59608,9 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Method": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementOne": {
@@ -59004,6 +59620,9 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementTwo": {
@@ -59013,29 +59632,39 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementOne": {
@@ -59051,6 +59680,10 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementTwo": {
@@ -59066,6 +59699,10 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
@@ -59078,9 +59715,17 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.Rule": {
@@ -59102,49 +59747,25 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59162,9 +59783,18 @@ var SamSchema = `{
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.SqliMatchStatement": {
@@ -59174,9 +59804,16 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.StatementOne": {
@@ -59245,18 +59882,6 @@ var SamSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -59296,30 +59921,6 @@ var SamSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -59330,23 +59931,10 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.VisibilityConfig": {
@@ -59362,6 +59950,11 @@ var SamSchema = `{
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.XssMatchStatement": {
@@ -59371,9 +59964,16 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL": {
@@ -59418,13 +60018,19 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
@@ -59450,42 +60056,34 @@ var SamSchema = `{
             ],
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ByteMatchStatement": {
@@ -59504,36 +60102,28 @@ var SamSchema = `{
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountryCodes": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
                     },
                     "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.DefaultAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59545,43 +60135,34 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.ExcludedRules": {
-            "additionalProperties": false,
-            "properties": {
-                "ExcludedRules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
-                    },
-                    "type": "array"
-                }
-            },
+            "required": [
+                "Name"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.FieldToMatch": {
             "additionalProperties": false,
             "properties": {
                 "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllQueryArguments"
+                    "type": "object"
                 },
                 "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Body"
+                    "type": "object"
                 },
                 "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Method"
+                    "type": "object"
                 },
                 "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.QueryString"
+                    "type": "object"
                 },
                 "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleHeader"
+                    "type": "object"
                 },
                 "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleQueryArgument"
+                    "type": "object"
                 },
                 "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.UriPath"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59590,7 +60171,10 @@ var SamSchema = `{
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountryCodes"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 }
             },
             "type": "object"
@@ -59602,13 +60186,19 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ManagedRuleGroupStatement": {
             "additionalProperties": false,
             "properties": {
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
+                    },
+                    "type": "array"
                 },
                 "Name": {
                     "type": "string"
@@ -59617,16 +60207,10 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Method": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.NoneAction": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Name",
+                "VendorName"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementOne": {
@@ -59636,6 +60220,9 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementTwo": {
@@ -59645,41 +60232,51 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OverrideAction": {
             "additionalProperties": false,
             "properties": {
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 },
                 "None": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.NoneAction"
+                    "type": "object"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementOne": {
@@ -59695,6 +60292,10 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementTwo": {
@@ -59710,6 +60311,10 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
@@ -59722,9 +60327,17 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.Rule": {
@@ -59749,19 +60362,25 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59773,39 +60392,15 @@ var SamSchema = `{
                     "type": "string"
                 },
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
                     "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
                     },
                     "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SizeConstraintStatement": {
@@ -59821,9 +60416,18 @@ var SamSchema = `{
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SqliMatchStatement": {
@@ -59833,9 +60437,16 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.StatementOne": {
@@ -59916,18 +60527,6 @@ var SamSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -59973,30 +60572,6 @@ var SamSchema = `{
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -60007,23 +60582,10 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.VisibilityConfig": {
@@ -60039,6 +60601,11 @@ var SamSchema = `{
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.XssMatchStatement": {
@@ -60048,9 +60615,16 @@ var SamSchema = `{
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACLAssociation": {
@@ -60867,10 +61441,16 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Config::ConfigurationRecorder"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::ConformancePack"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConformancePack"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
@@ -60979,6 +61559,12 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::LaunchTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRoute"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NatGateway"
@@ -61219,6 +61805,12 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Events::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::Policy"
                         },
                         {
                             "$ref": "#/definitions/AWS::FSx::FileSystem"

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -11504,6 +11504,12 @@
                         "Environment": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.Environment"
                         },
+                        "FileSystemLocations": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::CodeBuild::Project.ProjectFileSystemLocation"
+                            },
+                            "type": "array"
+                        },
                         "LogsConfig": {
                             "$ref": "#/definitions/AWS::CodeBuild::Project.LogsConfig"
                         },
@@ -11734,6 +11740,33 @@
                 }
             },
             "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CodeBuild::Project.ProjectFileSystemLocation": {
+            "additionalProperties": false,
+            "properties": {
+                "Identifier": {
+                    "type": "string"
+                },
+                "Location": {
+                    "type": "string"
+                },
+                "MountOptions": {
+                    "type": "string"
+                },
+                "MountPoint": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Identifier",
+                "Location",
+                "MountPoint",
                 "Type"
             ],
             "type": "object"
@@ -13797,6 +13830,9 @@
                             },
                             "type": "array"
                         },
+                        "UsernameConfiguration": {
+                            "$ref": "#/definitions/AWS::Cognito::UserPool.UsernameConfiguration"
+                        },
                         "VerificationMessageTemplate": {
                             "$ref": "#/definitions/AWS::Cognito::UserPool.VerificationMessageTemplate"
                         }
@@ -14039,6 +14075,15 @@
             "properties": {
                 "AdvancedSecurityMode": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.UsernameConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CaseSensitive": {
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -14964,6 +15009,12 @@
                         },
                         "AuthorizedAwsRegion": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15159,6 +15210,12 @@
                         },
                         "OrganizationAggregationSource": {
                             "$ref": "#/definitions/AWS::Config::ConfigurationAggregator.OrganizationAggregationSource"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -15300,6 +15357,95 @@
                     "type": "array"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::ConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "ConformancePackName": {
+                            "type": "string"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConformancePackName",
+                        "DeliveryS3Bucket"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::ConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::ConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
+            ],
             "type": "object"
         },
         "AWS::Config::DeliveryChannel": {
@@ -15519,6 +15665,101 @@
             },
             "required": [
                 "RuleIdentifier"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ConformancePackInputParameters": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Config::OrganizationConformancePack.ConformancePackInputParameter"
+                            },
+                            "type": "array"
+                        },
+                        "DeliveryS3Bucket": {
+                            "type": "string"
+                        },
+                        "DeliveryS3KeyPrefix": {
+                            "type": "string"
+                        },
+                        "ExcludedAccounts": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "OrganizationConformancePackName": {
+                            "type": "string"
+                        },
+                        "TemplateBody": {
+                            "type": "string"
+                        },
+                        "TemplateS3Uri": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DeliveryS3Bucket",
+                        "OrganizationConformancePackName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Config::OrganizationConformancePack"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::Config::OrganizationConformancePack.ConformancePackInputParameter": {
+            "additionalProperties": false,
+            "properties": {
+                "ParameterName": {
+                    "type": "string"
+                },
+                "ParameterValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ParameterName",
+                "ParameterValue"
             ],
             "type": "object"
         },
@@ -19913,6 +20154,141 @@
                 "ResourceType": {
                     "type": "string"
                 },
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DestinationCidrBlock": {
+                            "type": "string"
+                        },
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "LocalGatewayVirtualInterfaceGroupId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationCidrBlock",
+                        "LocalGatewayRouteTableId",
+                        "LocalGatewayVirtualInterfaceGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRoute"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LocalGatewayRouteTableId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags"
+                        },
+                        "VpcId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LocalGatewayRouteTableId",
+                        "VpcId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::LocalGatewayRouteTableVPCAssociation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::LocalGatewayRouteTableVPCAssociation.Tags": {
+            "additionalProperties": false,
+            "properties": {
                 "Tags": {
                     "items": {
                         "$ref": "#/definitions/Tag"
@@ -27847,6 +28223,9 @@
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -27986,6 +28365,21 @@
             ],
             "type": "object"
         },
+        "AWS::ElasticLoadBalancingV2::Listener.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::ElasticLoadBalancingV2::Listener.RedirectConfig": {
             "additionalProperties": false,
             "properties": {
@@ -28011,6 +28405,30 @@
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::Listener.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerCertificate": {
@@ -28167,6 +28585,9 @@
                 "FixedResponseConfig": {
                     "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.FixedResponseConfig"
                 },
+                "ForwardConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig"
+                },
                 "Order": {
                     "type": "number"
                 },
@@ -28295,6 +28716,21 @@
             "required": [
                 "StatusCode"
             ],
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.ForwardConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupStickinessConfig": {
+                    "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig"
+                },
+                "TargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticLoadBalancingV2::ListenerRule.HostHeaderConfig": {
@@ -28440,6 +28876,30 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupStickinessConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DurationSeconds": {
+                    "type": "number"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule.TargetGroupTuple": {
+            "additionalProperties": false,
+            "properties": {
+                "TargetGroupArn": {
+                    "type": "string"
+                },
+                "Weight": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -29623,6 +30083,204 @@
             ],
             "type": "object"
         },
+        "AWS::FMS::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "SnsRoleName": {
+                            "type": "string"
+                        },
+                        "SnsTopicArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "SnsRoleName",
+                        "SnsTopicArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::NotificationChannel"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DeleteAllPolicyResources": {
+                            "type": "boolean"
+                        },
+                        "ExcludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "ExcludeResourceTags": {
+                            "type": "boolean"
+                        },
+                        "IncludeMap": {
+                            "$ref": "#/definitions/AWS::FMS::Policy.IEMap"
+                        },
+                        "PolicyName": {
+                            "type": "string"
+                        },
+                        "RemediationEnabled": {
+                            "type": "boolean"
+                        },
+                        "ResourceTags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.ResourceTag"
+                            },
+                            "type": "array"
+                        },
+                        "ResourceType": {
+                            "type": "string"
+                        },
+                        "ResourceTypeList": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "SecurityServicePolicyData": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::FMS::Policy.PolicyTag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ExcludeResourceTags",
+                        "PolicyName",
+                        "RemediationEnabled",
+                        "ResourceType",
+                        "SecurityServicePolicyData"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::FMS::Policy"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.IEMap": {
+            "additionalProperties": false,
+            "properties": {
+                "ACCOUNT": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::FMS::Policy.PolicyTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::FMS::Policy.ResourceTag": {
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Key"
+            ],
+            "type": "object"
+        },
         "AWS::FSx::FileSystem": {
             "additionalProperties": false,
             "properties": {
@@ -29714,6 +30372,9 @@
         "AWS::FSx::FileSystem.LustreConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentType": {
+                    "type": "string"
+                },
                 "ExportPath": {
                     "type": "string"
                 },
@@ -29721,6 +30382,9 @@
                     "type": "string"
                 },
                 "ImportedFileChunkSize": {
+                    "type": "number"
+                },
+                "PerUnitStorageThroughput": {
                     "type": "number"
                 },
                 "WeeklyMaintenanceStartTime": {
@@ -43003,11 +43667,17 @@
                         "DBSubnetGroupName": {
                             "type": "string"
                         },
+                        "DeletionProtection": {
+                            "type": "boolean"
+                        },
                         "EnableCloudwatchLogsExports": {
                             "items": {
                                 "type": "string"
                             },
                             "type": "array"
+                        },
+                        "EngineVersion": {
+                            "type": "string"
                         },
                         "IamAuthEnabled": {
                             "type": "boolean"
@@ -58632,7 +59302,10 @@
                     "additionalProperties": false,
                     "properties": {
                         "Addresses": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.IPAddresses"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Description": {
                             "type": "string"
@@ -58647,7 +59320,10 @@
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::IPSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -58668,30 +59344,6 @@
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.IPAddresses": {
-            "additionalProperties": false,
-            "properties": {
-                "IPAddresses": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::IPSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RegexPatternSet": {
@@ -58733,13 +59385,19 @@
                             "type": "string"
                         },
                         "RegularExpressionList": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.RegularExpressionList"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -58759,39 +59417,6 @@
                 "Type",
                 "Properties"
             ],
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.Regex": {
-            "additionalProperties": false,
-            "properties": {
-                "RegexString": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.RegularExpressionList": {
-            "additionalProperties": false,
-            "properties": {
-                "RegularExpressionList": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RegexPatternSet.Regex"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RegexPatternSet.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup": {
@@ -58836,13 +59461,19 @@
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
@@ -58868,42 +59499,34 @@
             ],
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.ByteMatchStatement": {
@@ -58922,17 +59545,48 @@
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
+            "type": "object"
+        },
+        "AWS::WAFv2::RuleGroup.FieldToMatch": {
+            "additionalProperties": false,
+            "properties": {
+                "AllQueryArguments": {
+                    "type": "object"
+                },
+                "Body": {
+                    "type": "object"
+                },
+                "Method": {
+                    "type": "object"
+                },
+                "QueryString": {
+                    "type": "object"
+                },
+                "SingleHeader": {
+                    "type": "object"
+                },
+                "SingleQueryArgument": {
+                    "type": "object"
+                },
+                "UriPath": {
+                    "type": "object"
                 }
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.CountryCodes": {
+        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
@@ -58944,42 +59598,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.FieldToMatch": {
-            "additionalProperties": false,
-            "properties": {
-                "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllQueryArguments"
-                },
-                "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Body"
-                },
-                "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Method"
-                },
-                "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.QueryString"
-                },
-                "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleHeader"
-                },
-                "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.SingleQueryArgument"
-                },
-                "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.UriPath"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.GeoMatchStatement": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountryCodes"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.IPSetReferenceStatement": {
             "additionalProperties": false,
             "properties": {
@@ -58987,11 +59605,9 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Method": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementOne": {
@@ -59001,6 +59617,9 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.NotStatementTwo": {
@@ -59010,29 +59629,39 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementOne": {
@@ -59048,6 +59677,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RateBasedStatementTwo": {
@@ -59063,6 +59696,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement": {
@@ -59075,9 +59712,17 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.Rule": {
@@ -59099,49 +59744,25 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.CountAction"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.Rule"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59159,9 +59780,18 @@
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.SqliMatchStatement": {
@@ -59171,9 +59801,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.StatementOne": {
@@ -59242,18 +59879,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -59293,30 +59918,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::RuleGroup.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::RuleGroup.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -59327,23 +59928,10 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::RuleGroup.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.VisibilityConfig": {
@@ -59359,6 +59947,11 @@
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::RuleGroup.XssMatchStatement": {
@@ -59368,9 +59961,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::RuleGroup.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::RuleGroup.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL": {
@@ -59415,13 +60015,19 @@
                             "type": "string"
                         },
                         "Rules": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.Rules"
+                            "items": {
+                                "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                            },
+                            "type": "array"
                         },
                         "Scope": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::WAFv2::WebACL.TagList"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VisibilityConfig": {
                             "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
@@ -59447,42 +60053,34 @@
             ],
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.AllQueryArguments": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.AllowAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.AndStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.AndStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.BlockAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Body": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ByteMatchStatement": {
@@ -59501,36 +60099,28 @@
                     "type": "string"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountAction": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.CountryCodes": {
-            "additionalProperties": false,
-            "properties": {
-                "CountryCodes": {
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
                     },
                     "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "PositionalConstraint",
+                "SearchString",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.DefaultAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59542,43 +60132,34 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.ExcludedRules": {
-            "additionalProperties": false,
-            "properties": {
-                "ExcludedRules": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
-                    },
-                    "type": "array"
-                }
-            },
+            "required": [
+                "Name"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.FieldToMatch": {
             "additionalProperties": false,
             "properties": {
                 "AllQueryArguments": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllQueryArguments"
+                    "type": "object"
                 },
                 "Body": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Body"
+                    "type": "object"
                 },
                 "Method": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.Method"
+                    "type": "object"
                 },
                 "QueryString": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.QueryString"
+                    "type": "object"
                 },
                 "SingleHeader": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleHeader"
+                    "type": "object"
                 },
                 "SingleQueryArgument": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.SingleQueryArgument"
+                    "type": "object"
                 },
                 "UriPath": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.UriPath"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59587,7 +60168,10 @@
             "additionalProperties": false,
             "properties": {
                 "CountryCodes": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountryCodes"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 }
             },
             "type": "object"
@@ -59599,13 +60183,19 @@
                     "type": "string"
                 }
             },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.ManagedRuleGroupStatement": {
             "additionalProperties": false,
             "properties": {
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
+                    },
+                    "type": "array"
                 },
                 "Name": {
                     "type": "string"
@@ -59614,16 +60204,10 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Method": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.NoneAction": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Name",
+                "VendorName"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementOne": {
@@ -59633,6 +60217,9 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.NotStatementTwo": {
@@ -59642,41 +60229,51 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "Statement"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementOne": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwos"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OrStatementTwo": {
             "additionalProperties": false,
             "properties": {
                 "Statements": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThrees"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Statements"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.OverrideAction": {
             "additionalProperties": false,
             "properties": {
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 },
                 "None": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.NoneAction"
+                    "type": "object"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.QueryString": {
-            "additionalProperties": false,
-            "properties": {},
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementOne": {
@@ -59692,6 +60289,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RateBasedStatementTwo": {
@@ -59707,6 +60308,10 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
                 }
             },
+            "required": [
+                "AggregateKeyType",
+                "Limit"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement": {
@@ -59719,9 +60324,17 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "Arn",
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.Rule": {
@@ -59746,19 +60359,25 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.VisibilityConfig"
                 }
             },
+            "required": [
+                "Name",
+                "Priority",
+                "Statement",
+                "VisibilityConfig"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.RuleAction": {
             "additionalProperties": false,
             "properties": {
                 "Allow": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.AllowAction"
+                    "type": "object"
                 },
                 "Block": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.BlockAction"
+                    "type": "object"
                 },
                 "Count": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.CountAction"
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -59770,39 +60389,15 @@
                     "type": "string"
                 },
                 "ExcludedRules": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRules"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.Rules": {
-            "additionalProperties": false,
-            "properties": {
-                "Rules": {
                     "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.Rule"
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.ExcludedRule"
                     },
                     "type": "array"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleHeader": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.SingleQueryArgument": {
-            "additionalProperties": false,
-            "properties": {
-                "Name": {
-                    "type": "string"
-                }
-            },
+            "required": [
+                "Arn"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SizeConstraintStatement": {
@@ -59818,9 +60413,18 @@
                     "type": "number"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "ComparisonOperator",
+                "FieldToMatch",
+                "Size",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.SqliMatchStatement": {
@@ -59830,9 +60434,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.StatementOne": {
@@ -59913,18 +60524,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementThrees": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementThrees": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementThree"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.StatementTwo": {
             "additionalProperties": false,
             "properties": {
@@ -59970,30 +60569,6 @@
             },
             "type": "object"
         },
-        "AWS::WAFv2::WebACL.StatementTwos": {
-            "additionalProperties": false,
-            "properties": {
-                "StatementTwos": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.StatementTwo"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TagList": {
-            "additionalProperties": false,
-            "properties": {
-                "TagList": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::WAFv2::WebACL.TextTransformation": {
             "additionalProperties": false,
             "properties": {
@@ -60004,23 +60579,10 @@
                     "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.TextTransformations": {
-            "additionalProperties": false,
-            "properties": {
-                "TextTransformations": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::WAFv2::WebACL.UriPath": {
-            "additionalProperties": false,
-            "properties": {},
+            "required": [
+                "Priority",
+                "Type"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.VisibilityConfig": {
@@ -60036,6 +60598,11 @@
                     "type": "boolean"
                 }
             },
+            "required": [
+                "CloudWatchMetricsEnabled",
+                "MetricName",
+                "SampledRequestsEnabled"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACL.XssMatchStatement": {
@@ -60045,9 +60612,16 @@
                     "$ref": "#/definitions/AWS::WAFv2::WebACL.FieldToMatch"
                 },
                 "TextTransformations": {
-                    "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformations"
+                    "items": {
+                        "$ref": "#/definitions/AWS::WAFv2::WebACL.TextTransformation"
+                    },
+                    "type": "array"
                 }
             },
+            "required": [
+                "FieldToMatch",
+                "TextTransformations"
+            ],
             "type": "object"
         },
         "AWS::WAFv2::WebACLAssociation": {
@@ -60864,10 +61438,16 @@
                             "$ref": "#/definitions/AWS::Config::ConfigurationRecorder"
                         },
                         {
+                            "$ref": "#/definitions/AWS::Config::ConformancePack"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Config::DeliveryChannel"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::OrganizationConfigRule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Config::OrganizationConformancePack"
                         },
                         {
                             "$ref": "#/definitions/AWS::Config::RemediationConfiguration"
@@ -60976,6 +61556,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::LaunchTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRoute"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::LocalGatewayRouteTableVPCAssociation"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NatGateway"
@@ -61216,6 +61802,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Events::Rule"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::FMS::Policy"
                         },
                         {
                             "$ref": "#/definitions/AWS::FSx::FileSystem"


### PR DESCRIPTION
Updated the following AWS CloudFormation resources:

 - AWS::WAFv2::RuleGroup
 - AWS::Config::ConfigurationAggregator
 - AWS::WAFv2::IPSet
 - AWS::Cognito::UserPool
 - AWS::WAFv2::RegexPatternSet
 - AWS::CodeBuild::Project
 - AWS::Config::AggregationAuthorization
 - AWS::WAFv2::WebACL
 - AWS::WAFv2::WebACL.ExcludedRule
 - AWS::WAFv2::WebACL.SizeConstraintStatement
 - AWS::WAFv2::WebACL.IPSetReferenceStatement
 - AWS::WAFv2::RuleGroup.AndStatementOne
 - AWS::CodeBuild::Project.ProjectFileSystemLocation
 - AWS::WAFv2::WebACL.ManagedRuleGroupStatement
 - AWS::WAFv2::WebACL.OverrideAction
 - AWS::WAFv2::RuleGroup.XssMatchStatement
 - AWS::WAFv2::WebACL.AndStatementOne
 - AWS::WAFv2::RuleGroup.SqliMatchStatement
 - AWS::WAFv2::RuleGroup.SizeConstraintStatement
 - AWS::WAFv2::WebACL.DefaultAction
 - AWS::WAFv2::RuleGroup.RegexPatternSetReferenceStatement
 - AWS::WAFv2::WebACL.TextTransformation
 - AWS::WAFv2::WebACL.Rule
 - AWS::WAFv2::RuleGroup.RateBasedStatementTwo
 - AWS::WAFv2::RuleGroup.TextTransformation
 - AWS::WAFv2::RuleGroup.IPSetReferenceStatement
 - AWS::WAFv2::RuleGroup.Rule
 - AWS::WAFv2::WebACL.AndStatementTwo
 - AWS::WAFv2::WebACL.FieldToMatch
 - AWS::WAFv2::RuleGroup.NotStatementOne
 - AWS::WAFv2::WebACL.OrStatementTwo
 - AWS::WAFv2::WebACL.RateBasedStatementTwo
 - AWS::WAFv2::WebACL.RateBasedStatementOne
 - AWS::WAFv2::RuleGroup.VisibilityConfig
 - AWS::WAFv2::RuleGroup.OrStatementTwo
 - AWS::WAFv2::WebACL.XssMatchStatement
 - AWS::WAFv2::WebACL.RuleGroupReferenceStatement
 - AWS::Cognito::UserPool.UsernameConfiguration
 - AWS::WAFv2::WebACL.OrStatementOne
 - AWS::WAFv2::RuleGroup.AndStatementTwo
 - AWS::WAFv2::RuleGroup.NotStatementTwo
 - AWS::WAFv2::RuleGroup.GeoMatchStatement
 - AWS::WAFv2::WebACL.ByteMatchStatement
 - AWS::WAFv2::RuleGroup.FieldToMatch
 - AWS::WAFv2::RuleGroup.RateBasedStatementOne
 - AWS::WAFv2::WebACL.GeoMatchStatement
 - AWS::WAFv2::RuleGroup.RuleAction
 - AWS::WAFv2::WebACL.RegexPatternSetReferenceStatement
 - AWS::WAFv2::WebACL.NotStatementTwo
 - AWS::WAFv2::WebACL.VisibilityConfig
 - AWS::WAFv2::WebACL.NotStatementOne
 - AWS::WAFv2::RuleGroup.ByteMatchStatement
 - AWS::WAFv2::WebACL.RuleAction
 - AWS::WAFv2::RuleGroup.OrStatementOne
 - AWS::WAFv2::WebACL.SqliMatchStatement

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
