### PR TITLE
fix(generator): Check for properties with no type in CFN spec

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -166,12 +166,16 @@ func (rg *ResourceGenerator) processSpec(specname string, data []byte) (*CloudFo
 
 	// Check that all of resource properties have a valid type
 	// see: https://github.com/awslabs/goformation/issues/300
+	invalid := []string{}
 	for rname, resource := range spec.Resources {
 		for pname, property := range resource.Properties {
 			if !property.HasValidType() {
-				return nil, fmt.Errorf("%s.%s has no type information in the CloudFormation Resource Specification", rname, pname)
+				invalid = append(invalid, fmt.Sprintf("\t%s.%s", rname, pname))
 			}
 		}
+	}
+	if len(invalid) > 0 {
+		return nil, fmt.Errorf("the following resource properties have no type information in the CloudFormation Resource Specification:\n%s\n", strings.Join(invalid, "\n"))
 	}
 
 	// Add the resources processed to the ResourceGenerator output

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -164,6 +164,16 @@ func (rg *ResourceGenerator) processSpec(specname string, data []byte) (*CloudFo
 		return nil, err
 	}
 
+	// Check that all of resource properties have a valid type
+	// see: https://github.com/awslabs/goformation/issues/300
+	for rname, resource := range spec.Resources {
+		for pname, property := range resource.Properties {
+			if !property.HasValidType() {
+				return nil, fmt.Errorf("%s.%s has no type information in the CloudFormation Resource Specification", rname, pname)
+			}
+		}
+	}
+
 	// Add the resources processed to the ResourceGenerator output
 	for name := range spec.Resources {
 

--- a/generate/property.go
+++ b/generate/property.go
@@ -129,6 +129,22 @@ func (p Property) Schema(name, parent string) string {
 
 }
 
+// HasValidType checks whether a property has a valid type defined
+// It is possible that an invalid CloudFormation Resource Specification is published
+// that does not have any type information for a property. If this happens, then
+// generation should fail with an error message.
+func (p Property) HasValidType() bool {
+	invalid := p.ItemType == "" &&
+		p.PrimitiveType == "" &&
+		p.PrimitiveItemType == "" &&
+		p.Type == "" &&
+		len(p.ItemTypes) == 0 &&
+		len(p.PrimitiveTypes) == 0 &&
+		len(p.PrimitiveItemTypes) == 0 &&
+		len(p.Types) == 0
+	return !invalid
+}
+
 // IsPolymorphic checks whether a property can be multiple different types
 func (p Property) IsPolymorphic() bool {
 	return len(p.PrimitiveTypes) > 0 || len(p.PrimitiveItemTypes) > 0 || len(p.PrimitiveItemTypes) > 0 || len(p.ItemTypes) > 0 || len(p.Types) > 0


### PR DESCRIPTION
*Issue #, if available:* #300

*Description of changes:*
If the CloudFormation Resource Specification has a resource property
that does not include any type information then this should be a
breaking error and generation should fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
