### PR TITLE
Fix Join function to allow to use parameters of type `List<>`

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -110,7 +110,7 @@ var EncoderIntrinsics = map[string]intrinsics.IntrinsicHandler{
 	"Fn::GetAtt":      strSplit2Wrap(GetAtt),
 	"Fn::GetAZs":      strWrap(GetAZs),
 	"Fn::ImportValue": strWrap(ImportValue),
-	"Fn::Join":        str2AWrap(Join),
+	"Fn::Join":        str2Wrap(Join),
 	"Fn::Select":      str2AWrap(Select),
 	"Fn::Split":       str2Wrap(Split),
 	"Fn::Sub":         strWrap(Sub),
@@ -182,13 +182,16 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 // (str, []str) -> str
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
-func Join(delimiter interface{}, values []string) string {
-	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values)))
-}
-
-// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
-func JoinListParameter(delimiter interface{}, parameter string) string {
-	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] ] }`, delimiter, parameter))
+func Join(delimiter interface{}, values interface{}) string {
+	switch x := values.(type) {
+	case []string:
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values.([]string))))
+	case string:
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values))
+	default:
+		fmt.Printf("Unsupported type for Join: %T\n", x)
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values))
+	}
 }
 
 // Select returns a single object from a list of objects by index.

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -183,7 +183,7 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, values []string) string {
-	if len(values) == 1 {
+	if len(values) == 1 && strings.Contains(values[0], "Fn::Ref") {
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values[0]))
 	}
 	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values)))

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -183,6 +183,9 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, values []string) string {
+	if len(values) == 1 {
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values[0]))
+	}
 	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values)))
 }
 

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -182,15 +182,15 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 // (str, []str) -> str
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
-func Join(delimiter interface{}, values interface{}) string {
-	switch x := values.(type) {
+func Join(delimiter interface{}, value interface{}) string {
+	switch v := value.(type) {
 	case []string:
-		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values.([]string))))
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(value.([]string))))
 	case string:
-		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values))
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, value))
 	default:
-		fmt.Printf("Unsupported type for Join: %T\n", x)
-		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values))
+		fmt.Printf("Unsupported type for Join: %T\n", v)
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, value))
 	}
 }
 

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -183,8 +183,11 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, values []string) string {
-	if len(values) == 1 && strings.Contains(values[0], "Fn::Ref") {
-		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values[0]))
+	if len(values) == 1 {
+		sDec, _ := base64.StdEncoding.DecodeString(values[0])
+		if strings.Contains(string(sDec), "\"Ref\":") {
+			return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values[0]))
+		}
 	}
 	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values)))
 }

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -187,7 +187,7 @@ func Join(delimiter interface{}, value interface{}) string {
 	case []string:
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(value.([]string))))
 	case []interface{}:
-		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ "%v" ] ] }`, delimiter, strings.Join(interfaceAtostrA(value.([]interface{})), `","`)))
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(interfaceAtostrA(value.([]interface{})))))
 	case string:
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, value))
 	default:

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -183,13 +183,12 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, values []string) string {
-	if len(values) == 1 {
-		sDec, _ := base64.StdEncoding.DecodeString(values[0])
-		if strings.Contains(string(sDec), "\"Ref\":") {
-			return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, values[0]))
-		}
-	}
 	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(values)))
+}
+
+// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+func JoinListParameter(delimiter interface{}, parameter string) string {
+	return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] ] }`, delimiter, parameter))
 }
 
 // Select returns a single object from a list of objects by index.

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -184,7 +184,7 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, value interface{}) string {
 	switch v := value.(type) {
-	case []string:
+	case []string, []interface{}:
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(value.([]string))))
 	case string:
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, value))

--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -184,8 +184,10 @@ func If(value, ifEqual, ifNotEqual interface{}) string {
 // Join appends a set of values into a single value, separated by the specified delimiter. If a delimiter is the empty string, the set of values are concatenated with no delimiter.
 func Join(delimiter interface{}, value interface{}) string {
 	switch v := value.(type) {
-	case []string, []interface{}:
+	case []string:
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ %v ] ] }`, delimiter, printList(value.([]string))))
+	case []interface{}:
+		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q, [ "%v" ] ] }`, delimiter, strings.Join(interfaceAtostrA(value.([]interface{})), `","`)))
 	case string:
 		return encode(fmt.Sprintf(`{ "Fn::Join": [ %q,  %q ] }`, delimiter, value))
 	default:


### PR DESCRIPTION
*Issue #308, #282 

Tbh I do not found a better solution to fix that problem - also it will help to be compatible backward. Read more here - https://stackoverflow.com/questions/50560729/fnsub-expression-does-not-resolve-to-a-string