### PR TITLE
chore(generator): autofix missing property types

### DIFF
--- a/.github/workflows/update_schema.yml
+++ b/.github/workflows/update_schema.yml
@@ -3,6 +3,7 @@ name: Update Schema
 on: 
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch: {}
 
 jobs:
   run:

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -164,20 +164,6 @@ func (rg *ResourceGenerator) processSpec(specname string, data []byte) (*CloudFo
 		return nil, err
 	}
 
-	// Check that all of resource properties have a valid type
-	// see: https://github.com/awslabs/goformation/issues/300
-	invalid := []string{}
-	for rname, resource := range spec.Resources {
-		for pname, property := range resource.Properties {
-			if !property.HasValidType() {
-				invalid = append(invalid, fmt.Sprintf("\t%s.%s", rname, pname))
-			}
-		}
-	}
-	if len(invalid) > 0 {
-		return nil, fmt.Errorf("the following resource properties have no type information in the CloudFormation Resource Specification:\n%s\n", strings.Join(invalid, "\n"))
-	}
-
 	// Add the resources processed to the ResourceGenerator output
 	for name := range spec.Resources {
 


### PR DESCRIPTION
*Issue #, if available:* #300 

*Description of changes:*
If a resource property is missing a type in the CloudFormation Resource
Specification (see #300), then autofix it to type = 'Json', which will
in turn set it to interface{} in the generated Go structs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
