### PR TITLE
Add UpdateReplacePolicy to all resources

### DIFF
--- a/cloudformation/policies/policies.go
+++ b/cloudformation/policies/policies.go
@@ -33,6 +33,12 @@ type ResourceSignal struct {
 // see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
 type DeletionPolicy string
 
+// UpdateReplacePolicy can retain or (in some cases) backup the existing physical instance of a resource when it is replaced during a stack update operation.
+// You specify a UpdateReplacePolicy attribute for each resource that you want to control. If a resource has no UpdateReplacePolicy attribute, AWS CloudFormation deletes the resource by default.
+// Either "Delete", "Retain" or "Snapshot".
+// see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html
+type UpdateReplacePolicy string
+
 // UpdatePolicy specifies how AWS CloudFormation handles updates to the AWS::AutoScaling::AutoScalingGroup or AWS::Lambda::Alias resource.
 // For AWS::AutoScaling::AutoScalingGroup resources, AWS CloudFormation invokes one of three update policies depending on the type of change you make or whether a scheduled action is associated with the Auto Scaling group.
 // The AutoScalingReplacingUpdate and AutoScalingRollingUpdate policies apply only when you do one or more of the following:

--- a/generate/templates/resource.template
+++ b/generate/templates/resource.template
@@ -36,6 +36,9 @@ type {{.StructName}} struct {
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
     // AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
     AWSCloudFormationDependsOn []string `json:"-"`
 
@@ -63,6 +66,7 @@ func (r {{.StructName}}) MarshalJSON() ([]byte, error) {
 		DependsOn []string `json:"DependsOn,omitempty"`
 		Metadata  map[string]interface{} `json:"Metadata,omitempty"`
 		DeletionPolicy policies.DeletionPolicy `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
 		Condition string `json:"Condition,omitempty"`
 		{{if .HasUpdatePolicy}}UpdatePolicy *policies.UpdatePolicy `json:"UpdatePolicy,omitempty"`{{end}}
 		{{if .HasCreationPolicy}}CreationPolicy *policies.CreationPolicy `json:"CreationPolicy,omitempty"`{{end}}
@@ -72,6 +76,7 @@ func (r {{.StructName}}) MarshalJSON() ([]byte, error) {
 		DependsOn: r.AWSCloudFormationDependsOn,
 		Metadata: r.AWSCloudFormationMetadata,
 		DeletionPolicy: r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
 		Condition: r.AWSCloudFormationCondition,
 		{{if .HasUpdatePolicy}}UpdatePolicy: r.AWSCloudFormationUpdatePolicy,{{end}}
 		{{if .HasCreationPolicy}}CreationPolicy: r.AWSCloudFormationCreationPolicy,{{end}}
@@ -88,6 +93,7 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 		DependsOn []string
 		Metadata map[string]interface{}
 		DeletionPolicy string
+		UpdateReplacePolicy string
 		Condition string
 	}{}
 
@@ -111,6 +117,9 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 	}
 	if res.DeletionPolicy != "" {
 		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
 	}
 	if res.Condition != "" {
 		r.AWSCloudFormationCondition = res.Condition

--- a/generate/templates/schema-resource.template
+++ b/generate/templates/schema-resource.template
@@ -44,6 +44,14 @@
                 "Snapshot"
             ]
         },
+        "UpdateReplacePolicy": {
+            "type": "string",
+            "enum": [
+                "Delete",
+                "Retain",
+                "Snapshot"
+            ]
+        },
         "DependsOn": {
             "anyOf": [
                 {


### PR DESCRIPTION
Add UpdateReplacePolicy to templates and policies so that it is generated for every resource.

As defined in https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html

*Issue #, if available:*

*Description of changes:*
Add UpdateReplacePolicy to templates and policies so that it is generated for every resource.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
