### PR TITLE
[WIP][Feature] add Serverless FileSystemConfigs

### DIFF
--- a/cloudformation/serverless/aws-serverless-function.go
+++ b/cloudformation/serverless/aws-serverless-function.go
@@ -47,6 +47,11 @@ type Function struct {
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
 	Events map[string]Function_EventSource `json:"Events,omitempty"`
 
+	// FileSystemConfigs AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html
+	FileSystemConfigs []Function_FileSystemConfig `json:"FileSystemConfigs,omitempty"`
+
 	// FunctionName AWS CloudFormation Property
 	// Required: false
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/cloudformation/serverless/aws-serverless-function_filesystemconfig.go
+++ b/cloudformation/serverless/aws-serverless-function_filesystemconfig.go
@@ -1,0 +1,40 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Function_FileSystemConfig AWS CloudFormation Resource (AWS::Serverless::Function.FileSystemConfig)
+// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath
+type Function_FileSystemConfig struct {
+
+	// Arn AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath
+	Arn string `json:"Arn,omitempty"`
+
+	// LocalMountPath AWS CloudFormation Property
+	// Required: false
+	// See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath
+	LocalMountPath string `json:"LocalMountPath,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Function_FileSystemConfig) AWSCloudFormationType() string {
+	return "AWS::Serverless::Function.FileSystemConfig"
+}

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -34,6 +34,13 @@
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 },
+                "FileSystemConfigs": {
+                    "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html",
+                    "Required": false,
+                    "Type": "List",
+                    "ItemType": "FileSystemConfig",
+                    "UpdateType": "Immutable"
+                },
                 "Description": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
                     "Required": false,
@@ -420,6 +427,23 @@
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
                     "Required": false,
                     "PrimitiveType": "Integer",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::Function.FileSystemConfig": {
+            "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath",
+            "Properties": {
+                "Arn": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath",
+                    "Required": false,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                },
+                "LocalMountPath": {
+                    "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html#cfn-lambda-function-filesystemconfig-localmountpath",
+                    "Required": false,
+                    "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 }
             }

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -63405,6 +63405,12 @@ var SamSchema = `{
                             },
                             "type": "object"
                         },
+                        "FileSystemConfigs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Serverless::Function.FileSystemConfig"
+                            },
+                            "type": "array"
+                        },
                         "FunctionName": {
                             "type": "string"
                         },
@@ -63737,6 +63743,18 @@ var SamSchema = `{
                 "Properties",
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::Serverless::Function.FileSystemConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "LocalMountPath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Serverless::Function.FunctionEnvironment": {

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -63402,6 +63402,12 @@
                             },
                             "type": "object"
                         },
+                        "FileSystemConfigs": {
+                            "items": {
+                                "$ref": "#/definitions/AWS::Serverless::Function.FileSystemConfig"
+                            },
+                            "type": "array"
+                        },
                         "FunctionName": {
                             "type": "string"
                         },
@@ -63734,6 +63740,18 @@
                 "Properties",
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::Serverless::Function.FileSystemConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "LocalMountPath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Serverless::Function.FunctionEnvironment": {


### PR DESCRIPTION
*Description of changes:*
This PR adds `FileSystemConfigs` ([see](https://aws.amazon.com/blogs/compute/using-amazon-efs-for-aws-lambda-in-your-serverless-applications/)) to `AWS::Serverless::Function`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
