### PR TITLE
Accept dodgy parameter properties

### DIFF
--- a/goformation_test.go
+++ b/goformation_test.go
@@ -1252,4 +1252,16 @@ var _ = Describe("Goformation", func() {
 
 	})
 
+	Context("with a template which is accepted by CloudFormation but doesn't quite match the spec", func() {
+		It("should load the template anyway", func() {
+			template, err := goformation.Open("test/yaml/accepted-but-against-spec.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(template.Parameters).To(HaveKey("AnnoyingParam1"))
+			Expect(template.Parameters["AnnoyingParam1"].MinLength).To(Equal(cloudformation.MaybeInt(8)))
+			Expect(template.Parameters["AnnoyingParam1"].MaxLength).To(Equal(cloudformation.MaybeInt(255)))
+			Expect(template.Parameters).To(HaveKey("AnnoyingParam2"))
+			Expect(template.Parameters["AnnoyingParam2"].MinValue).To(Equal(cloudformation.MaybeNumber(1150)))
+			Expect(template.Parameters["AnnoyingParam2"].MaxValue).To(Equal(cloudformation.MaybeNumber(65535)))
+		})
+	})
 })

--- a/test/yaml/accepted-but-against-spec.yaml
+++ b/test/yaml/accepted-but-against-spec.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CFN template which doesn't match spec but accepted by CFN
+Parameters:
+  AnnoyingParam1:
+    Type: String
+    MinLength: 8   # The spec says these should both be ints
+    MaxLength: '255' #
+
+  AnnoyingParam2:
+    Type: Number
+    MinValue: 1150
+    MaxValue: '65535'
+
+Resources:
+  Topic:
+    Type: AWS::SNS::Topic


### PR DESCRIPTION
Some parameter properties should be numbers according to the spec, but
CloudFormation will quite happily accept strings.

"Can't beat the system, go with the flow."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
