### PR TITLE
Allow use parameters of type `List<>` in resources with properties where PrimitiveItemType = String and Type = List 

### DIFF
--- a/generate/property.go
+++ b/generate/property.go
@@ -236,7 +236,9 @@ func (p Property) GoType(typename string, basename string, name string) string {
 
 	if p.IsList() {
 
-		if p.convertTypeToGo() != "" {
+		if p.convertTypeToGo() == "string" {
+			return "interface{}"
+		} else if p.convertTypeToGo() != "" {
 			return "[]" + p.convertTypeToGo()
 		}
 


### PR DESCRIPTION
*Issue #, if available:*
#306 #282

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
