### PR TITLE
[Fix] Add Change and Update policies to the Unmarshal method

### DIFF
--- a/cloudformation/autoscaling/aws-autoscaling-autoscalinggroup.go
+++ b/cloudformation/autoscaling/aws-autoscaling-autoscalinggroup.go
@@ -193,6 +193,8 @@ func (r *AutoScalingGroup) UnmarshalJSON(b []byte) error {
 		DeletionPolicy      string
 		UpdateReplacePolicy string
 		Condition           string
+		UpdatePolicy        map[string]interface{}
+		CreationPolicy      map[string]interface{}
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))

--- a/cloudformation/autoscaling/aws-autoscaling-autoscalinggroup.go
+++ b/cloudformation/autoscaling/aws-autoscaling-autoscalinggroup.go
@@ -193,8 +193,8 @@ func (r *AutoScalingGroup) UnmarshalJSON(b []byte) error {
 		DeletionPolicy      string
 		UpdateReplacePolicy string
 		Condition           string
-		UpdatePolicy        map[string]interface{}
-		CreationPolicy      map[string]interface{}
+		UpdatePolicy        *policies.UpdatePolicy
+		CreationPolicy      *policies.CreationPolicy
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
@@ -224,5 +224,13 @@ func (r *AutoScalingGroup) UnmarshalJSON(b []byte) error {
 	if res.Condition != "" {
 		r.AWSCloudFormationCondition = res.Condition
 	}
+	if res.UpdatePolicy != nil {
+		r.AWSCloudFormationUpdatePolicy = res.UpdatePolicy
+	}
+
+	if res.CreationPolicy != nil {
+		r.AWSCloudFormationCreationPolicy = res.CreationPolicy
+	}
+
 	return nil
 }

--- a/cloudformation/cloudformation/aws-cloudformation-waitcondition.go
+++ b/cloudformation/cloudformation/aws-cloudformation-waitcondition.go
@@ -90,6 +90,8 @@ func (r *WaitCondition) UnmarshalJSON(b []byte) error {
 		DeletionPolicy      string
 		UpdateReplacePolicy string
 		Condition           string
+
+		CreationPolicy map[string]interface{}
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))

--- a/cloudformation/cloudformation/aws-cloudformation-waitcondition.go
+++ b/cloudformation/cloudformation/aws-cloudformation-waitcondition.go
@@ -91,7 +91,7 @@ func (r *WaitCondition) UnmarshalJSON(b []byte) error {
 		UpdateReplacePolicy string
 		Condition           string
 
-		CreationPolicy map[string]interface{}
+		CreationPolicy *policies.CreationPolicy
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
@@ -121,5 +121,9 @@ func (r *WaitCondition) UnmarshalJSON(b []byte) error {
 	if res.Condition != "" {
 		r.AWSCloudFormationCondition = res.Condition
 	}
+	if res.CreationPolicy != nil {
+		r.AWSCloudFormationCreationPolicy = res.CreationPolicy
+	}
+
 	return nil
 }

--- a/cloudformation/ec2/aws-ec2-instance.go
+++ b/cloudformation/ec2/aws-ec2-instance.go
@@ -261,6 +261,8 @@ func (r *Instance) UnmarshalJSON(b []byte) error {
 		DeletionPolicy      string
 		UpdateReplacePolicy string
 		Condition           string
+
+		CreationPolicy map[string]interface{}
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))

--- a/cloudformation/ec2/aws-ec2-instance.go
+++ b/cloudformation/ec2/aws-ec2-instance.go
@@ -262,7 +262,7 @@ func (r *Instance) UnmarshalJSON(b []byte) error {
 		UpdateReplacePolicy string
 		Condition           string
 
-		CreationPolicy map[string]interface{}
+		CreationPolicy *policies.CreationPolicy
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
@@ -292,5 +292,9 @@ func (r *Instance) UnmarshalJSON(b []byte) error {
 	if res.Condition != "" {
 		r.AWSCloudFormationCondition = res.Condition
 	}
+	if res.CreationPolicy != nil {
+		r.AWSCloudFormationCreationPolicy = res.CreationPolicy
+	}
+
 	return nil
 }

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -2,6 +2,7 @@ package cloudformation
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -105,99 +106,109 @@ var EncoderIntrinsics = map[string]intrinsics.IntrinsicHandler{
 
 // Ref creates a CloudFormation Reference to another resource in the template
 func Ref(logicalName interface{}) string {
-	return encode(fmt.Sprintf(`{ "Ref": "%v" }`, logicalName))
+	return encode(fmt.Sprintf(`{ "Ref": %q }`, logicalName))
 }
 
 // ImportValue returns the value of an output exported by another stack. You typically use this function to create cross-stack references. In the following example template snippets, Stack A exports VPC security group values and Stack B imports them.
 func ImportValue(name interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::ImportValue": "%v" }`, name))
+	return encode(fmt.Sprintf(`{ "Fn::ImportValue": %q }`, name))
 }
 
 // Base64 returns the Base64 representation of the input string. This function is typically used to pass encoded data to Amazon EC2 instances by way of the UserData property
 func Base64(input interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Base64": "%v" }`, input))
+	return encode(fmt.Sprintf(`{ "Fn::Base64": %q }`, input))
 }
 
 // GetAZs returns an array that lists Availability Zones for a specified region. Because customers have access to different Availability Zones, the intrinsic function Fn::GetAZs enables template authors to write templates that adapt to the calling user's access. That way you don't have to hard-code a full list of Availability Zones for a specified region.
 func GetAZs(region interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::GetAZs": "%v" }`, region))
+	return encode(fmt.Sprintf(`{ "Fn::GetAZs": %q }`, region))
 }
 
 // Sub substitutes variables in an input string with values that you specify. In your templates, you can use this function to construct commands or outputs that include values that aren't available until you create or update a stack.
 func Sub(value interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Sub" : "%v" }`, value))
+	return encode(fmt.Sprintf(`{ "Fn::Sub" : %q }`, value.(string)))
 }
 
 // (str, str) -> str
 
 // GetAtt returns the value of an attribute from a resource in the template.
 func GetAtt(logicalName string, attribute string) string {
-	return encode(fmt.Sprintf(`{ "Fn::GetAtt" : [ "%v", "%v" ] }`, logicalName, attribute))
+	return encode(fmt.Sprintf(`{ "Fn::GetAtt" : [ %q, %q ] }`, logicalName, attribute))
 }
 
 // Split splits a string into a list of string values so that you can select an element from the resulting string list, use the Fn::Split intrinsic function. Specify the location of splits with a delimiter, such as , (a comma). After you split a string, use the Fn::Select function to pick a specific element.
 func Split(delimiter, source interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Split" : [ "%v", "%v" ] }`, delimiter, source))
+	return encode(fmt.Sprintf(`{ "Fn::Split" : [ %q, %q ] }`, delimiter, source))
 }
 
 // Equals compares if two values are equal. Returns true if the two values are equal or false if they aren't.
 func Equals(value1, value2 interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Equals" : [ "%v", "%v" ] }`, value1, value2))
+	return encode(fmt.Sprintf(`{ "Fn::Equals" : [ %q, %q ] }`, value1, value2))
 }
 
 // (str, str, str) -> str
 
 // CIDR returns an array of CIDR address blocks. The number of CIDR blocks returned is dependent on the count parameter.
 func CIDR(ipBlock, count, cidrBits interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Cidr" : [ "%v", "%v", "%v" ] }`, ipBlock, count, cidrBits))
+	return encode(fmt.Sprintf(`{ "Fn::Cidr" : [ %q, %q, %q ] }`, ipBlock, count, cidrBits))
 }
 
 // FindInMap returns the value corresponding to keys in a two-level map that is declared in the Mappings section.
 func FindInMap(mapName, topLevelKey, secondLevelKey interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::FindInMap" : [ "%v", "%v", "%v" ] }`, mapName, topLevelKey, secondLevelKey))
+	return encode(fmt.Sprintf(`{ "Fn::FindInMap" : [ %q, %q, %q ] }`, mapName, topLevelKey, secondLevelKey))
 }
 
 // If returns one value if the specified condition evaluates to true and another value if the specified condition evaluates to false. Currently, AWS CloudFormation supports the Fn::If intrinsic function in the metadata attribute, update policy attribute, and property values in the Resources section and Outputs sections of a template. You can use the AWS::NoValue pseudo parameter as a return value to remove the corresponding property.
 func If(value, ifEqual, ifNotEqual interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::If" : [ "%v", "%v", "%v" ] }`, value, ifEqual, ifNotEqual))
+	return encode(fmt.Sprintf(`{ "Fn::If" : [ %q, %q, %q ] }`, value, ifEqual, ifNotEqual))
 }
 
 // (str, []str) -> str
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, values []string) string {
-	return encode(fmt.Sprintf(`{ "Fn::Join": [ "%v", [ "%v" ] ] }`, delimiter, strings.Trim(strings.Join(values, `", "`), `, "`)))
+	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %q ] ] }`, delimiter, strings.Trim(strings.Join(values, `", "`), `, "`)))
 }
 
 // Select returns a single object from a list of objects by index.
 func Select(index interface{}, list []string) string {
 	if len(list) == 1 {
-		return encode(fmt.Sprintf(`{ "Fn::Select": [ "%v",  "%v" ] }`, index, list[0]))
+		return encode(fmt.Sprintf(`{ "Fn::Select": [ %q,  %q ] }`, index, list[0]))
 	}
-	return encode(fmt.Sprintf(`{ "Fn::Select": [ "%v", [ "%v" ] ] }`, index, strings.Trim(strings.Join(list, `", "`), `, "`)))
+	return encode(fmt.Sprintf(`{ "Fn::Select": [ %q, [ %q ] ] }`, index, strings.Trim(strings.Join(list, `", "`), `, "`)))
 }
 
 // ([]str) -> str
 
 // And returns true if all the specified conditions evaluate to true, or returns false if any one of the conditions evaluates to false. Fn::And acts as an AND operator. The minimum number of conditions that you can include is 2, and the maximum is 10.
 func And(conditions []string) string {
-	return encode(fmt.Sprintf(`{ "Fn::And": [ "%v" ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
+	return encode(fmt.Sprintf(`{ "Fn::And": [ %q ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
 }
 
 // Not returns true for a condition that evaluates to false or returns false for a condition that evaluates to true. Fn::Not acts as a NOT operator.
 func Not(conditions []string) string {
-	return encode(fmt.Sprintf(`{ "Fn::Not": [ "%v" ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
+	return encode(fmt.Sprintf(`{ "Fn::Not": [ %q ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
 }
 
 // Or returns true if any one of the specified conditions evaluate to true, or returns false if all of the conditions evaluates to false. Fn::Or acts as an OR operator. The minimum number of conditions that you can include is 2, and the maximum is 10.
 func Or(conditions []string) string {
-	return encode(fmt.Sprintf(`{ "Fn::Or": [ "%v" ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
+	return encode(fmt.Sprintf(`{ "Fn::Or": [ %q ] }`, strings.Trim(strings.Join(conditions, `", "`), `, "`)))
 }
 
 // encode takes a string representation of an intrinsic function, and base64 encodes it.
 // This prevents the escaping issues when nesting multiple layers of intrinsic functions.
 func encode(value string) string {
+
 	return base64.StdEncoding.EncodeToString([]byte(value))
+}
+
+func jsonEscape(i string) string {
+	b, err := json.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	s := string(b)
+	return s[1 : len(s)-1]
 }
 
 func interfaceAtostrA(values []interface{}) []string {

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -18,12 +18,29 @@ func strWrap(fn func(interface{}) string) intrinsics.IntrinsicHandler {
 func strSplit2Wrap(fn func(string, string) string) intrinsics.IntrinsicHandler {
 	delim := "."
 	return func(name string, input interface{}, template interface{}) interface{} {
-		if str, ok := input.(string); ok {
-			arr := strings.SplitN(str, delim, 2)
+		switch v := input.(type) {
+		case string:
+			arr := strings.SplitN(v, delim, 2)
 			if len(arr) != 2 {
 				return nil
 			}
 			return fn(arr[0], arr[1])
+		case []interface{}:
+			if len(v) != 2 {
+				return nil
+			}
+
+			str1, ok := v[0].(string)
+			if !ok {
+				return nil
+			}
+
+			str2, ok := v[1].(string)
+			if !ok {
+				return nil
+			}
+
+			return fn(str1, str2)
 		}
 		return nil
 	}

--- a/cloudformation/intrinsics_test.go
+++ b/cloudformation/intrinsics_test.go
@@ -99,6 +99,13 @@ var _ = Describe("Goformation", func() {
 				Input:    `Description: !Or [a, b, c]`,
 				Expected: `{"Description":{"Fn::Or":["a","b","c"]}}`,
 			},
+			{
+				Name: "JSON escaped",
+				Input: `Description: !Sub |
+  "quote"
+  newline`,
+				Expected: `{"Description":{"Fn::Sub":"\"quote\"\nnewline"}}`,
+			},
 		}
 
 		for _, test := range tests {

--- a/cloudformation/lambda/aws-lambda-alias.go
+++ b/cloudformation/lambda/aws-lambda-alias.go
@@ -103,7 +103,7 @@ func (r *Alias) UnmarshalJSON(b []byte) error {
 		DeletionPolicy      string
 		UpdateReplacePolicy string
 		Condition           string
-		UpdatePolicy        map[string]interface{}
+		UpdatePolicy        *policies.UpdatePolicy
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
@@ -133,5 +133,9 @@ func (r *Alias) UnmarshalJSON(b []byte) error {
 	if res.Condition != "" {
 		r.AWSCloudFormationCondition = res.Condition
 	}
+	if res.UpdatePolicy != nil {
+		r.AWSCloudFormationUpdatePolicy = res.UpdatePolicy
+	}
+
 	return nil
 }

--- a/cloudformation/lambda/aws-lambda-alias.go
+++ b/cloudformation/lambda/aws-lambda-alias.go
@@ -103,6 +103,7 @@ func (r *Alias) UnmarshalJSON(b []byte) error {
 		DeletionPolicy      string
 		UpdateReplacePolicy string
 		Condition           string
+		UpdatePolicy        map[string]interface{}
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))

--- a/generate/templates/resource.template
+++ b/generate/templates/resource.template
@@ -93,6 +93,8 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 		DependsOn []string
 		Metadata map[string]interface{}
 		DeletionPolicy string
+		{{if .HasUpdatePolicy}}UpdatePolicy map[string]interface{} {{end}}
+		{{if .HasCreationPolicy}}CreationPolicy map[string]interface{} {{end}}
 		UpdateReplacePolicy string
 		Condition string
 	}{}

--- a/generate/templates/resource.template
+++ b/generate/templates/resource.template
@@ -83,6 +83,8 @@ func (r {{.StructName}}) MarshalJSON() ([]byte, error) {
 	})
 }
 
+
+
 // UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
 // AWS CloudFormation resource object, and just keeps the 'Properties' field.
 func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
@@ -95,8 +97,8 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 		DeletionPolicy string
 		UpdateReplacePolicy string
 		Condition string
-		{{if .HasUpdatePolicy}}UpdatePolicy map[string]interface{} {{end}}
-		{{if .HasCreationPolicy}}CreationPolicy map[string]interface{} {{end}}
+		{{if .HasUpdatePolicy}}UpdatePolicy *policies.UpdatePolicy {{end}}
+		{{if .HasCreationPolicy}}CreationPolicy *policies.CreationPolicy{{end}}
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
@@ -125,7 +127,11 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 	}
 	if res.Condition != "" {
 		r.AWSCloudFormationCondition = res.Condition
-	}
+	} {{if .HasUpdatePolicy }}
+		if res.UpdatePolicy != nil { r.AWSCloudFormationUpdatePolicy = res.UpdatePolicy }
+	{{end}} {{if .HasCreationPolicy}}
+		if res.CreationPolicy != nil { r.AWSCloudFormationCreationPolicy = res.CreationPolicy }
+	{{end}}
 	return nil
 }
 

--- a/generate/templates/resource.template
+++ b/generate/templates/resource.template
@@ -93,10 +93,10 @@ func (r *{{.StructName}}) UnmarshalJSON(b []byte) error {
 		DependsOn []string
 		Metadata map[string]interface{}
 		DeletionPolicy string
-		{{if .HasUpdatePolicy}}UpdatePolicy map[string]interface{} {{end}}
-		{{if .HasCreationPolicy}}CreationPolicy map[string]interface{} {{end}}
 		UpdateReplacePolicy string
 		Condition string
+		{{if .HasUpdatePolicy}}UpdatePolicy map[string]interface{} {{end}}
+		{{if .HasCreationPolicy}}CreationPolicy map[string]interface{} {{end}}
 	}{}
 
 	dec := json.NewDecoder(bytes.NewReader(b))


### PR DESCRIPTION
*Description of changes:*
This PR:

1. adds the Change and Update policies to the Unmarshal method, then runs `go generate`. Without this change we get an unmarshal error for resources with these policies.
2. fixes intrinsic encoding incorrectly if an argument contains something needing escaping, e.g. if the !Sub has a new line in it.
3. fixes GetAtt decoding if it is a JSON fn::GetAtt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
