### PR TITLE
Accept dodgy parameter properties

### DIFF
--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/awslabs/goformation/v4/cloudformation/types"
 	"github.com/awslabs/goformation/v4/intrinsics"
 	"github.com/sanathkr/yaml"
 )
@@ -54,6 +55,30 @@ type Resource interface {
 type Parameters map[string]Parameter
 type Resources map[string]Resource
 type Outputs map[string]Output
+
+func (p *Parameter) UnmarshalJSON(b []byte) error {
+	type Alias Parameter
+	params := &Parameter{}
+	newParams := &struct {
+		MaxLength types.MaybeInt   `json:"MaxLength"`
+		MinLength types.MaybeInt   `json:"MinLength"`
+		MaxValue  types.MaybeFloat `json:"MaxValue"`
+		MinValue  types.MaybeFloat `json:"MinValue"`
+		NoEcho    types.MaybeBool  `json:"NoEcho"`
+		*Alias
+	}{Alias: (*Alias)(params)}
+	err := json.Unmarshal(b, newParams)
+	if err != nil {
+		return err
+	}
+	params.MaxLength = int(newParams.MaxLength)
+	params.MinLength = int(newParams.MinLength)
+	params.MaxValue = float64(newParams.MaxValue)
+	params.MinValue = float64(newParams.MinValue)
+	params.NoEcho = bool(newParams.NoEcho)
+	*p = *params
+	return nil
+}
 
 func (resources *Resources) UnmarshalJSON(b []byte) error {
 	// Resources

--- a/cloudformation/types/boolean.go
+++ b/cloudformation/types/boolean.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type MaybeBool bool
+
+func (o *MaybeBool) UnmarshalJSON(b []byte) error {
+	// CFN accepts the strings 'true' and 'false' as boolean
+	var raw interface{}
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	var l bool
+	switch v := raw.(type) {
+	case bool:
+		l = v
+	case string:
+		lowerV := strings.ToLower(v)
+		if lowerV == "false" {
+			l = false
+		}
+		if lowerV == "true" {
+			l = true
+		}
+	case nil:
+		l = false
+	default:
+		return fmt.Errorf("invalid type %T - expected bool or bool-like-string", raw)
+	}
+	*o = MaybeBool(l)
+	return nil
+}

--- a/cloudformation/types/number.go
+++ b/cloudformation/types/number.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type MaybeInt int
+
+func (i *MaybeInt) UnmarshalJSON(b []byte) error {
+	// Treat this as a float if we possibly can
+	var raw interface{}
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	ret, err := strconv.Atoi(fmt.Sprintf("%v", raw))
+	if err != nil {
+		return err
+	}
+	*i = MaybeInt(ret)
+
+	return nil
+}
+
+type MaybeFloat float64
+
+func (f *MaybeFloat) UnmarshalJSON(b []byte) error {
+	// Treat this as a float if we possibly can
+	var raw interface{}
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	ret, err := strconv.ParseFloat(fmt.Sprintf("%v", raw), 64)
+	if err != nil {
+		return err
+	}
+	*f = MaybeFloat(ret)
+
+	return nil
+}

--- a/cloudformation/types/string.go
+++ b/cloudformation/types/string.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+/*
+	CloudFormation is a lot more accepting of mistmatched types than the
+	default Go JSON decoder.
+
+	Here we try and match this behaviour.
+*/
+
+type MaybeString string
+
+func (s *MaybeString) UnmarshalJSON(b []byte) error {
+	// Treat this as a string, even if it's really an int or whatever
+	var raw interface{}
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	*s = MaybeString(fmt.Sprintf("%v", raw))
+
+	return nil
+}

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -1251,5 +1251,18 @@ var _ = Describe("Goformation", func() {
 		})
 
 	})
-
+	Context("with a template which is accepted by CloudFormation but doesn't quite match the spec", func() {
+		It("should load the template anyway", func() {
+			template, err := goformation.Open("test/yaml/accepted-but-against-spec.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(template.Parameters).To(HaveKey("AnnoyingParam1"))
+			Expect(template.Parameters["AnnoyingParam1"].MinLength).To(Equal(8))
+			Expect(template.Parameters["AnnoyingParam1"].MaxLength).To(Equal(255))
+			Expect(template.Parameters["AnnoyingParam1"].NoEcho).To(BeTrue())
+			Expect(template.Parameters).To(HaveKey("AnnoyingParam2"))
+			Expect(template.Parameters["AnnoyingParam2"].MinValue).To(Equal(float64(1150)))
+			Expect(template.Parameters["AnnoyingParam2"].MaxValue).To(Equal(float64(65535)))
+			Expect(template.Parameters["AnnoyingParam2"].NoEcho).To(BeTrue())
+		})
+	})
 })

--- a/test/yaml/accepted-but-against-spec.yaml
+++ b/test/yaml/accepted-but-against-spec.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CFN template which doesn't match spec but accepted by CFN
+Parameters:
+  AnnoyingParam1:
+    Type: String
+    MinLength: 8     # The spec says these should both be ints
+    MaxLength: '255' #
+    NoEcho: true
+
+  AnnoyingParam2:
+    Type: Number
+    MinValue: 1150
+    MaxValue: '65535'
+    NoEcho: "true"
+
+Resources:
+  Topic:
+    Type: AWS::SNS::Topic


### PR DESCRIPTION
Some parameter properties should be numbers according to the spec, but CloudFormation will quite happily accept strings.

This is a cleaner implementation of #298 which only alters unmarshaling.  This means it shouldn't break any existing code.

I've got a commit ready for resource parsing too, but #301 has (deliberately?) broken code generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
