### PR TITLE
Hooks and Rules template sections

### DIFF
--- a/generate/templates/schema.template
+++ b/generate/templates/schema.template
@@ -88,6 +88,14 @@
                 }
             },
             "additionalProperties": false
+        },
+        "Hooks": {
+          "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/blue-green.html",
+          "type": "object"
+        },
+        "Rules": {
+          "description": "https://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html",
+          "type": "object"
         }
     },
     "required": [


### PR DESCRIPTION
fixes https://github.com/awslabs/goformation/issues/83
https://github.com/aws-cloudformation/aws-cloudformation-template-schema/pull/47
https://github.com/awsdocs/aws-cloudformation-user-guide/issues/794
[`Hooks`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/blue-green.html)
[`Rules`](https://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html)

---

Just saw [`schema/`](https://github.com/awslabs/goformation/tree/master/schema) shouldn't be edited directly 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
