### PR TITLE
[Feature] adding AWS::Serverless::StateMachine and FileSystemConfigs to Function

### DIFF
--- a/cloudformation/all.go
+++ b/cloudformation/all.go
@@ -624,6 +624,7 @@ func AllResources() map[string]Resource {
 		"AWS::Serverless::Function":                                   &serverless.Function{},
 		"AWS::Serverless::LayerVersion":                               &serverless.LayerVersion{},
 		"AWS::Serverless::SimpleTable":                                &serverless.SimpleTable{},
+		"AWS::Serverless::StateMachine":                               &serverless.StateMachine{},
 		"AWS::ServiceCatalog::AcceptedPortfolioShare":                 &servicecatalog.AcceptedPortfolioShare{},
 		"AWS::ServiceCatalog::CloudFormationProduct":                  &servicecatalog.CloudFormationProduct{},
 		"AWS::ServiceCatalog::CloudFormationProvisionedProduct":       &servicecatalog.CloudFormationProvisionedProduct{},
@@ -12602,6 +12603,30 @@ func (t *Template) GetServerlessSimpleTableWithName(name string) (*serverless.Si
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type serverless.SimpleTable not found", name)
+}
+
+// GetAllServerlessStateMachineResources retrieves all serverless.StateMachine items from an AWS CloudFormation template
+func (t *Template) GetAllServerlessStateMachineResources() map[string]*serverless.StateMachine {
+	results := map[string]*serverless.StateMachine{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *serverless.StateMachine:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetServerlessStateMachineWithName retrieves all serverless.StateMachine items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetServerlessStateMachineWithName(name string) (*serverless.StateMachine, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *serverless.StateMachine:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type serverless.StateMachine not found", name)
 }
 
 // GetAllServiceCatalogAcceptedPortfolioShareResources retrieves all servicecatalog.AcceptedPortfolioShare items from an AWS CloudFormation template

--- a/cloudformation/serverless/aws-serverless-function.go
+++ b/cloudformation/serverless/aws-serverless-function.go
@@ -47,6 +47,11 @@ type Function struct {
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
 	Events map[string]Function_EventSource `json:"Events,omitempty"`
 
+	// FileSystemConfigs AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html
+	FileSystemConfigs []Function_FileSystemConfig `json:"FileSystemConfigs,omitempty"`
+
 	// FunctionName AWS CloudFormation Property
 	// Required: false
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/cloudformation/serverless/aws-serverless-function_filesystemconfig.go
+++ b/cloudformation/serverless/aws-serverless-function_filesystemconfig.go
@@ -1,0 +1,40 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Function_FileSystemConfig AWS CloudFormation Resource (AWS::Serverless::Function.FileSystemConfig)
+// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath
+type Function_FileSystemConfig struct {
+
+	// Arn AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath
+	Arn string `json:"Arn,omitempty"`
+
+	// LocalMountPath AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath
+	LocalMountPath string `json:"LocalMountPath,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Function_FileSystemConfig) AWSCloudFormationType() string {
+	return "AWS::Serverless::Function.FileSystemConfig"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine.go
+++ b/cloudformation/serverless/aws-serverless-statemachine.go
@@ -1,0 +1,151 @@
+package serverless
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine AWS CloudFormation Resource (AWS::Serverless::StateMachine)
+// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+type StateMachine struct {
+
+	// Definition AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Definition interface{} `json:"Definition,omitempty"`
+
+	// DefinitionSubstitutions AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	DefinitionSubstitutions map[string]string `json:"DefinitionSubstitutions,omitempty"`
+
+	// DefinitionUri AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	DefinitionUri *StateMachine_DefinitionUri `json:"DefinitionUri,omitempty"`
+
+	// Events AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Events map[string]StateMachine_EventSource `json:"Events,omitempty"`
+
+	// Logging AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Logging *StateMachine_LoggingConfiguration `json:"Logging,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Name string `json:"Name,omitempty"`
+
+	// Policies AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Policies *StateMachine_Policies `json:"Policies,omitempty"`
+
+	// Role AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Role string `json:"Role,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Tags map[string]string `json:"Tags,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+	Type string `json:"Type,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r StateMachine) MarshalJSON() ([]byte, error) {
+	type Properties StateMachine
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *StateMachine) UnmarshalJSON(b []byte) error {
+	type Properties StateMachine
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = StateMachine(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_apievent.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_apievent.go
@@ -1,0 +1,45 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_ApiEvent AWS CloudFormation Resource (AWS::Serverless::StateMachine.ApiEvent)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+type StateMachine_ApiEvent struct {
+
+	// Method AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+	Method string `json:"Method,omitempty"`
+
+	// Path AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+	Path string `json:"Path,omitempty"`
+
+	// RestApiId AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+	RestApiId string `json:"RestApiId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_ApiEvent) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.ApiEvent"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_cloudwatcheventevent.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_cloudwatcheventevent.go
@@ -1,0 +1,50 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_CloudWatchEventEvent AWS CloudFormation Resource (AWS::Serverless::StateMachine.CloudWatchEventEvent)
+// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+type StateMachine_CloudWatchEventEvent struct {
+
+	// EventBusName AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+	EventBusName string `json:"EventBusName,omitempty"`
+
+	// Input AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+	Input string `json:"Input,omitempty"`
+
+	// InputPath AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+	InputPath string `json:"InputPath,omitempty"`
+
+	// Pattern AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
+	Pattern interface{} `json:"Pattern,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_CloudWatchEventEvent) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.CloudWatchEventEvent"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_cloudwatchlogsloggroup.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_cloudwatchlogsloggroup.go
@@ -1,0 +1,35 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_CloudWatchLogsLogGroup AWS CloudFormation Resource (AWS::Serverless::StateMachine.CloudWatchLogsLogGroup)
+// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup.html
+type StateMachine_CloudWatchLogsLogGroup struct {
+
+	// LogGroupArn AWS CloudFormation Property
+	// Required: true
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup.html
+	LogGroupArn string `json:"LogGroupArn,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_CloudWatchLogsLogGroup) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.CloudWatchLogsLogGroup"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_eventbridgeruleevent.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_eventbridgeruleevent.go
@@ -1,0 +1,50 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_EventBridgeRuleEvent AWS CloudFormation Resource (AWS::Serverless::StateMachine.EventBridgeRuleEvent)
+// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+type StateMachine_EventBridgeRuleEvent struct {
+
+	// EventBusName AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+	EventBusName string `json:"EventBusName,omitempty"`
+
+	// Input AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+	Input string `json:"Input,omitempty"`
+
+	// InputPath AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html
+	InputPath string `json:"InputPath,omitempty"`
+
+	// Pattern AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
+	Pattern interface{} `json:"Pattern,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_EventBridgeRuleEvent) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.EventBridgeRuleEvent"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_eventsource.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_eventsource.go
@@ -1,0 +1,40 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_EventSource AWS CloudFormation Resource (AWS::Serverless::StateMachine.EventSource)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-object
+type StateMachine_EventSource struct {
+
+	// Properties AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-types
+	Properties *StateMachine_Properties `json:"Properties,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-object
+	Type string `json:"Type,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_EventSource) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.EventSource"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_functionsampt.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_functionsampt.go
@@ -1,0 +1,35 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_FunctionSAMPT AWS CloudFormation Resource (AWS::Serverless::StateMachine.FunctionSAMPT)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+type StateMachine_FunctionSAMPT struct {
+
+	// FunctionName AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+	FunctionName string `json:"FunctionName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_FunctionSAMPT) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.FunctionSAMPT"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_iampolicydocument.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_iampolicydocument.go
@@ -1,0 +1,35 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_IAMPolicyDocument AWS CloudFormation Resource (AWS::Serverless::StateMachine.IAMPolicyDocument)
+// See: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html
+type StateMachine_IAMPolicyDocument struct {
+
+	// Statement AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html
+	Statement interface{} `json:"Statement,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_IAMPolicyDocument) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.IAMPolicyDocument"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_logdestination.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_logdestination.go
@@ -1,0 +1,35 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_LogDestination AWS CloudFormation Resource (AWS::Serverless::StateMachine.LogDestination)
+// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination.html#cfn-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup
+type StateMachine_LogDestination struct {
+
+	// CloudWatchLogsLogGroup AWS CloudFormation Property
+	// Required: true
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination.html#cfn-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup
+	CloudWatchLogsLogGroup *StateMachine_CloudWatchLogsLogGroup `json:"CloudWatchLogsLogGroup,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_LogDestination) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.LogDestination"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_loggingconfiguration.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_loggingconfiguration.go
@@ -1,0 +1,45 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_LoggingConfiguration AWS CloudFormation Resource (AWS::Serverless::StateMachine.LoggingConfiguration)
+// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html
+type StateMachine_LoggingConfiguration struct {
+
+	// Destinations AWS CloudFormation Property
+	// Required: true
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html
+	Destinations []StateMachine_LogDestination `json:"Destinations,omitempty"`
+
+	// IncludeExecutionData AWS CloudFormation Property
+	// Required: true
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html
+	IncludeExecutionData bool `json:"IncludeExecutionData"`
+
+	// Level AWS CloudFormation Property
+	// Required: true
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html
+	Level string `json:"Level,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_LoggingConfiguration) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.LoggingConfiguration"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_s3location.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_s3location.go
@@ -1,0 +1,45 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_S3Location AWS CloudFormation Resource (AWS::Serverless::StateMachine.S3Location)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3-location-object
+type StateMachine_S3Location struct {
+
+	// Bucket AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+	Bucket string `json:"Bucket,omitempty"`
+
+	// Key AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+	Key string `json:"Key,omitempty"`
+
+	// Version AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+	Version int `json:"Version,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_S3Location) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.S3Location"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_sampolicytemplate.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_sampolicytemplate.go
@@ -1,0 +1,40 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_SAMPolicyTemplate AWS CloudFormation Resource (AWS::Serverless::StateMachine.SAMPolicyTemplate)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+type StateMachine_SAMPolicyTemplate struct {
+
+	// LambdaInvokePolicy AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+	LambdaInvokePolicy *StateMachine_FunctionSAMPT `json:"LambdaInvokePolicy,omitempty"`
+
+	// StepFunctionsExecutionPolicy AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+	StepFunctionsExecutionPolicy *StateMachine_StateMachineSAMPT `json:"StepFunctionsExecutionPolicy,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_SAMPolicyTemplate) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.SAMPolicyTemplate"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_scheduleevent.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_scheduleevent.go
@@ -1,0 +1,40 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_ScheduleEvent AWS CloudFormation Resource (AWS::Serverless::StateMachine.ScheduleEvent)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
+type StateMachine_ScheduleEvent struct {
+
+	// Input AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
+	Input string `json:"Input,omitempty"`
+
+	// Schedule AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
+	Schedule string `json:"Schedule,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_ScheduleEvent) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.ScheduleEvent"
+}

--- a/cloudformation/serverless/aws-serverless-statemachine_statemachinesampt.go
+++ b/cloudformation/serverless/aws-serverless-statemachine_statemachinesampt.go
@@ -1,0 +1,35 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// StateMachine_StateMachineSAMPT AWS CloudFormation Resource (AWS::Serverless::StateMachine.StateMachineSAMPT)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+type StateMachine_StateMachineSAMPT struct {
+
+	// StateMachineName AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst
+	StateMachineName string `json:"StateMachineName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *StateMachine_StateMachineSAMPT) AWSCloudFormationType() string {
+	return "AWS::Serverless::StateMachine.StateMachineSAMPT"
+}

--- a/cloudformation/serverless/statemachine_definitionuri.go
+++ b/cloudformation/serverless/statemachine_definitionuri.go
@@ -1,0 +1,64 @@
+package serverless
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/awslabs/goformation/v4/cloudformation/utils"
+)
+
+// StateMachine_DefinitionUri is a helper struct that can hold either a String or S3Location value
+type StateMachine_DefinitionUri struct {
+	String *string
+
+	S3Location *StateMachine_S3Location
+}
+
+func (r StateMachine_DefinitionUri) value() interface{} {
+	ret := []interface{}{}
+
+	if r.String != nil {
+		ret = append(ret, r.String)
+	}
+
+	if r.S3Location != nil {
+		ret = append(ret, *r.S3Location)
+	}
+
+	sort.Sort(utils.ByJSONLength(ret)) // Heuristic to select best attribute
+	if len(ret) > 0 {
+		return ret[0]
+	}
+
+	return nil
+}
+
+func (r StateMachine_DefinitionUri) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.value())
+}
+
+// Hook into the marshaller
+func (r *StateMachine_DefinitionUri) UnmarshalJSON(b []byte) error {
+
+	// Unmarshal into interface{} to check it's type
+	var typecheck interface{}
+	if err := json.Unmarshal(b, &typecheck); err != nil {
+		return err
+	}
+
+	switch val := typecheck.(type) {
+
+	case string:
+		r.String = &val
+
+	case map[string]interface{}:
+		val = val // This ensures val is used to stop an error
+
+		json.Unmarshal(b, &r.S3Location)
+
+	case []interface{}:
+
+	}
+
+	return nil
+}

--- a/cloudformation/serverless/statemachine_policies.go
+++ b/cloudformation/serverless/statemachine_policies.go
@@ -1,0 +1,90 @@
+package serverless
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/awslabs/goformation/v4/cloudformation/utils"
+)
+
+// StateMachine_Policies is a helper struct that can hold either a String, String, IAMPolicyDocument, SAMPolicyTemplate, or IAMPolicyDocument value
+type StateMachine_Policies struct {
+	String *string
+
+	StringArray *[]string
+
+	IAMPolicyDocument *StateMachine_IAMPolicyDocument
+
+	IAMPolicyDocumentArray *[]StateMachine_IAMPolicyDocument
+	SAMPolicyTemplateArray *[]StateMachine_SAMPolicyTemplate
+}
+
+func (r StateMachine_Policies) value() interface{} {
+	ret := []interface{}{}
+
+	if r.String != nil {
+		ret = append(ret, r.String)
+	}
+
+	if r.StringArray != nil {
+		ret = append(ret, r.StringArray)
+	}
+
+	if r.IAMPolicyDocument != nil {
+		ret = append(ret, *r.IAMPolicyDocument)
+	}
+
+	if r.IAMPolicyDocumentArray != nil {
+		ret = append(ret, r.IAMPolicyDocumentArray)
+	}
+
+	if r.SAMPolicyTemplateArray != nil {
+		ret = append(ret, r.SAMPolicyTemplateArray)
+	}
+
+	sort.Sort(utils.ByJSONLength(ret)) // Heuristic to select best attribute
+	if len(ret) > 0 {
+		return ret[0]
+	}
+
+	return nil
+}
+
+func (r StateMachine_Policies) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.value())
+}
+
+// Hook into the marshaller
+func (r *StateMachine_Policies) UnmarshalJSON(b []byte) error {
+
+	// Unmarshal into interface{} to check it's type
+	var typecheck interface{}
+	if err := json.Unmarshal(b, &typecheck); err != nil {
+		return err
+	}
+
+	switch val := typecheck.(type) {
+
+	case string:
+		r.String = &val
+
+	case []string:
+		r.StringArray = &val
+
+	case map[string]interface{}:
+		val = val // This ensures val is used to stop an error
+
+		json.Unmarshal(b, &r.IAMPolicyDocument)
+
+	case []interface{}:
+
+		json.Unmarshal(b, &r.StringArray)
+
+		json.Unmarshal(b, &r.IAMPolicyDocumentArray)
+
+		json.Unmarshal(b, &r.SAMPolicyTemplateArray)
+
+	}
+
+	return nil
+}

--- a/cloudformation/serverless/statemachine_properties.go
+++ b/cloudformation/serverless/statemachine_properties.go
@@ -1,0 +1,76 @@
+package serverless
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/awslabs/goformation/v4/cloudformation/utils"
+)
+
+// StateMachine_Properties is a helper struct that can hold either a CloudWatchEventEvent, EventBridgeRuleEvent, ScheduleEvent, or ApiEvent value
+type StateMachine_Properties struct {
+	CloudWatchEventEvent *StateMachine_CloudWatchEventEvent
+	EventBridgeRuleEvent *StateMachine_EventBridgeRuleEvent
+	ScheduleEvent        *StateMachine_ScheduleEvent
+	ApiEvent             *StateMachine_ApiEvent
+}
+
+func (r StateMachine_Properties) value() interface{} {
+	ret := []interface{}{}
+
+	if r.CloudWatchEventEvent != nil {
+		ret = append(ret, *r.CloudWatchEventEvent)
+	}
+
+	if r.EventBridgeRuleEvent != nil {
+		ret = append(ret, *r.EventBridgeRuleEvent)
+	}
+
+	if r.ScheduleEvent != nil {
+		ret = append(ret, *r.ScheduleEvent)
+	}
+
+	if r.ApiEvent != nil {
+		ret = append(ret, *r.ApiEvent)
+	}
+
+	sort.Sort(utils.ByJSONLength(ret)) // Heuristic to select best attribute
+	if len(ret) > 0 {
+		return ret[0]
+	}
+
+	return nil
+}
+
+func (r StateMachine_Properties) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.value())
+}
+
+// Hook into the marshaller
+func (r *StateMachine_Properties) UnmarshalJSON(b []byte) error {
+
+	// Unmarshal into interface{} to check it's type
+	var typecheck interface{}
+	if err := json.Unmarshal(b, &typecheck); err != nil {
+		return err
+	}
+
+	switch val := typecheck.(type) {
+
+	case map[string]interface{}:
+		val = val // This ensures val is used to stop an error
+
+		json.Unmarshal(b, &r.CloudWatchEventEvent)
+
+		json.Unmarshal(b, &r.EventBridgeRuleEvent)
+
+		json.Unmarshal(b, &r.ScheduleEvent)
+
+		json.Unmarshal(b, &r.ApiEvent)
+
+	case []interface{}:
+
+	}
+
+	return nil
+}

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -1422,6 +1422,197 @@
                     "UpdateType": "Immutable"
                 }
             }
+        },
+        "AWS::Serverless::StateMachine.IAMPolicyDocument": {
+            "Documentation": "http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html",
+            "Properties": {
+                "Statement": {
+                    "Documentation": "http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html",
+                    "PrimitiveType": "Json",
+                    "Required": true,
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.SAMPolicyTemplate": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+            "Properties": {
+                "LambdaInvokePolicy": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+                    "Type": "FunctionSAMPT",
+                    "UpdateType": "Immutable"
+                },
+                "StepFunctionsExecutionPolicy": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+                    "Type": "StateMachineSAMPT",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.StateMachineSAMPT": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+            "Properties": {
+                "StateMachineName": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.FunctionSAMPT": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+            "Properties": {
+                "FunctionName": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/docs/policy_templates.rst",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.S3Location": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#s3-location-object",
+            "Properties": {
+                "Bucket": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Key": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Version": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
+                    "Required": false,
+                    "PrimitiveType": "Integer",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.EventSource": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-object",
+            "Properties": {
+                "Type": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-object",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Properties": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#event-source-types",
+                    "Required": true,
+                    "Types": [
+                        "CloudWatchEventEvent",
+                        "EventBridgeRuleEvent",
+                        "ScheduleEvent",
+                        "ApiEvent"
+                    ],
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.CloudWatchEventEvent": {
+            "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+            "Properties": {
+                "Pattern": {
+                    "Documentation": "http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html",
+                    "Required": true,
+                    "PrimitiveType": "Json",
+                    "UpdateType": "Immutable"
+                },
+                "EventBusName": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Input": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "InputPath": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.EventBridgeRuleEvent": {
+            "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+            "Properties": {
+                "Pattern": {
+                    "Documentation": "http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html",
+                    "Required": true,
+                    "PrimitiveType": "Json",
+                    "UpdateType": "Immutable"
+                },
+                "EventBusName": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Input": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "InputPath": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-statemachine-cloudwatchevent.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.ScheduleEvent": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule",
+            "Properties": {
+                "Schedule": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Input": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.ApiEvent": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api",
+            "Properties": {
+                "Path": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Method": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "RestApiId": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
         }
     }
 }

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -381,6 +381,91 @@
                     "UpdateType": "Immutable"
                 }
             }
+        },
+        "AWS::Serverless::StateMachine": {
+            "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+            "Properties": {
+                "Definition": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "PrimitiveType": "Json",
+                    "UpdateType": "Immutable"
+                },
+                "DefinitionSubstitutions": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "Type": "Map",
+                    "PrimitiveItemType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "DefinitionUri": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "PrimitiveTypes": [
+                        "String"
+                    ],
+                    "Types": [
+                        "S3Location"
+                    ],
+                    "UpdateType": "Immutable"
+                },
+                "Events": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "Type": "Map",
+                    "ItemType": "EventSource",
+                    "UpdateType": "Immutable"
+                },
+                "Logging": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "Type": "LoggingConfiguration",
+                    "UpdateType": "Immutable"
+                },
+                "Name": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Policies": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "PrimitiveTypes": [
+                        "String"
+                    ],
+                    "PrimitiveItemTypes": [
+                        "String"
+                    ],
+                    "Types": [
+                        "IAMPolicyDocument"
+                    ],
+                    "ItemTypes": [
+                        "IAMPolicyDocument",
+                        "SAMPolicyTemplate"
+                    ],
+                    "UpdateType": "Immutable"
+                },
+                "Role": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Tags": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "Type": "Map",
+                    "PrimitiveItemType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "Type": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
         }
     },
     "PropertyTypes": {
@@ -1149,6 +1234,52 @@
                 },
                 "Value": {
                     "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter-s3key-rules.html",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.LoggingConfiguration": {
+            "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html",
+            "Properties": {
+                "Destinations": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html",
+                    "Required": true,
+                    "Type": "List",
+                    "ItemType": "LogDestination",
+                    "UpdateType": "Immutable"
+                },
+                "IncludeExecutionData": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html",
+                    "Required": true,
+                    "PrimitiveType": "Boolean",
+                    "UpdateType": "Immutable"
+                },
+                "Level": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-loggingconfiguration.html",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.LogDestination": {
+            "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination.html#cfn-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup",
+            "Properties": {
+                "CloudWatchLogsLogGroup": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination.html#cfn-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup",
+                    "Required": true,
+                    "Type": "CloudWatchLogsLogGroup",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::StateMachine.CloudWatchLogsLogGroup": {
+            "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup.html",
+            "Properties": {
+                "LogGroupArn": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-logdestination-cloudwatchlogsloggroup.html",
                     "Required": true,
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -34,6 +34,13 @@
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 },
+                "FileSystemConfigs": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html",
+                    "Required": false,
+                    "Type": "List",
+                    "ItemType": "FileSystemConfig",
+                    "UpdateType": "Immutable"
+                },
                 "Description": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
                     "Required": false,
@@ -505,6 +512,23 @@
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
                     "Required": false,
                     "PrimitiveType": "Integer",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::Function.FileSystemConfig": {
+            "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath",
+            "Properties": {
+                "Arn": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "LocalMountPath": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath",
+                    "Required": false,
+                    "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 }
             }

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -63405,6 +63405,12 @@ var SamSchema = `{
                             },
                             "type": "object"
                         },
+                        "FileSystemConfigs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Serverless::Function.FileSystemConfig"
+                            },
+                            "type": "array"
+                        },
                         "FunctionName": {
                             "type": "string"
                         },
@@ -63737,6 +63743,18 @@ var SamSchema = `{
                 "Properties",
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::Serverless::Function.FileSystemConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "LocalMountPath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Serverless::Function.FunctionEnvironment": {

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -64377,6 +64377,364 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::Serverless::StateMachine": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Definition": {
+                            "type": "object"
+                        },
+                        "DefinitionSubstitutions": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "DefinitionUri": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::StateMachine.S3Location"
+                                }
+                            ]
+                        },
+                        "Events": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "$ref": "#/definitions/AWS::Serverless::StateMachine.EventSource"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Logging": {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.LoggingConfiguration"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::StateMachine.IAMPolicyDocument"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/AWS::Serverless::StateMachine.IAMPolicyDocument"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/AWS::Serverless::StateMachine.SAMPolicyTemplate"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Serverless::StateMachine"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.ApiEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "Method": {
+                    "type": "string"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "RestApiId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Method",
+                "Path"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.CloudWatchEventEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "EventBusName": {
+                    "type": "string"
+                },
+                "Input": {
+                    "type": "string"
+                },
+                "InputPath": {
+                    "type": "string"
+                },
+                "Pattern": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "Pattern"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.CloudWatchLogsLogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "LogGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LogGroupArn"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.EventBridgeRuleEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "EventBusName": {
+                    "type": "string"
+                },
+                "Input": {
+                    "type": "string"
+                },
+                "InputPath": {
+                    "type": "string"
+                },
+                "Pattern": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "Pattern"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.EventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.CloudWatchEventEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.EventBridgeRuleEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.ScheduleEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.ApiEvent"
+                        }
+                    ]
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Properties",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.FunctionSAMPT": {
+            "additionalProperties": false,
+            "properties": {
+                "FunctionName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FunctionName"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.IAMPolicyDocument": {
+            "additionalProperties": false,
+            "properties": {
+                "Statement": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "Statement"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.LogDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogsLogGroup": {
+                    "$ref": "#/definitions/AWS::Serverless::StateMachine.CloudWatchLogsLogGroup"
+                }
+            },
+            "required": [
+                "CloudWatchLogsLogGroup"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destinations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Serverless::StateMachine.LogDestination"
+                    },
+                    "type": "array"
+                },
+                "IncludeExecutionData": {
+                    "type": "boolean"
+                },
+                "Level": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destinations",
+                "IncludeExecutionData",
+                "Level"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.S3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Bucket",
+                "Key"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.SAMPolicyTemplate": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaInvokePolicy": {
+                    "$ref": "#/definitions/AWS::Serverless::StateMachine.FunctionSAMPT"
+                },
+                "StepFunctionsExecutionPolicy": {
+                    "$ref": "#/definitions/AWS::Serverless::StateMachine.StateMachineSAMPT"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.ScheduleEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "Input": {
+                    "type": "string"
+                },
+                "Schedule": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Schedule"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.StateMachineSAMPT": {
+            "additionalProperties": false,
+            "properties": {
+                "StateMachineName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "StateMachineName"
+            ],
+            "type": "object"
+        },
         "AWS::ServiceCatalog::AcceptedPortfolioShare": {
             "additionalProperties": false,
             "properties": {
@@ -71704,6 +72062,9 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::Serverless::SimpleTable"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine"
                         },
                         {
                             "$ref": "#/definitions/AWS::ServiceCatalog::AcceptedPortfolioShare"

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -63402,6 +63402,12 @@
                             },
                             "type": "object"
                         },
+                        "FileSystemConfigs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Serverless::Function.FileSystemConfig"
+                            },
+                            "type": "array"
+                        },
                         "FunctionName": {
                             "type": "string"
                         },
@@ -63734,6 +63740,18 @@
                 "Properties",
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::Serverless::Function.FileSystemConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "LocalMountPath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Serverless::Function.FunctionEnvironment": {

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -64374,6 +64374,364 @@
             },
             "type": "object"
         },
+        "AWS::Serverless::StateMachine": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Definition": {
+                            "type": "object"
+                        },
+                        "DefinitionSubstitutions": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "DefinitionUri": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::StateMachine.S3Location"
+                                }
+                            ]
+                        },
+                        "Events": {
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "$ref": "#/definitions/AWS::Serverless::StateMachine.EventSource"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Logging": {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.LoggingConfiguration"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Policies": {
+                            "anyOf": [
+                                {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "$ref": "#/definitions/AWS::Serverless::StateMachine.IAMPolicyDocument"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/AWS::Serverless::StateMachine.IAMPolicyDocument"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "items": {
+                                        "$ref": "#/definitions/AWS::Serverless::StateMachine.SAMPolicyTemplate"
+                                    },
+                                    "type": "array"
+                                }
+                            ]
+                        },
+                        "Role": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::Serverless::StateMachine"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.ApiEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "Method": {
+                    "type": "string"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "RestApiId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Method",
+                "Path"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.CloudWatchEventEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "EventBusName": {
+                    "type": "string"
+                },
+                "Input": {
+                    "type": "string"
+                },
+                "InputPath": {
+                    "type": "string"
+                },
+                "Pattern": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "Pattern"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.CloudWatchLogsLogGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "LogGroupArn": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LogGroupArn"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.EventBridgeRuleEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "EventBusName": {
+                    "type": "string"
+                },
+                "Input": {
+                    "type": "string"
+                },
+                "InputPath": {
+                    "type": "string"
+                },
+                "Pattern": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "Pattern"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.EventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.CloudWatchEventEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.EventBridgeRuleEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.ScheduleEvent"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine.ApiEvent"
+                        }
+                    ]
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Properties",
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.FunctionSAMPT": {
+            "additionalProperties": false,
+            "properties": {
+                "FunctionName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "FunctionName"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.IAMPolicyDocument": {
+            "additionalProperties": false,
+            "properties": {
+                "Statement": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "Statement"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.LogDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogsLogGroup": {
+                    "$ref": "#/definitions/AWS::Serverless::StateMachine.CloudWatchLogsLogGroup"
+                }
+            },
+            "required": [
+                "CloudWatchLogsLogGroup"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "Destinations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Serverless::StateMachine.LogDestination"
+                    },
+                    "type": "array"
+                },
+                "IncludeExecutionData": {
+                    "type": "boolean"
+                },
+                "Level": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Destinations",
+                "IncludeExecutionData",
+                "Level"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.S3Location": {
+            "additionalProperties": false,
+            "properties": {
+                "Bucket": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Bucket",
+                "Key"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.SAMPolicyTemplate": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaInvokePolicy": {
+                    "$ref": "#/definitions/AWS::Serverless::StateMachine.FunctionSAMPT"
+                },
+                "StepFunctionsExecutionPolicy": {
+                    "$ref": "#/definitions/AWS::Serverless::StateMachine.StateMachineSAMPT"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.ScheduleEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "Input": {
+                    "type": "string"
+                },
+                "Schedule": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Schedule"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::StateMachine.StateMachineSAMPT": {
+            "additionalProperties": false,
+            "properties": {
+                "StateMachineName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "StateMachineName"
+            ],
+            "type": "object"
+        },
         "AWS::ServiceCatalog::AcceptedPortfolioShare": {
             "additionalProperties": false,
             "properties": {
@@ -71701,6 +72059,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::Serverless::SimpleTable"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::Serverless::StateMachine"
                         },
                         {
                             "$ref": "#/definitions/AWS::ServiceCatalog::AcceptedPortfolioShare"


### PR DESCRIPTION
*Description of changes:*
This PR adds step functions via `AWS::Serverless::StateMachine` to the SAM template and generated code

This PR also adds `FileSystemConfigs` ([see](https://aws.amazon.com/blogs/compute/using-amazon-efs-for-aws-lambda-in-your-serverless-applications/)) to `AWS::Serverless::Function`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
