### PR TITLE
feat(schema): Add OpenApiVersion field to serverless Api

### DIFF
--- a/cloudformation/serverless/aws-serverless-api.go
+++ b/cloudformation/serverless/aws-serverless-api.go
@@ -67,6 +67,11 @@ type Api struct {
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi
 	Name string `json:"Name,omitempty"`
 
+	// OpenApiVersion AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi
+	OpenApiVersion string `json:"OpenApiVersion,omitempty"`
+
 	// StageName AWS CloudFormation Property
 	// Required: true
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -252,6 +252,12 @@
                     "Required": false,
                     "Type": "AccessLogSetting",
                     "UpdateType": "Immutable"
+                },
+                "OpenApiVersion": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
                 }
             }
         },


### PR DESCRIPTION
*Issue:* #280

*Description of changes:*
Added OpenApiVersion field to AWS::Serverless::Api resource


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
