### PR TITLE
fix(intrinsics): change Fn::Sub to allow AWS pseudo parameters

### DIFF
--- a/intrinsics/fnsub.go
+++ b/intrinsics/fnsub.go
@@ -36,7 +36,7 @@ func FnSub(name string, input interface{}, template interface{}) interface{} {
 
 	case string:
 		// Look up references for each of the variables
-		regex := regexp.MustCompile(`\$\{([\.0-9A-Za-z]+)\}`)
+		regex := regexp.MustCompile(`\$\{([\.:0-9A-Za-z]+)\}`)
 		variables := regex.FindAllStringSubmatch(val, -1)
 		for _, variable := range variables {
 


### PR DESCRIPTION
*Issue #, if available:*
#274, #202 

*Description of changes:*
Adds `:` character to regex for variable match, allowing all AWS pseudo parameters to be replaced


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
