### PR TITLE
Field Export on type Output should be pointer

### DIFF
--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -40,7 +40,7 @@ type Parameter struct {
 type Output struct {
 	Value       interface{} `json:"Value"`
 	Description string      `json:"Description,omitempty"`
-	Export      Export      `json:"Export,omitempty"`
+	Export      *Export     `json:"Export,omitempty"`
 }
 
 type Export struct {

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/awslabs/goformation/v4"
 	"github.com/awslabs/goformation/v4/cloudformation"
+	"github.com/awslabs/goformation/v4/cloudformation/ec2"
 	"github.com/awslabs/goformation/v4/cloudformation/lambda"
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
 	"github.com/awslabs/goformation/v4/cloudformation/route53"
@@ -1252,4 +1253,47 @@ var _ = Describe("Goformation", func() {
 
 	})
 
+	Context("with a template that contains outputs with no exports", func() {
+
+		Context("described as Go structs", func() {
+
+			template := cloudformation.NewTemplate()
+
+			template.Resources["Vpc"] = &ec2.VPC{
+				CidrBlock: "192.168.0.0/20",
+			}
+
+			template.Outputs["VpcId"] = cloudformation.Output{
+				Value: cloudformation.Ref("Vpc"),
+			}
+
+			expected := `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Outputs": {
+    "VpcId": {
+      "Value": {
+        "Ref": "Vpc"
+      }
+    }
+  },
+  "Resources": {
+    "Vpc": {
+      "Properties": {
+        "CidrBlock": "192.168.0.0/20"
+      },
+      "Type": "AWS::EC2::VPC"
+    }
+  }
+}`
+
+			got, err := template.JSON()
+			It("should marshal template successfully", func() {
+				Expect(err).To(BeNil())
+			})
+
+			It("should be equal to expected output", func() {
+				Expect(string(got)).To(Equal(expected))
+			})
+		})
+	})
 })


### PR DESCRIPTION
The field Export of the type Output should be a pointer,
otherwise it would produce invalid output, by adding
an empty struct to the export field:

```
Outputs:
  VpcId:
    Export: {}
```

This empty struct will cause a template validation error:

"Template format error: Output VpcId is malformed.
The Name field of every Export member is required."

Closes #294 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
