### PR TITLE
[Feature] Add ProvisionedConcurrencyConfig to Serverless::Functions

### DIFF
--- a/cloudformation/all.go
+++ b/cloudformation/all.go
@@ -17,6 +17,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/appsync"
 	"github.com/awslabs/goformation/v4/cloudformation/ask"
 	"github.com/awslabs/goformation/v4/cloudformation/athena"
+	"github.com/awslabs/goformation/v4/cloudformation/auditmanager"
 	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
 	"github.com/awslabs/goformation/v4/cloudformation/autoscalingplans"
 	"github.com/awslabs/goformation/v4/cloudformation/backup"
@@ -47,6 +48,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/datapipeline"
 	"github.com/awslabs/goformation/v4/cloudformation/dax"
 	"github.com/awslabs/goformation/v4/cloudformation/detective"
+	"github.com/awslabs/goformation/v4/cloudformation/devopsguru"
 	"github.com/awslabs/goformation/v4/cloudformation/directoryservice"
 	"github.com/awslabs/goformation/v4/cloudformation/dlm"
 	"github.com/awslabs/goformation/v4/cloudformation/dms"
@@ -71,6 +73,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/globalaccelerator"
 	"github.com/awslabs/goformation/v4/cloudformation/glue"
 	"github.com/awslabs/goformation/v4/cloudformation/greengrass"
+	"github.com/awslabs/goformation/v4/cloudformation/greengrassv2"
 	"github.com/awslabs/goformation/v4/cloudformation/guardduty"
 	"github.com/awslabs/goformation/v4/cloudformation/iam"
 	"github.com/awslabs/goformation/v4/cloudformation/imagebuilder"
@@ -81,6 +84,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/iotevents"
 	"github.com/awslabs/goformation/v4/cloudformation/iotsitewise"
 	"github.com/awslabs/goformation/v4/cloudformation/iotthingsgraph"
+	"github.com/awslabs/goformation/v4/cloudformation/iotwireless"
 	"github.com/awslabs/goformation/v4/cloudformation/ivs"
 	"github.com/awslabs/goformation/v4/cloudformation/kendra"
 	"github.com/awslabs/goformation/v4/cloudformation/kinesis"
@@ -90,6 +94,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/kms"
 	"github.com/awslabs/goformation/v4/cloudformation/lakeformation"
 	"github.com/awslabs/goformation/v4/cloudformation/lambda"
+	"github.com/awslabs/goformation/v4/cloudformation/licensemanager"
 	"github.com/awslabs/goformation/v4/cloudformation/logs"
 	"github.com/awslabs/goformation/v4/cloudformation/macie"
 	"github.com/awslabs/goformation/v4/cloudformation/managedblockchain"
@@ -98,6 +103,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/mediapackage"
 	"github.com/awslabs/goformation/v4/cloudformation/mediastore"
 	"github.com/awslabs/goformation/v4/cloudformation/msk"
+	"github.com/awslabs/goformation/v4/cloudformation/mwaa"
 	"github.com/awslabs/goformation/v4/cloudformation/neptune"
 	"github.com/awslabs/goformation/v4/cloudformation/networkfirewall"
 	"github.com/awslabs/goformation/v4/cloudformation/networkmanager"
@@ -217,6 +223,7 @@ func AllResources() map[string]Resource {
 		"AWS::Athena::DataCatalog":                                    &athena.DataCatalog{},
 		"AWS::Athena::NamedQuery":                                     &athena.NamedQuery{},
 		"AWS::Athena::WorkGroup":                                      &athena.WorkGroup{},
+		"AWS::AuditManager::Assessment":                               &auditmanager.Assessment{},
 		"AWS::AutoScaling::AutoScalingGroup":                          &autoscaling.AutoScalingGroup{},
 		"AWS::AutoScaling::LaunchConfiguration":                       &autoscaling.LaunchConfiguration{},
 		"AWS::AutoScaling::LifecycleHook":                             &autoscaling.LifecycleHook{},
@@ -238,6 +245,8 @@ func AllResources() map[string]Resource {
 		"AWS::Cloud9::EnvironmentEC2":                                 &cloud9.EnvironmentEC2{},
 		"AWS::CloudFormation::CustomResource":                         &cloudformation.CustomResource{},
 		"AWS::CloudFormation::Macro":                                  &cloudformation.Macro{},
+		"AWS::CloudFormation::ModuleDefaultVersion":                   &cloudformation.ModuleDefaultVersion{},
+		"AWS::CloudFormation::ModuleVersion":                          &cloudformation.ModuleVersion{},
 		"AWS::CloudFormation::Stack":                                  &cloudformation.Stack{},
 		"AWS::CloudFormation::StackSet":                               &cloudformation.StackSet{},
 		"AWS::CloudFormation::WaitCondition":                          &cloudformation.WaitCondition{},
@@ -313,6 +322,8 @@ func AllResources() map[string]Resource {
 		"AWS::DataPipeline::Pipeline":                                 &datapipeline.Pipeline{},
 		"AWS::Detective::Graph":                                       &detective.Graph{},
 		"AWS::Detective::MemberInvitation":                            &detective.MemberInvitation{},
+		"AWS::DevOpsGuru::NotificationChannel":                        &devopsguru.NotificationChannel{},
+		"AWS::DevOpsGuru::ResourceCollection":                         &devopsguru.ResourceCollection{},
 		"AWS::DirectoryService::MicrosoftAD":                          &directoryservice.MicrosoftAD{},
 		"AWS::DirectoryService::SimpleAD":                             &directoryservice.SimpleAD{},
 		"AWS::DocDB::DBCluster":                                       &docdb.DBCluster{},
@@ -343,6 +354,8 @@ func AllResources() map[string]Resource {
 		"AWS::EC2::NatGateway":                                        &ec2.NatGateway{},
 		"AWS::EC2::NetworkAcl":                                        &ec2.NetworkAcl{},
 		"AWS::EC2::NetworkAclEntry":                                   &ec2.NetworkAclEntry{},
+		"AWS::EC2::NetworkInsightsAnalysis":                           &ec2.NetworkInsightsAnalysis{},
+		"AWS::EC2::NetworkInsightsPath":                               &ec2.NetworkInsightsPath{},
 		"AWS::EC2::NetworkInterface":                                  &ec2.NetworkInterface{},
 		"AWS::EC2::NetworkInterfaceAttachment":                        &ec2.NetworkInterfaceAttachment{},
 		"AWS::EC2::NetworkInterfacePermission":                        &ec2.NetworkInterfacePermission{},
@@ -383,6 +396,7 @@ func AllResources() map[string]Resource {
 		"AWS::EC2::VPNGatewayRoutePropagation":                        &ec2.VPNGatewayRoutePropagation{},
 		"AWS::EC2::Volume":                                            &ec2.Volume{},
 		"AWS::EC2::VolumeAttachment":                                  &ec2.VolumeAttachment{},
+		"AWS::ECR::PublicRepository":                                  &ecr.PublicRepository{},
 		"AWS::ECR::Repository":                                        &ecr.Repository{},
 		"AWS::ECS::CapacityProvider":                                  &ecs.CapacityProvider{},
 		"AWS::ECS::Cluster":                                           &ecs.Cluster{},
@@ -407,6 +421,8 @@ func AllResources() map[string]Resource {
 		"AWS::ElastiCache::SecurityGroup":                             &elasticache.SecurityGroup{},
 		"AWS::ElastiCache::SecurityGroupIngress":                      &elasticache.SecurityGroupIngress{},
 		"AWS::ElastiCache::SubnetGroup":                               &elasticache.SubnetGroup{},
+		"AWS::ElastiCache::User":                                      &elasticache.User{},
+		"AWS::ElastiCache::UserGroup":                                 &elasticache.UserGroup{},
 		"AWS::ElasticBeanstalk::Application":                          &elasticbeanstalk.Application{},
 		"AWS::ElasticBeanstalk::ApplicationVersion":                   &elasticbeanstalk.ApplicationVersion{},
 		"AWS::ElasticBeanstalk::ConfigurationTemplate":                &elasticbeanstalk.ConfigurationTemplate{},
@@ -473,6 +489,7 @@ func AllResources() map[string]Resource {
 		"AWS::Greengrass::ResourceDefinitionVersion":                  &greengrass.ResourceDefinitionVersion{},
 		"AWS::Greengrass::SubscriptionDefinition":                     &greengrass.SubscriptionDefinition{},
 		"AWS::Greengrass::SubscriptionDefinitionVersion":              &greengrass.SubscriptionDefinitionVersion{},
+		"AWS::GreengrassV2::ComponentVersion":                         &greengrassv2.ComponentVersion{},
 		"AWS::GuardDuty::Detector":                                    &guardduty.Detector{},
 		"AWS::GuardDuty::Filter":                                      &guardduty.Filter{},
 		"AWS::GuardDuty::IPSet":                                       &guardduty.IPSet{},
@@ -519,10 +536,19 @@ func AllResources() map[string]Resource {
 		"AWS::IoTAnalytics::Pipeline":                                 &iotanalytics.Pipeline{},
 		"AWS::IoTEvents::DetectorModel":                               &iotevents.DetectorModel{},
 		"AWS::IoTEvents::Input":                                       &iotevents.Input{},
+		"AWS::IoTSiteWise::AccessPolicy":                              &iotsitewise.AccessPolicy{},
 		"AWS::IoTSiteWise::Asset":                                     &iotsitewise.Asset{},
 		"AWS::IoTSiteWise::AssetModel":                                &iotsitewise.AssetModel{},
+		"AWS::IoTSiteWise::Dashboard":                                 &iotsitewise.Dashboard{},
 		"AWS::IoTSiteWise::Gateway":                                   &iotsitewise.Gateway{},
+		"AWS::IoTSiteWise::Portal":                                    &iotsitewise.Portal{},
+		"AWS::IoTSiteWise::Project":                                   &iotsitewise.Project{},
 		"AWS::IoTThingsGraph::FlowTemplate":                           &iotthingsgraph.FlowTemplate{},
+		"AWS::IoTWireless::Destination":                               &iotwireless.Destination{},
+		"AWS::IoTWireless::DeviceProfile":                             &iotwireless.DeviceProfile{},
+		"AWS::IoTWireless::ServiceProfile":                            &iotwireless.ServiceProfile{},
+		"AWS::IoTWireless::WirelessDevice":                            &iotwireless.WirelessDevice{},
+		"AWS::IoTWireless::WirelessGateway":                           &iotwireless.WirelessGateway{},
 		"AWS::KMS::Alias":                                             &kms.Alias{},
 		"AWS::KMS::Key":                                               &kms.Key{},
 		"AWS::Kendra::DataSource":                                     &kendra.DataSource{},
@@ -550,12 +576,15 @@ func AllResources() map[string]Resource {
 		"AWS::Lambda::LayerVersionPermission":                         &lambda.LayerVersionPermission{},
 		"AWS::Lambda::Permission":                                     &lambda.Permission{},
 		"AWS::Lambda::Version":                                        &lambda.Version{},
+		"AWS::LicenseManager::Grant":                                  &licensemanager.Grant{},
+		"AWS::LicenseManager::License":                                &licensemanager.License{},
 		"AWS::Logs::Destination":                                      &logs.Destination{},
 		"AWS::Logs::LogGroup":                                         &logs.LogGroup{},
 		"AWS::Logs::LogStream":                                        &logs.LogStream{},
 		"AWS::Logs::MetricFilter":                                     &logs.MetricFilter{},
 		"AWS::Logs::SubscriptionFilter":                               &logs.SubscriptionFilter{},
 		"AWS::MSK::Cluster":                                           &msk.Cluster{},
+		"AWS::MWAA::Environment":                                      &mwaa.Environment{},
 		"AWS::Macie::CustomDataIdentifier":                            &macie.CustomDataIdentifier{},
 		"AWS::Macie::FindingsFilter":                                  &macie.FindingsFilter{},
 		"AWS::Macie::Session":                                         &macie.Session{},
@@ -680,14 +709,24 @@ func AllResources() map[string]Resource {
 		"AWS::SSM::PatchBaseline":                                     &ssm.PatchBaseline{},
 		"AWS::SSM::ResourceDataSync":                                  &ssm.ResourceDataSync{},
 		"AWS::SSO::Assignment":                                        &sso.Assignment{},
+		"AWS::SSO::InstanceAccessControlAttributeConfiguration":       &sso.InstanceAccessControlAttributeConfiguration{},
 		"AWS::SSO::PermissionSet":                                     &sso.PermissionSet{},
 		"AWS::SageMaker::CodeRepository":                              &sagemaker.CodeRepository{},
+		"AWS::SageMaker::DataQualityJobDefinition":                    &sagemaker.DataQualityJobDefinition{},
+		"AWS::SageMaker::Device":                                      &sagemaker.Device{},
+		"AWS::SageMaker::DeviceFleet":                                 &sagemaker.DeviceFleet{},
 		"AWS::SageMaker::Endpoint":                                    &sagemaker.Endpoint{},
 		"AWS::SageMaker::EndpointConfig":                              &sagemaker.EndpointConfig{},
 		"AWS::SageMaker::Model":                                       &sagemaker.Model{},
+		"AWS::SageMaker::ModelBiasJobDefinition":                      &sagemaker.ModelBiasJobDefinition{},
+		"AWS::SageMaker::ModelExplainabilityJobDefinition":            &sagemaker.ModelExplainabilityJobDefinition{},
+		"AWS::SageMaker::ModelPackageGroup":                           &sagemaker.ModelPackageGroup{},
+		"AWS::SageMaker::ModelQualityJobDefinition":                   &sagemaker.ModelQualityJobDefinition{},
 		"AWS::SageMaker::MonitoringSchedule":                          &sagemaker.MonitoringSchedule{},
 		"AWS::SageMaker::NotebookInstance":                            &sagemaker.NotebookInstance{},
 		"AWS::SageMaker::NotebookInstanceLifecycleConfig":             &sagemaker.NotebookInstanceLifecycleConfig{},
+		"AWS::SageMaker::Pipeline":                                    &sagemaker.Pipeline{},
+		"AWS::SageMaker::Project":                                     &sagemaker.Project{},
 		"AWS::SageMaker::Workteam":                                    &sagemaker.Workteam{},
 		"AWS::SecretsManager::ResourcePolicy":                         &secretsmanager.ResourcePolicy{},
 		"AWS::SecretsManager::RotationSchedule":                       &secretsmanager.RotationSchedule{},
@@ -2605,6 +2644,30 @@ func (t *Template) GetAthenaWorkGroupWithName(name string) (*athena.WorkGroup, e
 	return nil, fmt.Errorf("resource %q of type athena.WorkGroup not found", name)
 }
 
+// GetAllAuditManagerAssessmentResources retrieves all auditmanager.Assessment items from an AWS CloudFormation template
+func (t *Template) GetAllAuditManagerAssessmentResources() map[string]*auditmanager.Assessment {
+	results := map[string]*auditmanager.Assessment{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *auditmanager.Assessment:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetAuditManagerAssessmentWithName retrieves all auditmanager.Assessment items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetAuditManagerAssessmentWithName(name string) (*auditmanager.Assessment, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *auditmanager.Assessment:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type auditmanager.Assessment not found", name)
+}
+
 // GetAllAutoScalingAutoScalingGroupResources retrieves all autoscaling.AutoScalingGroup items from an AWS CloudFormation template
 func (t *Template) GetAllAutoScalingAutoScalingGroupResources() map[string]*autoscaling.AutoScalingGroup {
 	results := map[string]*autoscaling.AutoScalingGroup{}
@@ -3107,6 +3170,54 @@ func (t *Template) GetCloudFormationMacroWithName(name string) (*cloudformation.
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type cloudformation.Macro not found", name)
+}
+
+// GetAllCloudFormationModuleDefaultVersionResources retrieves all cloudformation.ModuleDefaultVersion items from an AWS CloudFormation template
+func (t *Template) GetAllCloudFormationModuleDefaultVersionResources() map[string]*cloudformation.ModuleDefaultVersion {
+	results := map[string]*cloudformation.ModuleDefaultVersion{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *cloudformation.ModuleDefaultVersion:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetCloudFormationModuleDefaultVersionWithName retrieves all cloudformation.ModuleDefaultVersion items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetCloudFormationModuleDefaultVersionWithName(name string) (*cloudformation.ModuleDefaultVersion, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *cloudformation.ModuleDefaultVersion:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type cloudformation.ModuleDefaultVersion not found", name)
+}
+
+// GetAllCloudFormationModuleVersionResources retrieves all cloudformation.ModuleVersion items from an AWS CloudFormation template
+func (t *Template) GetAllCloudFormationModuleVersionResources() map[string]*cloudformation.ModuleVersion {
+	results := map[string]*cloudformation.ModuleVersion{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *cloudformation.ModuleVersion:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetCloudFormationModuleVersionWithName retrieves all cloudformation.ModuleVersion items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetCloudFormationModuleVersionWithName(name string) (*cloudformation.ModuleVersion, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *cloudformation.ModuleVersion:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type cloudformation.ModuleVersion not found", name)
 }
 
 // GetAllCloudFormationStackResources retrieves all cloudformation.Stack items from an AWS CloudFormation template
@@ -4909,6 +5020,54 @@ func (t *Template) GetDetectiveMemberInvitationWithName(name string) (*detective
 	return nil, fmt.Errorf("resource %q of type detective.MemberInvitation not found", name)
 }
 
+// GetAllDevOpsGuruNotificationChannelResources retrieves all devopsguru.NotificationChannel items from an AWS CloudFormation template
+func (t *Template) GetAllDevOpsGuruNotificationChannelResources() map[string]*devopsguru.NotificationChannel {
+	results := map[string]*devopsguru.NotificationChannel{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *devopsguru.NotificationChannel:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetDevOpsGuruNotificationChannelWithName retrieves all devopsguru.NotificationChannel items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetDevOpsGuruNotificationChannelWithName(name string) (*devopsguru.NotificationChannel, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *devopsguru.NotificationChannel:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type devopsguru.NotificationChannel not found", name)
+}
+
+// GetAllDevOpsGuruResourceCollectionResources retrieves all devopsguru.ResourceCollection items from an AWS CloudFormation template
+func (t *Template) GetAllDevOpsGuruResourceCollectionResources() map[string]*devopsguru.ResourceCollection {
+	results := map[string]*devopsguru.ResourceCollection{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *devopsguru.ResourceCollection:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetDevOpsGuruResourceCollectionWithName retrieves all devopsguru.ResourceCollection items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetDevOpsGuruResourceCollectionWithName(name string) (*devopsguru.ResourceCollection, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *devopsguru.ResourceCollection:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type devopsguru.ResourceCollection not found", name)
+}
+
 // GetAllDirectoryServiceMicrosoftADResources retrieves all directoryservice.MicrosoftAD items from an AWS CloudFormation template
 func (t *Template) GetAllDirectoryServiceMicrosoftADResources() map[string]*directoryservice.MicrosoftAD {
 	results := map[string]*directoryservice.MicrosoftAD{}
@@ -5627,6 +5786,54 @@ func (t *Template) GetEC2NetworkAclEntryWithName(name string) (*ec2.NetworkAclEn
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type ec2.NetworkAclEntry not found", name)
+}
+
+// GetAllEC2NetworkInsightsAnalysisResources retrieves all ec2.NetworkInsightsAnalysis items from an AWS CloudFormation template
+func (t *Template) GetAllEC2NetworkInsightsAnalysisResources() map[string]*ec2.NetworkInsightsAnalysis {
+	results := map[string]*ec2.NetworkInsightsAnalysis{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *ec2.NetworkInsightsAnalysis:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEC2NetworkInsightsAnalysisWithName retrieves all ec2.NetworkInsightsAnalysis items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEC2NetworkInsightsAnalysisWithName(name string) (*ec2.NetworkInsightsAnalysis, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *ec2.NetworkInsightsAnalysis:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type ec2.NetworkInsightsAnalysis not found", name)
+}
+
+// GetAllEC2NetworkInsightsPathResources retrieves all ec2.NetworkInsightsPath items from an AWS CloudFormation template
+func (t *Template) GetAllEC2NetworkInsightsPathResources() map[string]*ec2.NetworkInsightsPath {
+	results := map[string]*ec2.NetworkInsightsPath{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *ec2.NetworkInsightsPath:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetEC2NetworkInsightsPathWithName retrieves all ec2.NetworkInsightsPath items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetEC2NetworkInsightsPathWithName(name string) (*ec2.NetworkInsightsPath, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *ec2.NetworkInsightsPath:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type ec2.NetworkInsightsPath not found", name)
 }
 
 // GetAllEC2NetworkInterfaceResources retrieves all ec2.NetworkInterface items from an AWS CloudFormation template
@@ -6589,6 +6796,30 @@ func (t *Template) GetEC2VolumeAttachmentWithName(name string) (*ec2.VolumeAttac
 	return nil, fmt.Errorf("resource %q of type ec2.VolumeAttachment not found", name)
 }
 
+// GetAllECRPublicRepositoryResources retrieves all ecr.PublicRepository items from an AWS CloudFormation template
+func (t *Template) GetAllECRPublicRepositoryResources() map[string]*ecr.PublicRepository {
+	results := map[string]*ecr.PublicRepository{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *ecr.PublicRepository:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetECRPublicRepositoryWithName retrieves all ecr.PublicRepository items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetECRPublicRepositoryWithName(name string) (*ecr.PublicRepository, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *ecr.PublicRepository:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type ecr.PublicRepository not found", name)
+}
+
 // GetAllECRRepositoryResources retrieves all ecr.Repository items from an AWS CloudFormation template
 func (t *Template) GetAllECRRepositoryResources() map[string]*ecr.Repository {
 	results := map[string]*ecr.Repository{}
@@ -7163,6 +7394,54 @@ func (t *Template) GetElastiCacheSubnetGroupWithName(name string) (*elasticache.
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type elasticache.SubnetGroup not found", name)
+}
+
+// GetAllElastiCacheUserResources retrieves all elasticache.User items from an AWS CloudFormation template
+func (t *Template) GetAllElastiCacheUserResources() map[string]*elasticache.User {
+	results := map[string]*elasticache.User{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *elasticache.User:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetElastiCacheUserWithName retrieves all elasticache.User items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetElastiCacheUserWithName(name string) (*elasticache.User, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *elasticache.User:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type elasticache.User not found", name)
+}
+
+// GetAllElastiCacheUserGroupResources retrieves all elasticache.UserGroup items from an AWS CloudFormation template
+func (t *Template) GetAllElastiCacheUserGroupResources() map[string]*elasticache.UserGroup {
+	results := map[string]*elasticache.UserGroup{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *elasticache.UserGroup:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetElastiCacheUserGroupWithName retrieves all elasticache.UserGroup items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetElastiCacheUserGroupWithName(name string) (*elasticache.UserGroup, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *elasticache.UserGroup:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type elasticache.UserGroup not found", name)
 }
 
 // GetAllElasticBeanstalkApplicationResources retrieves all elasticbeanstalk.Application items from an AWS CloudFormation template
@@ -8749,6 +9028,30 @@ func (t *Template) GetGreengrassSubscriptionDefinitionVersionWithName(name strin
 	return nil, fmt.Errorf("resource %q of type greengrass.SubscriptionDefinitionVersion not found", name)
 }
 
+// GetAllGreengrassV2ComponentVersionResources retrieves all greengrassv2.ComponentVersion items from an AWS CloudFormation template
+func (t *Template) GetAllGreengrassV2ComponentVersionResources() map[string]*greengrassv2.ComponentVersion {
+	results := map[string]*greengrassv2.ComponentVersion{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *greengrassv2.ComponentVersion:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetGreengrassV2ComponentVersionWithName retrieves all greengrassv2.ComponentVersion items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetGreengrassV2ComponentVersionWithName(name string) (*greengrassv2.ComponentVersion, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *greengrassv2.ComponentVersion:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type greengrassv2.ComponentVersion not found", name)
+}
+
 // GetAllGuardDutyDetectorResources retrieves all guardduty.Detector items from an AWS CloudFormation template
 func (t *Template) GetAllGuardDutyDetectorResources() map[string]*guardduty.Detector {
 	results := map[string]*guardduty.Detector{}
@@ -9853,6 +10156,30 @@ func (t *Template) GetIoTEventsInputWithName(name string) (*iotevents.Input, err
 	return nil, fmt.Errorf("resource %q of type iotevents.Input not found", name)
 }
 
+// GetAllIoTSiteWiseAccessPolicyResources retrieves all iotsitewise.AccessPolicy items from an AWS CloudFormation template
+func (t *Template) GetAllIoTSiteWiseAccessPolicyResources() map[string]*iotsitewise.AccessPolicy {
+	results := map[string]*iotsitewise.AccessPolicy{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotsitewise.AccessPolicy:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTSiteWiseAccessPolicyWithName retrieves all iotsitewise.AccessPolicy items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTSiteWiseAccessPolicyWithName(name string) (*iotsitewise.AccessPolicy, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotsitewise.AccessPolicy:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotsitewise.AccessPolicy not found", name)
+}
+
 // GetAllIoTSiteWiseAssetResources retrieves all iotsitewise.Asset items from an AWS CloudFormation template
 func (t *Template) GetAllIoTSiteWiseAssetResources() map[string]*iotsitewise.Asset {
 	results := map[string]*iotsitewise.Asset{}
@@ -9901,6 +10228,30 @@ func (t *Template) GetIoTSiteWiseAssetModelWithName(name string) (*iotsitewise.A
 	return nil, fmt.Errorf("resource %q of type iotsitewise.AssetModel not found", name)
 }
 
+// GetAllIoTSiteWiseDashboardResources retrieves all iotsitewise.Dashboard items from an AWS CloudFormation template
+func (t *Template) GetAllIoTSiteWiseDashboardResources() map[string]*iotsitewise.Dashboard {
+	results := map[string]*iotsitewise.Dashboard{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotsitewise.Dashboard:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTSiteWiseDashboardWithName retrieves all iotsitewise.Dashboard items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTSiteWiseDashboardWithName(name string) (*iotsitewise.Dashboard, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotsitewise.Dashboard:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotsitewise.Dashboard not found", name)
+}
+
 // GetAllIoTSiteWiseGatewayResources retrieves all iotsitewise.Gateway items from an AWS CloudFormation template
 func (t *Template) GetAllIoTSiteWiseGatewayResources() map[string]*iotsitewise.Gateway {
 	results := map[string]*iotsitewise.Gateway{}
@@ -9925,6 +10276,54 @@ func (t *Template) GetIoTSiteWiseGatewayWithName(name string) (*iotsitewise.Gate
 	return nil, fmt.Errorf("resource %q of type iotsitewise.Gateway not found", name)
 }
 
+// GetAllIoTSiteWisePortalResources retrieves all iotsitewise.Portal items from an AWS CloudFormation template
+func (t *Template) GetAllIoTSiteWisePortalResources() map[string]*iotsitewise.Portal {
+	results := map[string]*iotsitewise.Portal{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotsitewise.Portal:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTSiteWisePortalWithName retrieves all iotsitewise.Portal items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTSiteWisePortalWithName(name string) (*iotsitewise.Portal, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotsitewise.Portal:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotsitewise.Portal not found", name)
+}
+
+// GetAllIoTSiteWiseProjectResources retrieves all iotsitewise.Project items from an AWS CloudFormation template
+func (t *Template) GetAllIoTSiteWiseProjectResources() map[string]*iotsitewise.Project {
+	results := map[string]*iotsitewise.Project{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotsitewise.Project:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTSiteWiseProjectWithName retrieves all iotsitewise.Project items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTSiteWiseProjectWithName(name string) (*iotsitewise.Project, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotsitewise.Project:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotsitewise.Project not found", name)
+}
+
 // GetAllIoTThingsGraphFlowTemplateResources retrieves all iotthingsgraph.FlowTemplate items from an AWS CloudFormation template
 func (t *Template) GetAllIoTThingsGraphFlowTemplateResources() map[string]*iotthingsgraph.FlowTemplate {
 	results := map[string]*iotthingsgraph.FlowTemplate{}
@@ -9947,6 +10346,126 @@ func (t *Template) GetIoTThingsGraphFlowTemplateWithName(name string) (*iotthing
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type iotthingsgraph.FlowTemplate not found", name)
+}
+
+// GetAllIoTWirelessDestinationResources retrieves all iotwireless.Destination items from an AWS CloudFormation template
+func (t *Template) GetAllIoTWirelessDestinationResources() map[string]*iotwireless.Destination {
+	results := map[string]*iotwireless.Destination{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotwireless.Destination:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTWirelessDestinationWithName retrieves all iotwireless.Destination items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTWirelessDestinationWithName(name string) (*iotwireless.Destination, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotwireless.Destination:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotwireless.Destination not found", name)
+}
+
+// GetAllIoTWirelessDeviceProfileResources retrieves all iotwireless.DeviceProfile items from an AWS CloudFormation template
+func (t *Template) GetAllIoTWirelessDeviceProfileResources() map[string]*iotwireless.DeviceProfile {
+	results := map[string]*iotwireless.DeviceProfile{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotwireless.DeviceProfile:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTWirelessDeviceProfileWithName retrieves all iotwireless.DeviceProfile items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTWirelessDeviceProfileWithName(name string) (*iotwireless.DeviceProfile, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotwireless.DeviceProfile:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotwireless.DeviceProfile not found", name)
+}
+
+// GetAllIoTWirelessServiceProfileResources retrieves all iotwireless.ServiceProfile items from an AWS CloudFormation template
+func (t *Template) GetAllIoTWirelessServiceProfileResources() map[string]*iotwireless.ServiceProfile {
+	results := map[string]*iotwireless.ServiceProfile{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotwireless.ServiceProfile:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTWirelessServiceProfileWithName retrieves all iotwireless.ServiceProfile items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTWirelessServiceProfileWithName(name string) (*iotwireless.ServiceProfile, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotwireless.ServiceProfile:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotwireless.ServiceProfile not found", name)
+}
+
+// GetAllIoTWirelessWirelessDeviceResources retrieves all iotwireless.WirelessDevice items from an AWS CloudFormation template
+func (t *Template) GetAllIoTWirelessWirelessDeviceResources() map[string]*iotwireless.WirelessDevice {
+	results := map[string]*iotwireless.WirelessDevice{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotwireless.WirelessDevice:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTWirelessWirelessDeviceWithName retrieves all iotwireless.WirelessDevice items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTWirelessWirelessDeviceWithName(name string) (*iotwireless.WirelessDevice, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotwireless.WirelessDevice:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotwireless.WirelessDevice not found", name)
+}
+
+// GetAllIoTWirelessWirelessGatewayResources retrieves all iotwireless.WirelessGateway items from an AWS CloudFormation template
+func (t *Template) GetAllIoTWirelessWirelessGatewayResources() map[string]*iotwireless.WirelessGateway {
+	results := map[string]*iotwireless.WirelessGateway{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *iotwireless.WirelessGateway:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetIoTWirelessWirelessGatewayWithName retrieves all iotwireless.WirelessGateway items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetIoTWirelessWirelessGatewayWithName(name string) (*iotwireless.WirelessGateway, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *iotwireless.WirelessGateway:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type iotwireless.WirelessGateway not found", name)
 }
 
 // GetAllKMSAliasResources retrieves all kms.Alias items from an AWS CloudFormation template
@@ -10597,6 +11116,54 @@ func (t *Template) GetLambdaVersionWithName(name string) (*lambda.Version, error
 	return nil, fmt.Errorf("resource %q of type lambda.Version not found", name)
 }
 
+// GetAllLicenseManagerGrantResources retrieves all licensemanager.Grant items from an AWS CloudFormation template
+func (t *Template) GetAllLicenseManagerGrantResources() map[string]*licensemanager.Grant {
+	results := map[string]*licensemanager.Grant{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *licensemanager.Grant:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetLicenseManagerGrantWithName retrieves all licensemanager.Grant items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetLicenseManagerGrantWithName(name string) (*licensemanager.Grant, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *licensemanager.Grant:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type licensemanager.Grant not found", name)
+}
+
+// GetAllLicenseManagerLicenseResources retrieves all licensemanager.License items from an AWS CloudFormation template
+func (t *Template) GetAllLicenseManagerLicenseResources() map[string]*licensemanager.License {
+	results := map[string]*licensemanager.License{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *licensemanager.License:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetLicenseManagerLicenseWithName retrieves all licensemanager.License items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetLicenseManagerLicenseWithName(name string) (*licensemanager.License, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *licensemanager.License:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type licensemanager.License not found", name)
+}
+
 // GetAllLogsDestinationResources retrieves all logs.Destination items from an AWS CloudFormation template
 func (t *Template) GetAllLogsDestinationResources() map[string]*logs.Destination {
 	results := map[string]*logs.Destination{}
@@ -10739,6 +11306,30 @@ func (t *Template) GetMSKClusterWithName(name string) (*msk.Cluster, error) {
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type msk.Cluster not found", name)
+}
+
+// GetAllMWAAEnvironmentResources retrieves all mwaa.Environment items from an AWS CloudFormation template
+func (t *Template) GetAllMWAAEnvironmentResources() map[string]*mwaa.Environment {
+	results := map[string]*mwaa.Environment{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *mwaa.Environment:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetMWAAEnvironmentWithName retrieves all mwaa.Environment items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetMWAAEnvironmentWithName(name string) (*mwaa.Environment, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *mwaa.Environment:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type mwaa.Environment not found", name)
 }
 
 // GetAllMacieCustomDataIdentifierResources retrieves all macie.CustomDataIdentifier items from an AWS CloudFormation template
@@ -13717,6 +14308,30 @@ func (t *Template) GetSSOAssignmentWithName(name string) (*sso.Assignment, error
 	return nil, fmt.Errorf("resource %q of type sso.Assignment not found", name)
 }
 
+// GetAllSSOInstanceAccessControlAttributeConfigurationResources retrieves all sso.InstanceAccessControlAttributeConfiguration items from an AWS CloudFormation template
+func (t *Template) GetAllSSOInstanceAccessControlAttributeConfigurationResources() map[string]*sso.InstanceAccessControlAttributeConfiguration {
+	results := map[string]*sso.InstanceAccessControlAttributeConfiguration{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sso.InstanceAccessControlAttributeConfiguration:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSSOInstanceAccessControlAttributeConfigurationWithName retrieves all sso.InstanceAccessControlAttributeConfiguration items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSSOInstanceAccessControlAttributeConfigurationWithName(name string) (*sso.InstanceAccessControlAttributeConfiguration, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sso.InstanceAccessControlAttributeConfiguration:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sso.InstanceAccessControlAttributeConfiguration not found", name)
+}
+
 // GetAllSSOPermissionSetResources retrieves all sso.PermissionSet items from an AWS CloudFormation template
 func (t *Template) GetAllSSOPermissionSetResources() map[string]*sso.PermissionSet {
 	results := map[string]*sso.PermissionSet{}
@@ -13763,6 +14378,78 @@ func (t *Template) GetSageMakerCodeRepositoryWithName(name string) (*sagemaker.C
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type sagemaker.CodeRepository not found", name)
+}
+
+// GetAllSageMakerDataQualityJobDefinitionResources retrieves all sagemaker.DataQualityJobDefinition items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerDataQualityJobDefinitionResources() map[string]*sagemaker.DataQualityJobDefinition {
+	results := map[string]*sagemaker.DataQualityJobDefinition{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.DataQualityJobDefinition:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerDataQualityJobDefinitionWithName retrieves all sagemaker.DataQualityJobDefinition items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerDataQualityJobDefinitionWithName(name string) (*sagemaker.DataQualityJobDefinition, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.DataQualityJobDefinition:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.DataQualityJobDefinition not found", name)
+}
+
+// GetAllSageMakerDeviceResources retrieves all sagemaker.Device items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerDeviceResources() map[string]*sagemaker.Device {
+	results := map[string]*sagemaker.Device{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.Device:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerDeviceWithName retrieves all sagemaker.Device items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerDeviceWithName(name string) (*sagemaker.Device, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.Device:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.Device not found", name)
+}
+
+// GetAllSageMakerDeviceFleetResources retrieves all sagemaker.DeviceFleet items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerDeviceFleetResources() map[string]*sagemaker.DeviceFleet {
+	results := map[string]*sagemaker.DeviceFleet{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.DeviceFleet:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerDeviceFleetWithName retrieves all sagemaker.DeviceFleet items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerDeviceFleetWithName(name string) (*sagemaker.DeviceFleet, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.DeviceFleet:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.DeviceFleet not found", name)
 }
 
 // GetAllSageMakerEndpointResources retrieves all sagemaker.Endpoint items from an AWS CloudFormation template
@@ -13837,6 +14524,102 @@ func (t *Template) GetSageMakerModelWithName(name string) (*sagemaker.Model, err
 	return nil, fmt.Errorf("resource %q of type sagemaker.Model not found", name)
 }
 
+// GetAllSageMakerModelBiasJobDefinitionResources retrieves all sagemaker.ModelBiasJobDefinition items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerModelBiasJobDefinitionResources() map[string]*sagemaker.ModelBiasJobDefinition {
+	results := map[string]*sagemaker.ModelBiasJobDefinition{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelBiasJobDefinition:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerModelBiasJobDefinitionWithName retrieves all sagemaker.ModelBiasJobDefinition items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerModelBiasJobDefinitionWithName(name string) (*sagemaker.ModelBiasJobDefinition, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelBiasJobDefinition:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.ModelBiasJobDefinition not found", name)
+}
+
+// GetAllSageMakerModelExplainabilityJobDefinitionResources retrieves all sagemaker.ModelExplainabilityJobDefinition items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerModelExplainabilityJobDefinitionResources() map[string]*sagemaker.ModelExplainabilityJobDefinition {
+	results := map[string]*sagemaker.ModelExplainabilityJobDefinition{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelExplainabilityJobDefinition:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerModelExplainabilityJobDefinitionWithName retrieves all sagemaker.ModelExplainabilityJobDefinition items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerModelExplainabilityJobDefinitionWithName(name string) (*sagemaker.ModelExplainabilityJobDefinition, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelExplainabilityJobDefinition:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.ModelExplainabilityJobDefinition not found", name)
+}
+
+// GetAllSageMakerModelPackageGroupResources retrieves all sagemaker.ModelPackageGroup items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerModelPackageGroupResources() map[string]*sagemaker.ModelPackageGroup {
+	results := map[string]*sagemaker.ModelPackageGroup{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelPackageGroup:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerModelPackageGroupWithName retrieves all sagemaker.ModelPackageGroup items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerModelPackageGroupWithName(name string) (*sagemaker.ModelPackageGroup, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelPackageGroup:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.ModelPackageGroup not found", name)
+}
+
+// GetAllSageMakerModelQualityJobDefinitionResources retrieves all sagemaker.ModelQualityJobDefinition items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerModelQualityJobDefinitionResources() map[string]*sagemaker.ModelQualityJobDefinition {
+	results := map[string]*sagemaker.ModelQualityJobDefinition{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelQualityJobDefinition:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerModelQualityJobDefinitionWithName retrieves all sagemaker.ModelQualityJobDefinition items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerModelQualityJobDefinitionWithName(name string) (*sagemaker.ModelQualityJobDefinition, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.ModelQualityJobDefinition:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.ModelQualityJobDefinition not found", name)
+}
+
 // GetAllSageMakerMonitoringScheduleResources retrieves all sagemaker.MonitoringSchedule items from an AWS CloudFormation template
 func (t *Template) GetAllSageMakerMonitoringScheduleResources() map[string]*sagemaker.MonitoringSchedule {
 	results := map[string]*sagemaker.MonitoringSchedule{}
@@ -13907,6 +14690,54 @@ func (t *Template) GetSageMakerNotebookInstanceLifecycleConfigWithName(name stri
 		}
 	}
 	return nil, fmt.Errorf("resource %q of type sagemaker.NotebookInstanceLifecycleConfig not found", name)
+}
+
+// GetAllSageMakerPipelineResources retrieves all sagemaker.Pipeline items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerPipelineResources() map[string]*sagemaker.Pipeline {
+	results := map[string]*sagemaker.Pipeline{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.Pipeline:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerPipelineWithName retrieves all sagemaker.Pipeline items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerPipelineWithName(name string) (*sagemaker.Pipeline, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.Pipeline:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.Pipeline not found", name)
+}
+
+// GetAllSageMakerProjectResources retrieves all sagemaker.Project items from an AWS CloudFormation template
+func (t *Template) GetAllSageMakerProjectResources() map[string]*sagemaker.Project {
+	results := map[string]*sagemaker.Project{}
+	for name, untyped := range t.Resources {
+		switch resource := untyped.(type) {
+		case *sagemaker.Project:
+			results[name] = resource
+		}
+	}
+	return results
+}
+
+// GetSageMakerProjectWithName retrieves all sagemaker.Project items from an AWS CloudFormation template
+// whose logical ID matches the provided name. Returns an error if not found.
+func (t *Template) GetSageMakerProjectWithName(name string) (*sagemaker.Project, error) {
+	if untyped, ok := t.Resources[name]; ok {
+		switch resource := untyped.(type) {
+		case *sagemaker.Project:
+			return resource, nil
+		}
+	}
+	return nil, fmt.Errorf("resource %q of type sagemaker.Project not found", name)
 }
 
 // GetAllSageMakerWorkteamResources retrieves all sagemaker.Workteam items from an AWS CloudFormation template

--- a/cloudformation/appflow/aws-appflow-flow_destinationconnectorproperties.go
+++ b/cloudformation/appflow/aws-appflow-flow_destinationconnectorproperties.go
@@ -33,6 +33,11 @@ type Flow_DestinationConnectorProperties struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-destinationconnectorproperties.html#cfn-appflow-flow-destinationconnectorproperties-snowflake
 	Snowflake *Flow_SnowflakeDestinationProperties `json:"Snowflake,omitempty"`
 
+	// Upsolver AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-destinationconnectorproperties.html#cfn-appflow-flow-destinationconnectorproperties-upsolver
+	Upsolver *Flow_UpsolverDestinationProperties `json:"Upsolver,omitempty"`
+
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 

--- a/cloudformation/appflow/aws-appflow-flow_incrementalpullconfig.go
+++ b/cloudformation/appflow/aws-appflow-flow_incrementalpullconfig.go
@@ -1,0 +1,35 @@
+package appflow
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Flow_IncrementalPullConfig AWS CloudFormation Resource (AWS::AppFlow::Flow.IncrementalPullConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-incrementalpullconfig.html
+type Flow_IncrementalPullConfig struct {
+
+	// DatetimeTypeFieldName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-incrementalpullconfig.html#cfn-appflow-flow-incrementalpullconfig-datetimetypefieldname
+	DatetimeTypeFieldName string `json:"DatetimeTypeFieldName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Flow_IncrementalPullConfig) AWSCloudFormationType() string {
+	return "AWS::AppFlow::Flow.IncrementalPullConfig"
+}

--- a/cloudformation/appflow/aws-appflow-flow_sourceflowconfig.go
+++ b/cloudformation/appflow/aws-appflow-flow_sourceflowconfig.go
@@ -18,6 +18,11 @@ type Flow_SourceFlowConfig struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-sourceflowconfig.html#cfn-appflow-flow-sourceflowconfig-connectortype
 	ConnectorType string `json:"ConnectorType,omitempty"`
 
+	// IncrementalPullConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-sourceflowconfig.html#cfn-appflow-flow-sourceflowconfig-incrementalpullconfig
+	IncrementalPullConfig *Flow_IncrementalPullConfig `json:"IncrementalPullConfig,omitempty"`
+
 	// SourceConnectorProperties AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-sourceflowconfig.html#cfn-appflow-flow-sourceflowconfig-sourceconnectorproperties

--- a/cloudformation/appflow/aws-appflow-flow_upsolverdestinationproperties.go
+++ b/cloudformation/appflow/aws-appflow-flow_upsolverdestinationproperties.go
@@ -1,0 +1,45 @@
+package appflow
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Flow_UpsolverDestinationProperties AWS CloudFormation Resource (AWS::AppFlow::Flow.UpsolverDestinationProperties)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolverdestinationproperties.html
+type Flow_UpsolverDestinationProperties struct {
+
+	// BucketName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolverdestinationproperties.html#cfn-appflow-flow-upsolverdestinationproperties-bucketname
+	BucketName string `json:"BucketName,omitempty"`
+
+	// BucketPrefix AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolverdestinationproperties.html#cfn-appflow-flow-upsolverdestinationproperties-bucketprefix
+	BucketPrefix string `json:"BucketPrefix,omitempty"`
+
+	// S3OutputFormatConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolverdestinationproperties.html#cfn-appflow-flow-upsolverdestinationproperties-s3outputformatconfig
+	S3OutputFormatConfig *Flow_UpsolverS3OutputFormatConfig `json:"S3OutputFormatConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Flow_UpsolverDestinationProperties) AWSCloudFormationType() string {
+	return "AWS::AppFlow::Flow.UpsolverDestinationProperties"
+}

--- a/cloudformation/appflow/aws-appflow-flow_upsolvers3outputformatconfig.go
+++ b/cloudformation/appflow/aws-appflow-flow_upsolvers3outputformatconfig.go
@@ -1,0 +1,45 @@
+package appflow
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Flow_UpsolverS3OutputFormatConfig AWS CloudFormation Resource (AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolvers3outputformatconfig.html
+type Flow_UpsolverS3OutputFormatConfig struct {
+
+	// AggregationConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolvers3outputformatconfig.html#cfn-appflow-flow-upsolvers3outputformatconfig-aggregationconfig
+	AggregationConfig *Flow_AggregationConfig `json:"AggregationConfig,omitempty"`
+
+	// FileType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolvers3outputformatconfig.html#cfn-appflow-flow-upsolvers3outputformatconfig-filetype
+	FileType string `json:"FileType,omitempty"`
+
+	// PrefixConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appflow-flow-upsolvers3outputformatconfig.html#cfn-appflow-flow-upsolvers3outputformatconfig-prefixconfig
+	PrefixConfig *Flow_PrefixConfig `json:"PrefixConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Flow_UpsolverS3OutputFormatConfig) AWSCloudFormationType() string {
+	return "AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig"
+}

--- a/cloudformation/applicationinsights/aws-applicationinsights-application_configurationdetails.go
+++ b/cloudformation/applicationinsights/aws-applicationinsights-application_configurationdetails.go
@@ -18,6 +18,11 @@ type Application_ConfigurationDetails struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-configurationdetails.html#cfn-applicationinsights-application-configurationdetails-alarms
 	Alarms []Application_Alarm `json:"Alarms,omitempty"`
 
+	// JMXPrometheusExporter AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-configurationdetails.html#cfn-applicationinsights-application-configurationdetails-jmxprometheusexporter
+	JMXPrometheusExporter *Application_JMXPrometheusExporter `json:"JMXPrometheusExporter,omitempty"`
+
 	// Logs AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-configurationdetails.html#cfn-applicationinsights-application-configurationdetails-logs

--- a/cloudformation/applicationinsights/aws-applicationinsights-application_jmxprometheusexporter.go
+++ b/cloudformation/applicationinsights/aws-applicationinsights-application_jmxprometheusexporter.go
@@ -1,0 +1,45 @@
+package applicationinsights
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Application_JMXPrometheusExporter AWS CloudFormation Resource (AWS::ApplicationInsights::Application.JMXPrometheusExporter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-jmxprometheusexporter.html
+type Application_JMXPrometheusExporter struct {
+
+	// HostPort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-jmxprometheusexporter.html#cfn-applicationinsights-application-jmxprometheusexporter-hostport
+	HostPort string `json:"HostPort,omitempty"`
+
+	// JMXURL AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-jmxprometheusexporter.html#cfn-applicationinsights-application-jmxprometheusexporter-jmxurl
+	JMXURL string `json:"JMXURL,omitempty"`
+
+	// PrometheusPort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationinsights-application-jmxprometheusexporter.html#cfn-applicationinsights-application-jmxprometheusexporter-prometheusport
+	PrometheusPort string `json:"PrometheusPort,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Application_JMXPrometheusExporter) AWSCloudFormationType() string {
+	return "AWS::ApplicationInsights::Application.JMXPrometheusExporter"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment.go
@@ -1,0 +1,146 @@
+package auditmanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment AWS CloudFormation Resource (AWS::AuditManager::Assessment)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html
+type Assessment struct {
+
+	// assessmentReportsDestination AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-assessmentreportsdestination
+	assessmentReportsDestination *Assessment_AssessmentReportsDestination `json:"assessmentReportsDestination,omitempty"`
+
+	// awsAccount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-awsaccount
+	awsAccount *Assessment_AWSAccount `json:"awsAccount,omitempty"`
+
+	// description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-description
+	description string `json:"description,omitempty"`
+
+	// frameworkId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-frameworkid
+	frameworkId string `json:"frameworkId,omitempty"`
+
+	// name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-name
+	name string `json:"name,omitempty"`
+
+	// roles AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-roles
+	roles *Assessment_Roles `json:"roles,omitempty"`
+
+	// scope AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-scope
+	scope *Assessment_Scope `json:"scope,omitempty"`
+
+	// status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-status
+	status string `json:"status,omitempty"`
+
+	// tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-auditmanager-assessment.html#cfn-auditmanager-assessment-tags
+	tags *Assessment_Tags `json:"tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Assessment) MarshalJSON() ([]byte, error) {
+	type Properties Assessment
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Assessment) UnmarshalJSON(b []byte) error {
+	type Properties Assessment
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Assessment(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_assessmentreportsdestination.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_assessmentreportsdestination.go
@@ -1,0 +1,40 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_AssessmentReportsDestination AWS CloudFormation Resource (AWS::AuditManager::Assessment.AssessmentReportsDestination)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-assessmentreportsdestination.html
+type Assessment_AssessmentReportsDestination struct {
+
+	// destination AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-assessmentreportsdestination.html#cfn-auditmanager-assessment-assessmentreportsdestination-destination
+	destination string `json:"destination,omitempty"`
+
+	// destinationType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-assessmentreportsdestination.html#cfn-auditmanager-assessment-assessmentreportsdestination-destinationtype
+	destinationType string `json:"destinationType,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_AssessmentReportsDestination) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.AssessmentReportsDestination"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_awsaccount.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_awsaccount.go
@@ -1,0 +1,45 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_AWSAccount AWS CloudFormation Resource (AWS::AuditManager::Assessment.AWSAccount)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsaccount.html
+type Assessment_AWSAccount struct {
+
+	// emailAddress AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsaccount.html#cfn-auditmanager-assessment-awsaccount-emailaddress
+	emailAddress string `json:"emailAddress,omitempty"`
+
+	// id AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsaccount.html#cfn-auditmanager-assessment-awsaccount-id
+	id string `json:"id,omitempty"`
+
+	// name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsaccount.html#cfn-auditmanager-assessment-awsaccount-name
+	name string `json:"name,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_AWSAccount) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.AWSAccount"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_awsaccounts.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_awsaccounts.go
@@ -1,0 +1,35 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_AWSAccounts AWS CloudFormation Resource (AWS::AuditManager::Assessment.AWSAccounts)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsaccounts.html
+type Assessment_AWSAccounts struct {
+
+	// AWSAccounts AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsaccounts.html#cfn-auditmanager-assessment-awsaccounts-awsaccounts
+	AWSAccounts []Assessment_AWSAccount `json:"AWSAccounts,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_AWSAccounts) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.AWSAccounts"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_awsservice.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_awsservice.go
@@ -1,0 +1,35 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_AWSService AWS CloudFormation Resource (AWS::AuditManager::Assessment.AWSService)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsservice.html
+type Assessment_AWSService struct {
+
+	// serviceName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsservice.html#cfn-auditmanager-assessment-awsservice-servicename
+	serviceName string `json:"serviceName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_AWSService) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.AWSService"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_awsservices.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_awsservices.go
@@ -1,0 +1,35 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_AWSServices AWS CloudFormation Resource (AWS::AuditManager::Assessment.AWSServices)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsservices.html
+type Assessment_AWSServices struct {
+
+	// AWSServices AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-awsservices.html#cfn-auditmanager-assessment-awsservices-awsservices
+	AWSServices []Assessment_AWSService `json:"AWSServices,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_AWSServices) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.AWSServices"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_delegation.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_delegation.go
@@ -1,0 +1,85 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_Delegation AWS CloudFormation Resource (AWS::AuditManager::Assessment.Delegation)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html
+type Assessment_Delegation struct {
+
+	// assessmentId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-assessmentid
+	assessmentId string `json:"assessmentId,omitempty"`
+
+	// assessmentName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-assessmentname
+	assessmentName string `json:"assessmentName,omitempty"`
+
+	// comment AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-comment
+	comment string `json:"comment,omitempty"`
+
+	// controlSetId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-controlsetid
+	controlSetId string `json:"controlSetId,omitempty"`
+
+	// createdBy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-createdby
+	createdBy string `json:"createdBy,omitempty"`
+
+	// creationTime AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-creationtime
+	creationTime float64 `json:"creationTime,omitempty"`
+
+	// id AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-id
+	id string `json:"id,omitempty"`
+
+	// lastUpdated AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-lastupdated
+	lastUpdated float64 `json:"lastUpdated,omitempty"`
+
+	// roleArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-rolearn
+	roleArn string `json:"roleArn,omitempty"`
+
+	// roleType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-roletype
+	roleType string `json:"roleType,omitempty"`
+
+	// status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegation.html#cfn-auditmanager-assessment-delegation-status
+	status string `json:"status,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_Delegation) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.Delegation"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_delegations.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_delegations.go
@@ -1,0 +1,35 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_Delegations AWS CloudFormation Resource (AWS::AuditManager::Assessment.Delegations)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegations.html
+type Assessment_Delegations struct {
+
+	// Delegations AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-delegations.html#cfn-auditmanager-assessment-delegations-delegations
+	Delegations []Assessment_Delegation `json:"Delegations,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_Delegations) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.Delegations"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_role.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_role.go
@@ -1,0 +1,40 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_Role AWS CloudFormation Resource (AWS::AuditManager::Assessment.Role)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-role.html
+type Assessment_Role struct {
+
+	// roleArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-role.html#cfn-auditmanager-assessment-role-rolearn
+	roleArn string `json:"roleArn,omitempty"`
+
+	// roleType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-role.html#cfn-auditmanager-assessment-role-roletype
+	roleType string `json:"roleType,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_Role) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.Role"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_roles.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_roles.go
@@ -1,0 +1,35 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_Roles AWS CloudFormation Resource (AWS::AuditManager::Assessment.Roles)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-roles.html
+type Assessment_Roles struct {
+
+	// Roles AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-roles.html#cfn-auditmanager-assessment-roles-roles
+	Roles []Assessment_Role `json:"Roles,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_Roles) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.Roles"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_scope.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_scope.go
@@ -1,0 +1,40 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Assessment_Scope AWS CloudFormation Resource (AWS::AuditManager::Assessment.Scope)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-scope.html
+type Assessment_Scope struct {
+
+	// awsAccounts AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-scope.html#cfn-auditmanager-assessment-scope-awsaccounts
+	awsAccounts *Assessment_AWSAccounts `json:"awsAccounts,omitempty"`
+
+	// awsServices AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-scope.html#cfn-auditmanager-assessment-scope-awsservices
+	awsServices *Assessment_AWSServices `json:"awsServices,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_Scope) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.Scope"
+}

--- a/cloudformation/auditmanager/aws-auditmanager-assessment_tags.go
+++ b/cloudformation/auditmanager/aws-auditmanager-assessment_tags.go
@@ -1,0 +1,36 @@
+package auditmanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Assessment_Tags AWS CloudFormation Resource (AWS::AuditManager::Assessment.Tags)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-tags.html
+type Assessment_Tags struct {
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-auditmanager-assessment-tags.html#cfn-auditmanager-assessment-tags-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Assessment_Tags) AWSCloudFormationType() string {
+	return "AWS::AuditManager::Assessment.Tags"
+}

--- a/cloudformation/autoscaling/aws-autoscaling-launchconfiguration.go
+++ b/cloudformation/autoscaling/aws-autoscaling-launchconfiguration.go
@@ -80,7 +80,7 @@ type LaunchConfiguration struct {
 	// MetadataOptions AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-autoscaling-launchconfig-metadataoptions
-	MetadataOptions *LaunchConfiguration_MetadataOption `json:"MetadataOptions,omitempty"`
+	MetadataOptions *LaunchConfiguration_MetadataOptions `json:"MetadataOptions,omitempty"`
 
 	// PlacementTenancy AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/autoscaling/aws-autoscaling-launchconfiguration_metadataoptions.go
+++ b/cloudformation/autoscaling/aws-autoscaling-launchconfiguration_metadataoptions.go
@@ -1,0 +1,45 @@
+package autoscaling
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// LaunchConfiguration_MetadataOptions AWS CloudFormation Resource (AWS::AutoScaling::LaunchConfiguration.MetadataOptions)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-launchconfig-metadataoptions.html
+type LaunchConfiguration_MetadataOptions struct {
+
+	// HttpEndpoint AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-launchconfig-metadataoptions.html#cfn-autoscaling-launchconfig-metadataoptions-httpendpoint
+	HttpEndpoint string `json:"HttpEndpoint,omitempty"`
+
+	// HttpPutResponseHopLimit AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-launchconfig-metadataoptions.html#cfn-autoscaling-launchconfig-metadataoptions-httpputresponsehoplimit
+	HttpPutResponseHopLimit int `json:"HttpPutResponseHopLimit,omitempty"`
+
+	// HttpTokens AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-launchconfig-metadataoptions.html#cfn-autoscaling-launchconfig-metadataoptions-httptokens
+	HttpTokens string `json:"HttpTokens,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *LaunchConfiguration_MetadataOptions) AWSCloudFormationType() string {
+	return "AWS::AutoScaling::LaunchConfiguration.MetadataOptions"
+}

--- a/cloudformation/batch/aws-batch-computeenvironment_computeresources.go
+++ b/cloudformation/batch/aws-batch-computeenvironment_computeresources.go
@@ -39,12 +39,12 @@ type ComputeEnvironment_ComputeResources struct {
 	ImageId string `json:"ImageId,omitempty"`
 
 	// InstanceRole AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-instancerole
 	InstanceRole string `json:"InstanceRole,omitempty"`
 
 	// InstanceTypes AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-instancetypes
 	InstanceTypes []string `json:"InstanceTypes,omitempty"`
 
@@ -59,9 +59,9 @@ type ComputeEnvironment_ComputeResources struct {
 	MaxvCpus int `json:"MaxvCpus"`
 
 	// MinvCpus AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-minvcpus
-	MinvCpus int `json:"MinvCpus"`
+	MinvCpus int `json:"MinvCpus,omitempty"`
 
 	// PlacementGroup AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/batch/aws-batch-jobdefinition.go
+++ b/cloudformation/batch/aws-batch-jobdefinition.go
@@ -32,6 +32,16 @@ type JobDefinition struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-parameters
 	Parameters interface{} `json:"Parameters,omitempty"`
 
+	// PlatformCapabilities AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-platformcapabilities
+	PlatformCapabilities []string `json:"PlatformCapabilities,omitempty"`
+
+	// PropagateTags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-propagatetags
+	PropagateTags bool `json:"PropagateTags,omitempty"`
+
 	// RetryStrategy AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-retrystrategy

--- a/cloudformation/batch/aws-batch-jobdefinition_containerproperties.go
+++ b/cloudformation/batch/aws-batch-jobdefinition_containerproperties.go
@@ -23,6 +23,11 @@ type JobDefinition_ContainerProperties struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-executionrolearn
 	ExecutionRoleArn string `json:"ExecutionRoleArn,omitempty"`
 
+	// FargatePlatformConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-fargateplatformconfiguration
+	FargatePlatformConfiguration *JobDefinition_FargatePlatformConfiguration `json:"FargatePlatformConfiguration,omitempty"`
+
 	// Image AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-image
@@ -57,6 +62,11 @@ type JobDefinition_ContainerProperties struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-mountpoints
 	MountPoints []JobDefinition_MountPoints `json:"MountPoints,omitempty"`
+
+	// NetworkConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-networkconfiguration
+	NetworkConfiguration *JobDefinition_NetworkConfiguration `json:"NetworkConfiguration,omitempty"`
 
 	// Privileged AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/batch/aws-batch-jobdefinition_fargateplatformconfiguration.go
+++ b/cloudformation/batch/aws-batch-jobdefinition_fargateplatformconfiguration.go
@@ -1,0 +1,35 @@
+package batch
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// JobDefinition_FargatePlatformConfiguration AWS CloudFormation Resource (AWS::Batch::JobDefinition.FargatePlatformConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-fargateplatformconfiguration.html
+type JobDefinition_FargatePlatformConfiguration struct {
+
+	// PlatformVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-fargateplatformconfiguration.html#cfn-batch-jobdefinition-containerproperties-fargateplatformconfiguration-platformversion
+	PlatformVersion string `json:"PlatformVersion,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *JobDefinition_FargatePlatformConfiguration) AWSCloudFormationType() string {
+	return "AWS::Batch::JobDefinition.FargatePlatformConfiguration"
+}

--- a/cloudformation/batch/aws-batch-jobdefinition_networkconfiguration.go
+++ b/cloudformation/batch/aws-batch-jobdefinition_networkconfiguration.go
@@ -1,0 +1,35 @@
+package batch
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// JobDefinition_NetworkConfiguration AWS CloudFormation Resource (AWS::Batch::JobDefinition.NetworkConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-networkconfiguration.html
+type JobDefinition_NetworkConfiguration struct {
+
+	// AssignPublicIp AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties-networkconfiguration.html#cfn-batch-jobdefinition-containerproperties-networkconfiguration-assignpublicip
+	AssignPublicIp string `json:"AssignPublicIp,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *JobDefinition_NetworkConfiguration) AWSCloudFormationType() string {
+	return "AWS::Batch::JobDefinition.NetworkConfiguration"
+}

--- a/cloudformation/cloudformation/aws-cloudformation-moduledefaultversion.go
+++ b/cloudformation/cloudformation/aws-cloudformation-moduledefaultversion.go
@@ -1,0 +1,116 @@
+package cloudformation
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModuleDefaultVersion AWS CloudFormation Resource (AWS::CloudFormation::ModuleDefaultVersion)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduledefaultversion.html
+type ModuleDefaultVersion struct {
+
+	// Arn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduledefaultversion.html#cfn-cloudformation-moduledefaultversion-arn
+	Arn string `json:"Arn,omitempty"`
+
+	// ModuleName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduledefaultversion.html#cfn-cloudformation-moduledefaultversion-modulename
+	ModuleName string `json:"ModuleName,omitempty"`
+
+	// VersionId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduledefaultversion.html#cfn-cloudformation-moduledefaultversion-versionid
+	VersionId string `json:"VersionId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModuleDefaultVersion) AWSCloudFormationType() string {
+	return "AWS::CloudFormation::ModuleDefaultVersion"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ModuleDefaultVersion) MarshalJSON() ([]byte, error) {
+	type Properties ModuleDefaultVersion
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ModuleDefaultVersion) UnmarshalJSON(b []byte) error {
+	type Properties ModuleDefaultVersion
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ModuleDefaultVersion(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/cloudformation/aws-cloudformation-moduleversion.go
+++ b/cloudformation/cloudformation/aws-cloudformation-moduleversion.go
@@ -1,0 +1,111 @@
+package cloudformation
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModuleVersion AWS CloudFormation Resource (AWS::CloudFormation::ModuleVersion)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduleversion.html
+type ModuleVersion struct {
+
+	// ModuleName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduleversion.html#cfn-cloudformation-moduleversion-modulename
+	ModuleName string `json:"ModuleName,omitempty"`
+
+	// ModulePackage AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-moduleversion.html#cfn-cloudformation-moduleversion-modulepackage
+	ModulePackage string `json:"ModulePackage,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModuleVersion) AWSCloudFormationType() string {
+	return "AWS::CloudFormation::ModuleVersion"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ModuleVersion) MarshalJSON() ([]byte, error) {
+	type Properties ModuleVersion
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ModuleVersion) UnmarshalJSON(b []byte) error {
+	type Properties ModuleVersion
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ModuleVersion(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/cloudformation/aws-cloudformation-stackset.go
+++ b/cloudformation/cloudformation/aws-cloudformation-stackset.go
@@ -49,7 +49,7 @@ type StackSet struct {
 	Parameters []StackSet_Parameter `json:"Parameters,omitempty"`
 
 	// PermissionModel AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html#cfn-cloudformation-stackset-permissionmodel
 	PermissionModel string `json:"PermissionModel,omitempty"`
 
@@ -59,7 +59,7 @@ type StackSet struct {
 	StackInstancesGroup []StackSet_StackInstances `json:"StackInstancesGroup,omitempty"`
 
 	// StackSetName AWS CloudFormation Property
-	// Required: false
+	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html#cfn-cloudformation-stackset-stacksetname
 	StackSetName string `json:"StackSetName,omitempty"`
 

--- a/cloudformation/codeartifact/aws-codeartifact-domain.go
+++ b/cloudformation/codeartifact/aws-codeartifact-domain.go
@@ -18,6 +18,11 @@ type Domain struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-domain.html#cfn-codeartifact-domain-domainname
 	DomainName string `json:"DomainName,omitempty"`
 
+	// EncryptionKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-domain.html#cfn-codeartifact-domain-encryptionkey
+	EncryptionKey string `json:"EncryptionKey,omitempty"`
+
 	// PermissionsPolicyDocument AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-domain.html#cfn-codeartifact-domain-permissionspolicydocument

--- a/cloudformation/codeartifact/aws-codeartifact-repository.go
+++ b/cloudformation/codeartifact/aws-codeartifact-repository.go
@@ -18,6 +18,16 @@ type Repository struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-repository.html#cfn-codeartifact-repository-description
 	Description string `json:"Description,omitempty"`
 
+	// DomainName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-repository.html#cfn-codeartifact-repository-domainname
+	DomainName string `json:"DomainName,omitempty"`
+
+	// DomainOwner AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-repository.html#cfn-codeartifact-repository-domainowner
+	DomainOwner string `json:"DomainOwner,omitempty"`
+
 	// ExternalConnections AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-repository.html#cfn-codeartifact-repository-externalconnections

--- a/cloudformation/codegurureviewer/aws-codegurureviewer-repositoryassociation.go
+++ b/cloudformation/codegurureviewer/aws-codegurureviewer-repositoryassociation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // RepositoryAssociation AWS CloudFormation Resource (AWS::CodeGuruReviewer::RepositoryAssociation)
@@ -26,6 +27,11 @@ type RepositoryAssociation struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codegurureviewer-repositoryassociation.html#cfn-codegurureviewer-repositoryassociation-owner
 	Owner string `json:"Owner,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codegurureviewer-repositoryassociation.html#cfn-codegurureviewer-repositoryassociation-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// Type AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/cognito/aws-cognito-userpool_customemailsender.go
+++ b/cloudformation/cognito/aws-cognito-userpool_customemailsender.go
@@ -1,0 +1,40 @@
+package cognito
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserPool_CustomEmailSender AWS CloudFormation Resource (AWS::Cognito::UserPool.CustomEmailSender)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customemailsender.html
+type UserPool_CustomEmailSender struct {
+
+	// LambdaArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customemailsender.html#cfn-cognito-userpool-customemailsender-lambdaarn
+	LambdaArn string `json:"LambdaArn,omitempty"`
+
+	// LambdaVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customemailsender.html#cfn-cognito-userpool-customemailsender-lambdaversion
+	LambdaVersion string `json:"LambdaVersion,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserPool_CustomEmailSender) AWSCloudFormationType() string {
+	return "AWS::Cognito::UserPool.CustomEmailSender"
+}

--- a/cloudformation/cognito/aws-cognito-userpool_customsmssender.go
+++ b/cloudformation/cognito/aws-cognito-userpool_customsmssender.go
@@ -1,0 +1,40 @@
+package cognito
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserPool_CustomSMSSender AWS CloudFormation Resource (AWS::Cognito::UserPool.CustomSMSSender)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customsmssender.html
+type UserPool_CustomSMSSender struct {
+
+	// LambdaArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customsmssender.html#cfn-cognito-userpool-customsmssender-lambdaarn
+	LambdaArn string `json:"LambdaArn,omitempty"`
+
+	// LambdaVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customsmssender.html#cfn-cognito-userpool-customsmssender-lambdaversion
+	LambdaVersion string `json:"LambdaVersion,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserPool_CustomSMSSender) AWSCloudFormationType() string {
+	return "AWS::Cognito::UserPool.CustomSMSSender"
+}

--- a/cloudformation/cognito/aws-cognito-userpool_lambdaconfig.go
+++ b/cloudformation/cognito/aws-cognito-userpool_lambdaconfig.go
@@ -13,15 +13,30 @@ type UserPool_LambdaConfig struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html#cfn-cognito-userpool-lambdaconfig-createauthchallenge
 	CreateAuthChallenge string `json:"CreateAuthChallenge,omitempty"`
 
+	// CustomEmailSender AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html#cfn-cognito-userpool-lambdaconfig-customemailsender
+	CustomEmailSender *UserPool_CustomEmailSender `json:"CustomEmailSender,omitempty"`
+
 	// CustomMessage AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html#cfn-cognito-userpool-lambdaconfig-custommessage
 	CustomMessage string `json:"CustomMessage,omitempty"`
 
+	// CustomSMSSender AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html#cfn-cognito-userpool-lambdaconfig-customsmssender
+	CustomSMSSender *UserPool_CustomSMSSender `json:"CustomSMSSender,omitempty"`
+
 	// DefineAuthChallenge AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html#cfn-cognito-userpool-lambdaconfig-defineauthchallenge
 	DefineAuthChallenge string `json:"DefineAuthChallenge,omitempty"`
+
+	// KMSKeyID AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html#cfn-cognito-userpool-lambdaconfig-kmskeyid
+	KMSKeyID string `json:"KMSKeyID,omitempty"`
 
 	// PostAuthentication AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/devopsguru/aws-devopsguru-notificationchannel.go
+++ b/cloudformation/devopsguru/aws-devopsguru-notificationchannel.go
@@ -1,0 +1,106 @@
+package devopsguru
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NotificationChannel AWS CloudFormation Resource (AWS::DevOpsGuru::NotificationChannel)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-devopsguru-notificationchannel.html
+type NotificationChannel struct {
+
+	// Config AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-devopsguru-notificationchannel.html#cfn-devopsguru-notificationchannel-config
+	Config *NotificationChannel_NotificationChannelConfig `json:"Config,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NotificationChannel) AWSCloudFormationType() string {
+	return "AWS::DevOpsGuru::NotificationChannel"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r NotificationChannel) MarshalJSON() ([]byte, error) {
+	type Properties NotificationChannel
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *NotificationChannel) UnmarshalJSON(b []byte) error {
+	type Properties NotificationChannel
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = NotificationChannel(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/devopsguru/aws-devopsguru-notificationchannel_notificationchannelconfig.go
+++ b/cloudformation/devopsguru/aws-devopsguru-notificationchannel_notificationchannelconfig.go
@@ -1,0 +1,35 @@
+package devopsguru
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NotificationChannel_NotificationChannelConfig AWS CloudFormation Resource (AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-notificationchannel-notificationchannelconfig.html
+type NotificationChannel_NotificationChannelConfig struct {
+
+	// Sns AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-notificationchannel-notificationchannelconfig.html#cfn-devopsguru-notificationchannel-notificationchannelconfig-sns
+	Sns *NotificationChannel_SnsChannelConfig `json:"Sns,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NotificationChannel_NotificationChannelConfig) AWSCloudFormationType() string {
+	return "AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig"
+}

--- a/cloudformation/devopsguru/aws-devopsguru-notificationchannel_snschannelconfig.go
+++ b/cloudformation/devopsguru/aws-devopsguru-notificationchannel_snschannelconfig.go
@@ -1,0 +1,35 @@
+package devopsguru
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NotificationChannel_SnsChannelConfig AWS CloudFormation Resource (AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-notificationchannel-snschannelconfig.html
+type NotificationChannel_SnsChannelConfig struct {
+
+	// TopicArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-notificationchannel-snschannelconfig.html#cfn-devopsguru-notificationchannel-snschannelconfig-topicarn
+	TopicArn string `json:"TopicArn,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NotificationChannel_SnsChannelConfig) AWSCloudFormationType() string {
+	return "AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig"
+}

--- a/cloudformation/devopsguru/aws-devopsguru-resourcecollection.go
+++ b/cloudformation/devopsguru/aws-devopsguru-resourcecollection.go
@@ -1,0 +1,106 @@
+package devopsguru
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ResourceCollection AWS CloudFormation Resource (AWS::DevOpsGuru::ResourceCollection)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-devopsguru-resourcecollection.html
+type ResourceCollection struct {
+
+	// ResourceCollectionFilter AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-devopsguru-resourcecollection.html#cfn-devopsguru-resourcecollection-resourcecollectionfilter
+	ResourceCollectionFilter *ResourceCollection_ResourceCollectionFilter `json:"ResourceCollectionFilter,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ResourceCollection) AWSCloudFormationType() string {
+	return "AWS::DevOpsGuru::ResourceCollection"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ResourceCollection) MarshalJSON() ([]byte, error) {
+	type Properties ResourceCollection
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ResourceCollection) UnmarshalJSON(b []byte) error {
+	type Properties ResourceCollection
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ResourceCollection(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/devopsguru/aws-devopsguru-resourcecollection_cloudformationcollectionfilter.go
+++ b/cloudformation/devopsguru/aws-devopsguru-resourcecollection_cloudformationcollectionfilter.go
@@ -1,0 +1,35 @@
+package devopsguru
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ResourceCollection_CloudFormationCollectionFilter AWS CloudFormation Resource (AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-resourcecollection-cloudformationcollectionfilter.html
+type ResourceCollection_CloudFormationCollectionFilter struct {
+
+	// StackNames AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-resourcecollection-cloudformationcollectionfilter.html#cfn-devopsguru-resourcecollection-cloudformationcollectionfilter-stacknames
+	StackNames []string `json:"StackNames,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ResourceCollection_CloudFormationCollectionFilter) AWSCloudFormationType() string {
+	return "AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter"
+}

--- a/cloudformation/devopsguru/aws-devopsguru-resourcecollection_resourcecollectionfilter.go
+++ b/cloudformation/devopsguru/aws-devopsguru-resourcecollection_resourcecollectionfilter.go
@@ -1,0 +1,35 @@
+package devopsguru
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ResourceCollection_ResourceCollectionFilter AWS CloudFormation Resource (AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-resourcecollection-resourcecollectionfilter.html
+type ResourceCollection_ResourceCollectionFilter struct {
+
+	// CloudFormation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-devopsguru-resourcecollection-resourcecollectionfilter.html#cfn-devopsguru-resourcecollection-resourcecollectionfilter-cloudformation
+	CloudFormation *ResourceCollection_CloudFormationCollectionFilter `json:"CloudFormation,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ResourceCollection_ResourceCollectionFilter) AWSCloudFormationType() string {
+	return "AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter"
+}

--- a/cloudformation/dlm/aws-dlm-lifecyclepolicy.go
+++ b/cloudformation/dlm/aws-dlm-lifecyclepolicy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // LifecyclePolicy AWS CloudFormation Resource (AWS::DLM::LifecyclePolicy)
@@ -31,6 +32,11 @@ type LifecyclePolicy struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dlm-lifecyclepolicy.html#cfn-dlm-lifecyclepolicy-state
 	State string `json:"State,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dlm-lifecyclepolicy.html#cfn-dlm-lifecyclepolicy-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/ec2/aws-ec2-instance.go
+++ b/cloudformation/ec2/aws-ec2-instance.go
@@ -63,6 +63,11 @@ type Instance struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-elasticinferenceaccelerators
 	ElasticInferenceAccelerators []Instance_ElasticInferenceAccelerator `json:"ElasticInferenceAccelerators,omitempty"`
 
+	// EnclaveOptions AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-enclaveoptions
+	EnclaveOptions *Instance_EnclaveOptions `json:"EnclaveOptions,omitempty"`
+
 	// HibernationOptions AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-hibernationoptions

--- a/cloudformation/ec2/aws-ec2-instance_enclaveoptions.go
+++ b/cloudformation/ec2/aws-ec2-instance_enclaveoptions.go
@@ -1,0 +1,35 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Instance_EnclaveOptions AWS CloudFormation Resource (AWS::EC2::Instance.EnclaveOptions)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-enclaveoptions.html
+type Instance_EnclaveOptions struct {
+
+	// Enabled AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-enclaveoptions.html#cfn-ec2-instance-enclaveoptions-enabled
+	Enabled bool `json:"Enabled,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Instance_EnclaveOptions) AWSCloudFormationType() string {
+	return "AWS::EC2::Instance.EnclaveOptions"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis.go
@@ -1,0 +1,122 @@
+package ec2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// NetworkInsightsAnalysis AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightsanalysis.html
+type NetworkInsightsAnalysis struct {
+
+	// FilterInArns AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightsanalysis.html#cfn-ec2-networkinsightsanalysis-filterinarns
+	FilterInArns []string `json:"FilterInArns,omitempty"`
+
+	// NetworkInsightsPathId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightsanalysis.html#cfn-ec2-networkinsightsanalysis-networkinsightspathid
+	NetworkInsightsPathId string `json:"NetworkInsightsPathId,omitempty"`
+
+	// StatusMessage AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightsanalysis.html#cfn-ec2-networkinsightsanalysis-statusmessage
+	StatusMessage string `json:"StatusMessage,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightsanalysis.html#cfn-ec2-networkinsightsanalysis-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r NetworkInsightsAnalysis) MarshalJSON() ([]byte, error) {
+	type Properties NetworkInsightsAnalysis
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *NetworkInsightsAnalysis) UnmarshalJSON(b []byte) error {
+	type Properties NetworkInsightsAnalysis
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = NetworkInsightsAnalysis(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_alternatepathhint.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_alternatepathhint.go
@@ -1,0 +1,40 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AlternatePathHint AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AlternatePathHint)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-alternatepathhint.html
+type NetworkInsightsAnalysis_AlternatePathHint struct {
+
+	// ComponentArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-alternatepathhint.html#cfn-ec2-networkinsightsanalysis-alternatepathhint-componentarn
+	ComponentArn string `json:"ComponentArn,omitempty"`
+
+	// ComponentId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-alternatepathhint.html#cfn-ec2-networkinsightsanalysis-alternatepathhint-componentid
+	ComponentId string `json:"ComponentId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AlternatePathHint) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AlternatePathHint"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisaclrule.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisaclrule.go
@@ -1,0 +1,60 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisAclRule AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html
+type NetworkInsightsAnalysis_AnalysisAclRule struct {
+
+	// Cidr AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html#cfn-ec2-networkinsightsanalysis-analysisaclrule-cidr
+	Cidr string `json:"Cidr,omitempty"`
+
+	// Egress AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html#cfn-ec2-networkinsightsanalysis-analysisaclrule-egress
+	Egress bool `json:"Egress,omitempty"`
+
+	// PortRange AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html#cfn-ec2-networkinsightsanalysis-analysisaclrule-portrange
+	PortRange *NetworkInsightsAnalysis_PortRange `json:"PortRange,omitempty"`
+
+	// Protocol AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html#cfn-ec2-networkinsightsanalysis-analysisaclrule-protocol
+	Protocol string `json:"Protocol,omitempty"`
+
+	// RuleAction AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html#cfn-ec2-networkinsightsanalysis-analysisaclrule-ruleaction
+	RuleAction string `json:"RuleAction,omitempty"`
+
+	// RuleNumber AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisaclrule.html#cfn-ec2-networkinsightsanalysis-analysisaclrule-rulenumber
+	RuleNumber int `json:"RuleNumber,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisAclRule) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysiscomponent.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysiscomponent.go
@@ -1,0 +1,40 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisComponent AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysiscomponent.html
+type NetworkInsightsAnalysis_AnalysisComponent struct {
+
+	// Arn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysiscomponent.html#cfn-ec2-networkinsightsanalysis-analysiscomponent-arn
+	Arn string `json:"Arn,omitempty"`
+
+	// Id AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysiscomponent.html#cfn-ec2-networkinsightsanalysis-analysiscomponent-id
+	Id string `json:"Id,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisComponent) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisloadbalancerlistener.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisloadbalancerlistener.go
@@ -1,0 +1,40 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisLoadBalancerListener AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancerlistener.html
+type NetworkInsightsAnalysis_AnalysisLoadBalancerListener struct {
+
+	// InstancePort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancerlistener.html#cfn-ec2-networkinsightsanalysis-analysisloadbalancerlistener-instanceport
+	InstancePort int `json:"InstancePort,omitempty"`
+
+	// LoadBalancerPort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancerlistener.html#cfn-ec2-networkinsightsanalysis-analysisloadbalancerlistener-loadbalancerport
+	LoadBalancerPort int `json:"LoadBalancerPort,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisLoadBalancerListener) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisloadbalancertarget.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisloadbalancertarget.go
@@ -1,0 +1,50 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisLoadBalancerTarget AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancertarget.html
+type NetworkInsightsAnalysis_AnalysisLoadBalancerTarget struct {
+
+	// Address AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancertarget.html#cfn-ec2-networkinsightsanalysis-analysisloadbalancertarget-address
+	Address string `json:"Address,omitempty"`
+
+	// AvailabilityZone AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancertarget.html#cfn-ec2-networkinsightsanalysis-analysisloadbalancertarget-availabilityzone
+	AvailabilityZone string `json:"AvailabilityZone,omitempty"`
+
+	// Instance AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancertarget.html#cfn-ec2-networkinsightsanalysis-analysisloadbalancertarget-instance
+	Instance *NetworkInsightsAnalysis_AnalysisComponent `json:"Instance,omitempty"`
+
+	// Port AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisloadbalancertarget.html#cfn-ec2-networkinsightsanalysis-analysisloadbalancertarget-port
+	Port int `json:"Port,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisLoadBalancerTarget) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysispacketheader.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysispacketheader.go
@@ -1,0 +1,55 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisPacketHeader AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysispacketheader.html
+type NetworkInsightsAnalysis_AnalysisPacketHeader struct {
+
+	// DestinationAddresses AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysispacketheader.html#cfn-ec2-networkinsightsanalysis-analysispacketheader-destinationaddresses
+	DestinationAddresses []string `json:"DestinationAddresses,omitempty"`
+
+	// DestinationPortRanges AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysispacketheader.html#cfn-ec2-networkinsightsanalysis-analysispacketheader-destinationportranges
+	DestinationPortRanges []NetworkInsightsAnalysis_PortRange `json:"DestinationPortRanges,omitempty"`
+
+	// Protocol AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysispacketheader.html#cfn-ec2-networkinsightsanalysis-analysispacketheader-protocol
+	Protocol string `json:"Protocol,omitempty"`
+
+	// SourceAddresses AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysispacketheader.html#cfn-ec2-networkinsightsanalysis-analysispacketheader-sourceaddresses
+	SourceAddresses []string `json:"SourceAddresses,omitempty"`
+
+	// SourcePortRanges AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysispacketheader.html#cfn-ec2-networkinsightsanalysis-analysispacketheader-sourceportranges
+	SourcePortRanges []NetworkInsightsAnalysis_PortRange `json:"SourcePortRanges,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisPacketHeader) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisroutetableroute.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysisroutetableroute.go
@@ -1,0 +1,80 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisRouteTableRoute AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html
+type NetworkInsightsAnalysis_AnalysisRouteTableRoute struct {
+
+	// NatGatewayId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-natgatewayid
+	NatGatewayId string `json:"NatGatewayId,omitempty"`
+
+	// NetworkInterfaceId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-networkinterfaceid
+	NetworkInterfaceId string `json:"NetworkInterfaceId,omitempty"`
+
+	// Origin AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-origin
+	Origin string `json:"Origin,omitempty"`
+
+	// TransitGatewayId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-transitgatewayid
+	TransitGatewayId string `json:"TransitGatewayId,omitempty"`
+
+	// VpcPeeringConnectionId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-vpcpeeringconnectionid
+	VpcPeeringConnectionId string `json:"VpcPeeringConnectionId,omitempty"`
+
+	// destinationCidr AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-destinationcidr
+	destinationCidr string `json:"destinationCidr,omitempty"`
+
+	// destinationPrefixListId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-destinationprefixlistid
+	destinationPrefixListId string `json:"destinationPrefixListId,omitempty"`
+
+	// egressOnlyInternetGatewayId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-egressonlyinternetgatewayid
+	egressOnlyInternetGatewayId string `json:"egressOnlyInternetGatewayId,omitempty"`
+
+	// gatewayId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-gatewayid
+	gatewayId string `json:"gatewayId,omitempty"`
+
+	// instanceId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysisroutetableroute.html#cfn-ec2-networkinsightsanalysis-analysisroutetableroute-instanceid
+	instanceId string `json:"instanceId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisRouteTableRoute) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysissecuritygrouprule.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_analysissecuritygrouprule.go
@@ -1,0 +1,60 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_AnalysisSecurityGroupRule AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html
+type NetworkInsightsAnalysis_AnalysisSecurityGroupRule struct {
+
+	// Cidr AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html#cfn-ec2-networkinsightsanalysis-analysissecuritygrouprule-cidr
+	Cidr string `json:"Cidr,omitempty"`
+
+	// Direction AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html#cfn-ec2-networkinsightsanalysis-analysissecuritygrouprule-direction
+	Direction string `json:"Direction,omitempty"`
+
+	// PortRange AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html#cfn-ec2-networkinsightsanalysis-analysissecuritygrouprule-portrange
+	PortRange *NetworkInsightsAnalysis_PortRange `json:"PortRange,omitempty"`
+
+	// PrefixListId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html#cfn-ec2-networkinsightsanalysis-analysissecuritygrouprule-prefixlistid
+	PrefixListId string `json:"PrefixListId,omitempty"`
+
+	// Protocol AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html#cfn-ec2-networkinsightsanalysis-analysissecuritygrouprule-protocol
+	Protocol string `json:"Protocol,omitempty"`
+
+	// SecurityGroupId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-analysissecuritygrouprule.html#cfn-ec2-networkinsightsanalysis-analysissecuritygrouprule-securitygroupid
+	SecurityGroupId string `json:"SecurityGroupId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_AnalysisSecurityGroupRule) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_explanation.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_explanation.go
@@ -1,0 +1,255 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_Explanation AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.Explanation)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html
+type NetworkInsightsAnalysis_Explanation struct {
+
+	// Acl AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-acl
+	Acl *NetworkInsightsAnalysis_AnalysisComponent `json:"Acl,omitempty"`
+
+	// AclRule AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-aclrule
+	AclRule *NetworkInsightsAnalysis_AnalysisAclRule `json:"AclRule,omitempty"`
+
+	// Address AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-address
+	Address string `json:"Address,omitempty"`
+
+	// Addresses AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-addresses
+	Addresses []string `json:"Addresses,omitempty"`
+
+	// AttachedTo AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-attachedto
+	AttachedTo *NetworkInsightsAnalysis_AnalysisComponent `json:"AttachedTo,omitempty"`
+
+	// AvailabilityZones AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-availabilityzones
+	AvailabilityZones []string `json:"AvailabilityZones,omitempty"`
+
+	// Cidrs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-cidrs
+	Cidrs []string `json:"Cidrs,omitempty"`
+
+	// ClassicLoadBalancerListener AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-classicloadbalancerlistener
+	ClassicLoadBalancerListener *NetworkInsightsAnalysis_AnalysisLoadBalancerListener `json:"ClassicLoadBalancerListener,omitempty"`
+
+	// Component AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-component
+	Component *NetworkInsightsAnalysis_AnalysisComponent `json:"Component,omitempty"`
+
+	// CustomerGateway AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-customergateway
+	CustomerGateway *NetworkInsightsAnalysis_AnalysisComponent `json:"CustomerGateway,omitempty"`
+
+	// Destination AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-destination
+	Destination *NetworkInsightsAnalysis_AnalysisComponent `json:"Destination,omitempty"`
+
+	// DestinationVpc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-destinationvpc
+	DestinationVpc *NetworkInsightsAnalysis_AnalysisComponent `json:"DestinationVpc,omitempty"`
+
+	// Direction AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-direction
+	Direction string `json:"Direction,omitempty"`
+
+	// ElasticLoadBalancerListener AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-elasticloadbalancerlistener
+	ElasticLoadBalancerListener *NetworkInsightsAnalysis_AnalysisComponent `json:"ElasticLoadBalancerListener,omitempty"`
+
+	// ExplanationCode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-explanationcode
+	ExplanationCode string `json:"ExplanationCode,omitempty"`
+
+	// IngressRouteTable AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-ingressroutetable
+	IngressRouteTable *NetworkInsightsAnalysis_AnalysisComponent `json:"IngressRouteTable,omitempty"`
+
+	// InternetGateway AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-internetgateway
+	InternetGateway *NetworkInsightsAnalysis_AnalysisComponent `json:"InternetGateway,omitempty"`
+
+	// LoadBalancerArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-loadbalancerarn
+	LoadBalancerArn string `json:"LoadBalancerArn,omitempty"`
+
+	// LoadBalancerListenerPort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-loadbalancerlistenerport
+	LoadBalancerListenerPort int `json:"LoadBalancerListenerPort,omitempty"`
+
+	// LoadBalancerTarget AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-loadbalancertarget
+	LoadBalancerTarget *NetworkInsightsAnalysis_AnalysisLoadBalancerTarget `json:"LoadBalancerTarget,omitempty"`
+
+	// LoadBalancerTargetGroup AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-loadbalancertargetgroup
+	LoadBalancerTargetGroup *NetworkInsightsAnalysis_AnalysisComponent `json:"LoadBalancerTargetGroup,omitempty"`
+
+	// LoadBalancerTargetGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-loadbalancertargetgroups
+	LoadBalancerTargetGroups []NetworkInsightsAnalysis_AnalysisComponent `json:"LoadBalancerTargetGroups,omitempty"`
+
+	// LoadBalancerTargetPort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-loadbalancertargetport
+	LoadBalancerTargetPort int `json:"LoadBalancerTargetPort,omitempty"`
+
+	// MissingComponent AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-missingcomponent
+	MissingComponent string `json:"MissingComponent,omitempty"`
+
+	// NatGateway AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-natgateway
+	NatGateway *NetworkInsightsAnalysis_AnalysisComponent `json:"NatGateway,omitempty"`
+
+	// NetworkInterface AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-networkinterface
+	NetworkInterface *NetworkInsightsAnalysis_AnalysisComponent `json:"NetworkInterface,omitempty"`
+
+	// PacketField AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-packetfield
+	PacketField string `json:"PacketField,omitempty"`
+
+	// Port AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-port
+	Port int `json:"Port,omitempty"`
+
+	// PortRanges AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-portranges
+	PortRanges []NetworkInsightsAnalysis_PortRange `json:"PortRanges,omitempty"`
+
+	// PrefixList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-prefixlist
+	PrefixList *NetworkInsightsAnalysis_AnalysisComponent `json:"PrefixList,omitempty"`
+
+	// Protocols AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-protocols
+	Protocols []string `json:"Protocols,omitempty"`
+
+	// RouteTable AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-routetable
+	RouteTable *NetworkInsightsAnalysis_AnalysisComponent `json:"RouteTable,omitempty"`
+
+	// RouteTableRoute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-routetableroute
+	RouteTableRoute *NetworkInsightsAnalysis_AnalysisRouteTableRoute `json:"RouteTableRoute,omitempty"`
+
+	// SecurityGroup AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-securitygroup
+	SecurityGroup *NetworkInsightsAnalysis_AnalysisComponent `json:"SecurityGroup,omitempty"`
+
+	// SecurityGroupRule AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-securitygrouprule
+	SecurityGroupRule *NetworkInsightsAnalysis_AnalysisSecurityGroupRule `json:"SecurityGroupRule,omitempty"`
+
+	// SecurityGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-securitygroups
+	SecurityGroups []NetworkInsightsAnalysis_AnalysisComponent `json:"SecurityGroups,omitempty"`
+
+	// SourceVpc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-sourcevpc
+	SourceVpc *NetworkInsightsAnalysis_AnalysisComponent `json:"SourceVpc,omitempty"`
+
+	// State AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-state
+	State string `json:"State,omitempty"`
+
+	// Subnet AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-subnet
+	Subnet *NetworkInsightsAnalysis_AnalysisComponent `json:"Subnet,omitempty"`
+
+	// SubnetRouteTable AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-subnetroutetable
+	SubnetRouteTable *NetworkInsightsAnalysis_AnalysisComponent `json:"SubnetRouteTable,omitempty"`
+
+	// Vpc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-vpc
+	Vpc *NetworkInsightsAnalysis_AnalysisComponent `json:"Vpc,omitempty"`
+
+	// VpcPeeringConnection AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-vpcpeeringconnection
+	VpcPeeringConnection *NetworkInsightsAnalysis_AnalysisComponent `json:"VpcPeeringConnection,omitempty"`
+
+	// VpnConnection AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-vpnconnection
+	VpnConnection *NetworkInsightsAnalysis_AnalysisComponent `json:"VpnConnection,omitempty"`
+
+	// VpnGateway AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-vpngateway
+	VpnGateway *NetworkInsightsAnalysis_AnalysisComponent `json:"VpnGateway,omitempty"`
+
+	// vpcEndpoint AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-explanation.html#cfn-ec2-networkinsightsanalysis-explanation-vpcendpoint
+	vpcEndpoint *NetworkInsightsAnalysis_AnalysisComponent `json:"vpcEndpoint,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_Explanation) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.Explanation"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_pathcomponent.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_pathcomponent.go
@@ -1,0 +1,85 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_PathComponent AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.PathComponent)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html
+type NetworkInsightsAnalysis_PathComponent struct {
+
+	// AclRule AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-aclrule
+	AclRule *NetworkInsightsAnalysis_AnalysisAclRule `json:"AclRule,omitempty"`
+
+	// Component AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-component
+	Component *NetworkInsightsAnalysis_AnalysisComponent `json:"Component,omitempty"`
+
+	// DestinationVpc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-destinationvpc
+	DestinationVpc *NetworkInsightsAnalysis_AnalysisComponent `json:"DestinationVpc,omitempty"`
+
+	// InboundHeader AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-inboundheader
+	InboundHeader *NetworkInsightsAnalysis_AnalysisPacketHeader `json:"InboundHeader,omitempty"`
+
+	// OutboundHeader AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-outboundheader
+	OutboundHeader *NetworkInsightsAnalysis_AnalysisPacketHeader `json:"OutboundHeader,omitempty"`
+
+	// RouteTableRoute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-routetableroute
+	RouteTableRoute *NetworkInsightsAnalysis_AnalysisRouteTableRoute `json:"RouteTableRoute,omitempty"`
+
+	// SecurityGroupRule AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-securitygrouprule
+	SecurityGroupRule *NetworkInsightsAnalysis_AnalysisSecurityGroupRule `json:"SecurityGroupRule,omitempty"`
+
+	// SequenceNumber AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-sequencenumber
+	SequenceNumber int `json:"SequenceNumber,omitempty"`
+
+	// SourceVpc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-sourcevpc
+	SourceVpc *NetworkInsightsAnalysis_AnalysisComponent `json:"SourceVpc,omitempty"`
+
+	// Subnet AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-subnet
+	Subnet *NetworkInsightsAnalysis_AnalysisComponent `json:"Subnet,omitempty"`
+
+	// Vpc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-pathcomponent.html#cfn-ec2-networkinsightsanalysis-pathcomponent-vpc
+	Vpc *NetworkInsightsAnalysis_AnalysisComponent `json:"Vpc,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_PathComponent) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.PathComponent"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightsanalysis_portrange.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightsanalysis_portrange.go
@@ -1,0 +1,40 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// NetworkInsightsAnalysis_PortRange AWS CloudFormation Resource (AWS::EC2::NetworkInsightsAnalysis.PortRange)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-portrange.html
+type NetworkInsightsAnalysis_PortRange struct {
+
+	// From AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-portrange.html#cfn-ec2-networkinsightsanalysis-portrange-from
+	From int `json:"From,omitempty"`
+
+	// To AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinsightsanalysis-portrange.html#cfn-ec2-networkinsightsanalysis-portrange-to
+	To int `json:"To,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsAnalysis_PortRange) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsAnalysis.PortRange"
+}

--- a/cloudformation/ec2/aws-ec2-networkinsightspath.go
+++ b/cloudformation/ec2/aws-ec2-networkinsightspath.go
@@ -1,0 +1,137 @@
+package ec2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// NetworkInsightsPath AWS CloudFormation Resource (AWS::EC2::NetworkInsightsPath)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html
+type NetworkInsightsPath struct {
+
+	// Destination AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-destination
+	Destination string `json:"Destination,omitempty"`
+
+	// DestinationIp AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-destinationip
+	DestinationIp string `json:"DestinationIp,omitempty"`
+
+	// DestinationPort AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-destinationport
+	DestinationPort int `json:"DestinationPort,omitempty"`
+
+	// Protocol AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-protocol
+	Protocol string `json:"Protocol,omitempty"`
+
+	// Source AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-source
+	Source string `json:"Source,omitempty"`
+
+	// SourceIp AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-sourceip
+	SourceIp string `json:"SourceIp,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinsightspath.html#cfn-ec2-networkinsightspath-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *NetworkInsightsPath) AWSCloudFormationType() string {
+	return "AWS::EC2::NetworkInsightsPath"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r NetworkInsightsPath) MarshalJSON() ([]byte, error) {
+	type Properties NetworkInsightsPath
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *NetworkInsightsPath) UnmarshalJSON(b []byte) error {
+	type Properties NetworkInsightsPath
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = NetworkInsightsPath(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/ec2/aws-ec2-spotfleet_launchtemplateoverrides.go
+++ b/cloudformation/ec2/aws-ec2-spotfleet_launchtemplateoverrides.go
@@ -18,6 +18,11 @@ type SpotFleet_LaunchTemplateOverrides struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-launchtemplateoverrides.html#cfn-ec2-spotfleet-launchtemplateoverrides-instancetype
 	InstanceType string `json:"InstanceType,omitempty"`
 
+	// Priority AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-launchtemplateoverrides.html#cfn-ec2-spotfleet-launchtemplateoverrides-priority
+	Priority float64 `json:"Priority,omitempty"`
+
 	// SpotPrice AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-launchtemplateoverrides.html#cfn-ec2-spotfleet-launchtemplateoverrides-spotprice

--- a/cloudformation/ec2/aws-ec2-spotfleet_spotcapacityrebalance.go
+++ b/cloudformation/ec2/aws-ec2-spotfleet_spotcapacityrebalance.go
@@ -1,0 +1,35 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// SpotFleet_SpotCapacityRebalance AWS CloudFormation Resource (AWS::EC2::SpotFleet.SpotCapacityRebalance)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotcapacityrebalance.html
+type SpotFleet_SpotCapacityRebalance struct {
+
+	// ReplacementStrategy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotcapacityrebalance.html#cfn-ec2-spotfleet-spotcapacityrebalance-replacementstrategy
+	ReplacementStrategy string `json:"ReplacementStrategy,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *SpotFleet_SpotCapacityRebalance) AWSCloudFormationType() string {
+	return "AWS::EC2::SpotFleet.SpotCapacityRebalance"
+}

--- a/cloudformation/ec2/aws-ec2-spotfleet_spotfleetrequestconfigdata.go
+++ b/cloudformation/ec2/aws-ec2-spotfleet_spotfleetrequestconfigdata.go
@@ -28,6 +28,11 @@ type SpotFleet_SpotFleetRequestConfigData struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-instanceinterruptionbehavior
 	InstanceInterruptionBehavior string `json:"InstanceInterruptionBehavior,omitempty"`
 
+	// InstancePoolsToUseCount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-instancepoolstousecount
+	InstancePoolsToUseCount int `json:"InstancePoolsToUseCount,omitempty"`
+
 	// LaunchSpecifications AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications
@@ -43,10 +48,35 @@ type SpotFleet_SpotFleetRequestConfigData struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-loadbalancersconfig
 	LoadBalancersConfig *SpotFleet_LoadBalancersConfig `json:"LoadBalancersConfig,omitempty"`
 
+	// OnDemandAllocationStrategy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-ondemandallocationstrategy
+	OnDemandAllocationStrategy string `json:"OnDemandAllocationStrategy,omitempty"`
+
+	// OnDemandMaxTotalPrice AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-ondemandmaxtotalprice
+	OnDemandMaxTotalPrice string `json:"OnDemandMaxTotalPrice,omitempty"`
+
+	// OnDemandTargetCapacity AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-ondemandtargetcapacity
+	OnDemandTargetCapacity int `json:"OnDemandTargetCapacity,omitempty"`
+
 	// ReplaceUnhealthyInstances AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-replaceunhealthyinstances
 	ReplaceUnhealthyInstances bool `json:"ReplaceUnhealthyInstances,omitempty"`
+
+	// SpotMaintenanceStrategies AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-spotmaintenancestrategies
+	SpotMaintenanceStrategies *SpotFleet_SpotMaintenanceStrategies `json:"SpotMaintenanceStrategies,omitempty"`
+
+	// SpotMaxTotalPrice AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-spotmaxtotalprice
+	SpotMaxTotalPrice string `json:"SpotMaxTotalPrice,omitempty"`
 
 	// SpotPrice AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/ec2/aws-ec2-spotfleet_spotmaintenancestrategies.go
+++ b/cloudformation/ec2/aws-ec2-spotfleet_spotmaintenancestrategies.go
@@ -1,0 +1,35 @@
+package ec2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// SpotFleet_SpotMaintenanceStrategies AWS CloudFormation Resource (AWS::EC2::SpotFleet.SpotMaintenanceStrategies)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotmaintenancestrategies.html
+type SpotFleet_SpotMaintenanceStrategies struct {
+
+	// CapacityRebalance AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotmaintenancestrategies.html#cfn-ec2-spotfleet-spotmaintenancestrategies-capacityrebalance
+	CapacityRebalance *SpotFleet_SpotCapacityRebalance `json:"CapacityRebalance,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *SpotFleet_SpotMaintenanceStrategies) AWSCloudFormationType() string {
+	return "AWS::EC2::SpotFleet.SpotMaintenanceStrategies"
+}

--- a/cloudformation/ec2/aws-ec2-volume.go
+++ b/cloudformation/ec2/aws-ec2-volume.go
@@ -63,6 +63,11 @@ type Volume struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html#cfn-ec2-ebs-volume-tags
 	Tags []tags.Tag `json:"Tags,omitempty"`
 
+	// Throughput AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html#cfn-ec2-ebs-volume-throughput
+	Throughput int `json:"Throughput,omitempty"`
+
 	// VolumeType AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html#cfn-ec2-ebs-volume-volumetype

--- a/cloudformation/ecr/aws-ecr-publicrepository.go
+++ b/cloudformation/ecr/aws-ecr-publicrepository.go
@@ -1,0 +1,116 @@
+package ecr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// PublicRepository AWS CloudFormation Resource (AWS::ECR::PublicRepository)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-publicrepository.html
+type PublicRepository struct {
+
+	// RepositoryCatalogData AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-publicrepository.html#cfn-ecr-publicrepository-repositorycatalogdata
+	RepositoryCatalogData interface{} `json:"RepositoryCatalogData,omitempty"`
+
+	// RepositoryName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-publicrepository.html#cfn-ecr-publicrepository-repositoryname
+	RepositoryName string `json:"RepositoryName,omitempty"`
+
+	// RepositoryPolicyText AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-publicrepository.html#cfn-ecr-publicrepository-repositorypolicytext
+	RepositoryPolicyText interface{} `json:"RepositoryPolicyText,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *PublicRepository) AWSCloudFormationType() string {
+	return "AWS::ECR::PublicRepository"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r PublicRepository) MarshalJSON() ([]byte, error) {
+	type Properties PublicRepository
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *PublicRepository) UnmarshalJSON(b []byte) error {
+	type Properties PublicRepository
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = PublicRepository(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/ecs/aws-ecs-service_deploymentcircuitbreaker.go
+++ b/cloudformation/ecs/aws-ecs-service_deploymentcircuitbreaker.go
@@ -1,0 +1,40 @@
+package ecs
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Service_DeploymentCircuitBreaker AWS CloudFormation Resource (AWS::ECS::Service.DeploymentCircuitBreaker)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentcircuitbreaker.html
+type Service_DeploymentCircuitBreaker struct {
+
+	// Enable AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentcircuitbreaker.html#cfn-ecs-service-deploymentcircuitbreaker-enable
+	Enable bool `json:"Enable"`
+
+	// Rollback AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentcircuitbreaker.html#cfn-ecs-service-deploymentcircuitbreaker-rollback
+	Rollback bool `json:"Rollback"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Service_DeploymentCircuitBreaker) AWSCloudFormationType() string {
+	return "AWS::ECS::Service.DeploymentCircuitBreaker"
+}

--- a/cloudformation/ecs/aws-ecs-service_deploymentconfiguration.go
+++ b/cloudformation/ecs/aws-ecs-service_deploymentconfiguration.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentconfiguration.html
 type Service_DeploymentConfiguration struct {
 
+	// DeploymentCircuitBreaker AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentconfiguration.html#cfn-ecs-service-deploymentconfiguration-deploymentcircuitbreaker
+	DeploymentCircuitBreaker *Service_DeploymentCircuitBreaker `json:"DeploymentCircuitBreaker,omitempty"`
+
 	// MaximumPercent AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-deploymentconfiguration.html#cfn-ecs-service-deploymentconfiguration-maximumpercent

--- a/cloudformation/eks/aws-eks-nodegroup.go
+++ b/cloudformation/eks/aws-eks-nodegroup.go
@@ -17,6 +17,11 @@ type Nodegroup struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype
 	AmiType string `json:"AmiType,omitempty"`
 
+	// CapacityType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype
+	CapacityType string `json:"CapacityType,omitempty"`
+
 	// ClusterName AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername

--- a/cloudformation/elasticache/aws-elasticache-replicationgroup.go
+++ b/cloudformation/elasticache/aws-elasticache-replicationgroup.go
@@ -173,6 +173,11 @@ type ReplicationGroup struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-transitencryptionenabled
 	TransitEncryptionEnabled bool `json:"TransitEncryptionEnabled,omitempty"`
 
+	// UserGroupIds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-usergroupids
+	UserGroupIds []string `json:"UserGroupIds,omitempty"`
+
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 

--- a/cloudformation/elasticache/aws-elasticache-user.go
+++ b/cloudformation/elasticache/aws-elasticache-user.go
@@ -1,0 +1,131 @@
+package elasticache
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// User AWS CloudFormation Resource (AWS::ElastiCache::User)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html
+type User struct {
+
+	// AccessString AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html#cfn-elasticache-user-accessstring
+	AccessString string `json:"AccessString,omitempty"`
+
+	// Engine AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html#cfn-elasticache-user-engine
+	Engine string `json:"Engine,omitempty"`
+
+	// NoPasswordRequired AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html#cfn-elasticache-user-nopasswordrequired
+	NoPasswordRequired bool `json:"NoPasswordRequired,omitempty"`
+
+	// Passwords AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html#cfn-elasticache-user-passwords
+	Passwords *User_PasswordList `json:"Passwords,omitempty"`
+
+	// UserId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html#cfn-elasticache-user-userid
+	UserId string `json:"UserId,omitempty"`
+
+	// UserName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-user.html#cfn-elasticache-user-username
+	UserName string `json:"UserName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *User) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::User"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r User) MarshalJSON() ([]byte, error) {
+	type Properties User
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *User) UnmarshalJSON(b []byte) error {
+	type Properties User
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = User(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/elasticache/aws-elasticache-user_authentication.go
+++ b/cloudformation/elasticache/aws-elasticache-user_authentication.go
@@ -1,0 +1,40 @@
+package elasticache
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// User_Authentication AWS CloudFormation Resource (AWS::ElastiCache::User.Authentication)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-authentication.html
+type User_Authentication struct {
+
+	// PasswordCount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-authentication.html#cfn-elasticache-user-authentication-passwordcount
+	PasswordCount int `json:"PasswordCount,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-authentication.html#cfn-elasticache-user-authentication-type
+	Type string `json:"Type,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *User_Authentication) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::User.Authentication"
+}

--- a/cloudformation/elasticache/aws-elasticache-user_passwordlist.go
+++ b/cloudformation/elasticache/aws-elasticache-user_passwordlist.go
@@ -1,0 +1,35 @@
+package elasticache
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// User_PasswordList AWS CloudFormation Resource (AWS::ElastiCache::User.PasswordList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-passwordlist.html
+type User_PasswordList struct {
+
+	// PasswordList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-passwordlist.html#cfn-elasticache-user-passwordlist-passwordlist
+	PasswordList []string `json:"PasswordList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *User_PasswordList) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::User.PasswordList"
+}

--- a/cloudformation/elasticache/aws-elasticache-user_usergroupidlist.go
+++ b/cloudformation/elasticache/aws-elasticache-user_usergroupidlist.go
@@ -1,0 +1,35 @@
+package elasticache
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// User_UserGroupIdList AWS CloudFormation Resource (AWS::ElastiCache::User.UserGroupIdList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-usergroupidlist.html
+type User_UserGroupIdList struct {
+
+	// UserGroupIdList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-user-usergroupidlist.html#cfn-elasticache-user-usergroupidlist-usergroupidlist
+	UserGroupIdList []string `json:"UserGroupIdList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *User_UserGroupIdList) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::User.UserGroupIdList"
+}

--- a/cloudformation/elasticache/aws-elasticache-usergroup.go
+++ b/cloudformation/elasticache/aws-elasticache-usergroup.go
@@ -1,0 +1,116 @@
+package elasticache
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserGroup AWS CloudFormation Resource (AWS::ElastiCache::UserGroup)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-usergroup.html
+type UserGroup struct {
+
+	// Engine AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-usergroup.html#cfn-elasticache-usergroup-engine
+	Engine string `json:"Engine,omitempty"`
+
+	// UserGroupId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-usergroup.html#cfn-elasticache-usergroup-usergroupid
+	UserGroupId string `json:"UserGroupId,omitempty"`
+
+	// UserIds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-usergroup.html#cfn-elasticache-usergroup-userids
+	UserIds *UserGroup_UserIdList `json:"UserIds,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserGroup) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::UserGroup"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r UserGroup) MarshalJSON() ([]byte, error) {
+	type Properties UserGroup
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *UserGroup) UnmarshalJSON(b []byte) error {
+	type Properties UserGroup
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = UserGroup(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/elasticache/aws-elasticache-usergroup_replicationgroupidlist.go
+++ b/cloudformation/elasticache/aws-elasticache-usergroup_replicationgroupidlist.go
@@ -1,0 +1,35 @@
+package elasticache
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserGroup_ReplicationGroupIdList AWS CloudFormation Resource (AWS::ElastiCache::UserGroup.ReplicationGroupIdList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-replicationgroupidlist.html
+type UserGroup_ReplicationGroupIdList struct {
+
+	// ReplicationGroupIdList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-replicationgroupidlist.html#cfn-elasticache-usergroup-replicationgroupidlist-replicationgroupidlist
+	ReplicationGroupIdList []string `json:"ReplicationGroupIdList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserGroup_ReplicationGroupIdList) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::UserGroup.ReplicationGroupIdList"
+}

--- a/cloudformation/elasticache/aws-elasticache-usergroup_usergrouppendingchanges.go
+++ b/cloudformation/elasticache/aws-elasticache-usergroup_usergrouppendingchanges.go
@@ -1,0 +1,40 @@
+package elasticache
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserGroup_UserGroupPendingChanges AWS CloudFormation Resource (AWS::ElastiCache::UserGroup.UserGroupPendingChanges)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-usergrouppendingchanges.html
+type UserGroup_UserGroupPendingChanges struct {
+
+	// UserIdsToAdd AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-usergrouppendingchanges.html#cfn-elasticache-usergroup-usergrouppendingchanges-useridstoadd
+	UserIdsToAdd []string `json:"UserIdsToAdd,omitempty"`
+
+	// UserIdsToRemove AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-usergrouppendingchanges.html#cfn-elasticache-usergroup-usergrouppendingchanges-useridstoremove
+	UserIdsToRemove []string `json:"UserIdsToRemove,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserGroup_UserGroupPendingChanges) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::UserGroup.UserGroupPendingChanges"
+}

--- a/cloudformation/elasticache/aws-elasticache-usergroup_useridlist.go
+++ b/cloudformation/elasticache/aws-elasticache-usergroup_useridlist.go
@@ -1,0 +1,35 @@
+package elasticache
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// UserGroup_UserIdList AWS CloudFormation Resource (AWS::ElastiCache::UserGroup.UserIdList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-useridlist.html
+type UserGroup_UserIdList struct {
+
+	// UserIdList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-usergroup-useridlist.html#cfn-elasticache-usergroup-useridlist-useridlist
+	UserIdList []string `json:"UserIdList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *UserGroup_UserIdList) AWSCloudFormationType() string {
+	return "AWS::ElastiCache::UserGroup.UserIdList"
+}

--- a/cloudformation/elasticsearch/aws-elasticsearch-domain_domainendpointoptions.go
+++ b/cloudformation/elasticsearch/aws-elasticsearch-domain_domainendpointoptions.go
@@ -8,6 +8,21 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html
 type Domain_DomainEndpointOptions struct {
 
+	// CustomEndpoint AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html#cfn-elasticsearch-domain-domainendpointoptions-customendpoint
+	CustomEndpoint string `json:"CustomEndpoint,omitempty"`
+
+	// CustomEndpointCertificateArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html#cfn-elasticsearch-domain-domainendpointoptions-customendpointcertificatearn
+	CustomEndpointCertificateArn string `json:"CustomEndpointCertificateArn,omitempty"`
+
+	// CustomEndpointEnabled AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html#cfn-elasticsearch-domain-domainendpointoptions-customendpointenabled
+	CustomEndpointEnabled bool `json:"CustomEndpointEnabled,omitempty"`
+
 	// EnforceHTTPS AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html#cfn-elasticsearch-domain-domainendpointoptions-enforcehttps

--- a/cloudformation/events/aws-events-archive.go
+++ b/cloudformation/events/aws-events-archive.go
@@ -12,6 +12,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-archive.html
 type Archive struct {
 
+	// ArchiveName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-archive.html#cfn-events-archive-archivename
+	ArchiveName string `json:"ArchiveName,omitempty"`
+
 	// Description AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-archive.html#cfn-events-archive-description

--- a/cloudformation/glue/aws-glue-database_databaseinput.go
+++ b/cloudformation/glue/aws-glue-database_databaseinput.go
@@ -8,11 +8,6 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-database-databaseinput.html
 type Database_DatabaseInput struct {
 
-	// CreateTableDefaultPermissions AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-database-databaseinput.html#cfn-glue-database-databaseinput-createtabledefaultpermissions
-	CreateTableDefaultPermissions []Database_PrincipalPrivileges `json:"CreateTableDefaultPermissions,omitempty"`
-
 	// Description AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-database-databaseinput.html#cfn-glue-database-databaseinput-description

--- a/cloudformation/glue/aws-glue-partition_schemaid.go
+++ b/cloudformation/glue/aws-glue-partition_schemaid.go
@@ -1,0 +1,45 @@
+package glue
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Partition_SchemaId AWS CloudFormation Resource (AWS::Glue::Partition.SchemaId)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemaid.html
+type Partition_SchemaId struct {
+
+	// RegistryName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemaid.html#cfn-glue-partition-schemaid-registryname
+	RegistryName string `json:"RegistryName,omitempty"`
+
+	// SchemaArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemaid.html#cfn-glue-partition-schemaid-schemaarn
+	SchemaArn string `json:"SchemaArn,omitempty"`
+
+	// SchemaName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemaid.html#cfn-glue-partition-schemaid-schemaname
+	SchemaName string `json:"SchemaName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Partition_SchemaId) AWSCloudFormationType() string {
+	return "AWS::Glue::Partition.SchemaId"
+}

--- a/cloudformation/glue/aws-glue-partition_schemareference.go
+++ b/cloudformation/glue/aws-glue-partition_schemareference.go
@@ -1,0 +1,45 @@
+package glue
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Partition_SchemaReference AWS CloudFormation Resource (AWS::Glue::Partition.SchemaReference)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemareference.html
+type Partition_SchemaReference struct {
+
+	// SchameVersionId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemareference.html#cfn-glue-partition-schemareference-schameversionid
+	SchameVersionId string `json:"SchameVersionId,omitempty"`
+
+	// SchemaId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemareference.html#cfn-glue-partition-schemareference-schemaid
+	SchemaId *Partition_SchemaId `json:"SchemaId,omitempty"`
+
+	// SchemaVersionNumber AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-schemareference.html#cfn-glue-partition-schemareference-schemaversionnumber
+	SchemaVersionNumber int `json:"SchemaVersionNumber,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Partition_SchemaReference) AWSCloudFormationType() string {
+	return "AWS::Glue::Partition.SchemaReference"
+}

--- a/cloudformation/glue/aws-glue-partition_storagedescriptor.go
+++ b/cloudformation/glue/aws-glue-partition_storagedescriptor.go
@@ -48,6 +48,11 @@ type Partition_StorageDescriptor struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-storagedescriptor.html#cfn-glue-partition-storagedescriptor-parameters
 	Parameters interface{} `json:"Parameters,omitempty"`
 
+	// SchemaReference AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-storagedescriptor.html#cfn-glue-partition-storagedescriptor-schemareference
+	SchemaReference *Partition_SchemaReference `json:"SchemaReference,omitempty"`
+
 	// SerdeInfo AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-partition-storagedescriptor.html#cfn-glue-partition-storagedescriptor-serdeinfo

--- a/cloudformation/glue/aws-glue-table_schemaid.go
+++ b/cloudformation/glue/aws-glue-table_schemaid.go
@@ -1,0 +1,45 @@
+package glue
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Table_SchemaId AWS CloudFormation Resource (AWS::Glue::Table.SchemaId)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemaid.html
+type Table_SchemaId struct {
+
+	// RegistryName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemaid.html#cfn-glue-table-schemaid-registryname
+	RegistryName string `json:"RegistryName,omitempty"`
+
+	// SchemaArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemaid.html#cfn-glue-table-schemaid-schemaarn
+	SchemaArn string `json:"SchemaArn,omitempty"`
+
+	// SchemaName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemaid.html#cfn-glue-table-schemaid-schemaname
+	SchemaName string `json:"SchemaName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Table_SchemaId) AWSCloudFormationType() string {
+	return "AWS::Glue::Table.SchemaId"
+}

--- a/cloudformation/glue/aws-glue-table_schemareference.go
+++ b/cloudformation/glue/aws-glue-table_schemareference.go
@@ -1,0 +1,45 @@
+package glue
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Table_SchemaReference AWS CloudFormation Resource (AWS::Glue::Table.SchemaReference)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemareference.html
+type Table_SchemaReference struct {
+
+	// SchameVersionId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemareference.html#cfn-glue-table-schemareference-schameversionid
+	SchameVersionId string `json:"SchameVersionId,omitempty"`
+
+	// SchemaId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemareference.html#cfn-glue-table-schemareference-schemaid
+	SchemaId *Table_SchemaId `json:"SchemaId,omitempty"`
+
+	// SchemaVersionNumber AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-schemareference.html#cfn-glue-table-schemareference-schemaversionnumber
+	SchemaVersionNumber int `json:"SchemaVersionNumber,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Table_SchemaReference) AWSCloudFormationType() string {
+	return "AWS::Glue::Table.SchemaReference"
+}

--- a/cloudformation/glue/aws-glue-table_storagedescriptor.go
+++ b/cloudformation/glue/aws-glue-table_storagedescriptor.go
@@ -48,6 +48,11 @@ type Table_StorageDescriptor struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-parameters
 	Parameters interface{} `json:"Parameters,omitempty"`
 
+	// SchemaReference AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-schemareference
+	SchemaReference *Table_SchemaReference `json:"SchemaReference,omitempty"`
+
 	// SerdeInfo AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-serdeinfo

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion.go
@@ -1,0 +1,116 @@
+package greengrassv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrassv2-componentversion.html
+type ComponentVersion struct {
+
+	// InlineRecipe AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrassv2-componentversion.html#cfn-greengrassv2-componentversion-inlinerecipe
+	InlineRecipe string `json:"InlineRecipe,omitempty"`
+
+	// LambdaFunction AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrassv2-componentversion.html#cfn-greengrassv2-componentversion-lambdafunction
+	LambdaFunction *ComponentVersion_LambdaFunctionRecipeSource `json:"LambdaFunction,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-greengrassv2-componentversion.html#cfn-greengrassv2-componentversion-tags
+	Tags map[string]string `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ComponentVersion) MarshalJSON() ([]byte, error) {
+	type Properties ComponentVersion
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ComponentVersion) UnmarshalJSON(b []byte) error {
+	type Properties ComponentVersion
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ComponentVersion(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_componentdependencyrequirement.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_componentdependencyrequirement.go
@@ -1,0 +1,40 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_ComponentDependencyRequirement AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-componentdependencyrequirement.html
+type ComponentVersion_ComponentDependencyRequirement struct {
+
+	// DependencyType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-componentdependencyrequirement.html#cfn-greengrassv2-componentversion-componentdependencyrequirement-dependencytype
+	DependencyType string `json:"DependencyType,omitempty"`
+
+	// VersionRequirement AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-componentdependencyrequirement.html#cfn-greengrassv2-componentversion-componentdependencyrequirement-versionrequirement
+	VersionRequirement string `json:"VersionRequirement,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_ComponentDependencyRequirement) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_componentplatform.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_componentplatform.go
@@ -1,0 +1,40 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_ComponentPlatform AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.ComponentPlatform)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-componentplatform.html
+type ComponentVersion_ComponentPlatform struct {
+
+	// Attributes AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-componentplatform.html#cfn-greengrassv2-componentversion-componentplatform-attributes
+	Attributes map[string]string `json:"Attributes,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-componentplatform.html#cfn-greengrassv2-componentversion-componentplatform-name
+	Name string `json:"Name,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_ComponentPlatform) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.ComponentPlatform"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdacontainerparams.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdacontainerparams.go
@@ -1,0 +1,50 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaContainerParams AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaContainerParams)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdacontainerparams.html
+type ComponentVersion_LambdaContainerParams struct {
+
+	// Devices AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdacontainerparams.html#cfn-greengrassv2-componentversion-lambdacontainerparams-devices
+	Devices []ComponentVersion_LambdaDeviceMount `json:"Devices,omitempty"`
+
+	// MemorySizeInKB AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdacontainerparams.html#cfn-greengrassv2-componentversion-lambdacontainerparams-memorysizeinkb
+	MemorySizeInKB int `json:"MemorySizeInKB,omitempty"`
+
+	// MountROSysfs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdacontainerparams.html#cfn-greengrassv2-componentversion-lambdacontainerparams-mountrosysfs
+	MountROSysfs bool `json:"MountROSysfs,omitempty"`
+
+	// Volumes AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdacontainerparams.html#cfn-greengrassv2-componentversion-lambdacontainerparams-volumes
+	Volumes []ComponentVersion_LambdaVolumeMount `json:"Volumes,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaContainerParams) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaContainerParams"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdadevicemount.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdadevicemount.go
@@ -1,0 +1,45 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaDeviceMount AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdadevicemount.html
+type ComponentVersion_LambdaDeviceMount struct {
+
+	// AddGroupOwner AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdadevicemount.html#cfn-greengrassv2-componentversion-lambdadevicemount-addgroupowner
+	AddGroupOwner bool `json:"AddGroupOwner,omitempty"`
+
+	// Path AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdadevicemount.html#cfn-greengrassv2-componentversion-lambdadevicemount-path
+	Path string `json:"Path,omitempty"`
+
+	// Permission AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdadevicemount.html#cfn-greengrassv2-componentversion-lambdadevicemount-permission
+	Permission string `json:"Permission,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaDeviceMount) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdaeventsource.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdaeventsource.go
@@ -1,0 +1,40 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaEventSource AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaEventSource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaeventsource.html
+type ComponentVersion_LambdaEventSource struct {
+
+	// Topic AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaeventsource.html#cfn-greengrassv2-componentversion-lambdaeventsource-topic
+	Topic string `json:"Topic,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaeventsource.html#cfn-greengrassv2-componentversion-lambdaeventsource-type
+	Type string `json:"Type,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaEventSource) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaEventSource"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdaexecutionparameters.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdaexecutionparameters.go
@@ -1,0 +1,85 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaExecutionParameters AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html
+type ComponentVersion_LambdaExecutionParameters struct {
+
+	// EnvironmentVariables AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-environmentvariables
+	EnvironmentVariables map[string]string `json:"EnvironmentVariables,omitempty"`
+
+	// EventSources AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-eventsources
+	EventSources []ComponentVersion_LambdaEventSource `json:"EventSources,omitempty"`
+
+	// ExecArgs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-execargs
+	ExecArgs []string `json:"ExecArgs,omitempty"`
+
+	// InputPayloadEncodingType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-inputpayloadencodingtype
+	InputPayloadEncodingType string `json:"InputPayloadEncodingType,omitempty"`
+
+	// LinuxProcessParams AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-linuxprocessparams
+	LinuxProcessParams *ComponentVersion_LambdaLinuxProcessParams `json:"LinuxProcessParams,omitempty"`
+
+	// MaxIdleTimeInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-maxidletimeinseconds
+	MaxIdleTimeInSeconds int `json:"MaxIdleTimeInSeconds,omitempty"`
+
+	// MaxInstancesCount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-maxinstancescount
+	MaxInstancesCount int `json:"MaxInstancesCount,omitempty"`
+
+	// MaxQueueSize AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-maxqueuesize
+	MaxQueueSize int `json:"MaxQueueSize,omitempty"`
+
+	// Pinned AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-pinned
+	Pinned bool `json:"Pinned,omitempty"`
+
+	// StatusTimeoutInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-statustimeoutinseconds
+	StatusTimeoutInSeconds int `json:"StatusTimeoutInSeconds,omitempty"`
+
+	// TimeoutInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdaexecutionparameters.html#cfn-greengrassv2-componentversion-lambdaexecutionparameters-timeoutinseconds
+	TimeoutInSeconds int `json:"TimeoutInSeconds,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaExecutionParameters) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdafunctionrecipesource.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdafunctionrecipesource.go
@@ -1,0 +1,60 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaFunctionRecipeSource AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html
+type ComponentVersion_LambdaFunctionRecipeSource struct {
+
+	// ComponentDependencies AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html#cfn-greengrassv2-componentversion-lambdafunctionrecipesource-componentdependencies
+	ComponentDependencies map[string]ComponentVersion_ComponentDependencyRequirement `json:"ComponentDependencies,omitempty"`
+
+	// ComponentLambdaParameters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html#cfn-greengrassv2-componentversion-lambdafunctionrecipesource-componentlambdaparameters
+	ComponentLambdaParameters *ComponentVersion_LambdaExecutionParameters `json:"ComponentLambdaParameters,omitempty"`
+
+	// ComponentName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html#cfn-greengrassv2-componentversion-lambdafunctionrecipesource-componentname
+	ComponentName string `json:"ComponentName,omitempty"`
+
+	// ComponentPlatforms AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html#cfn-greengrassv2-componentversion-lambdafunctionrecipesource-componentplatforms
+	ComponentPlatforms []ComponentVersion_ComponentPlatform `json:"ComponentPlatforms,omitempty"`
+
+	// ComponentVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html#cfn-greengrassv2-componentversion-lambdafunctionrecipesource-componentversion
+	ComponentVersion string `json:"ComponentVersion,omitempty"`
+
+	// LambdaArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdafunctionrecipesource.html#cfn-greengrassv2-componentversion-lambdafunctionrecipesource-lambdaarn
+	LambdaArn string `json:"LambdaArn,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaFunctionRecipeSource) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdalinuxprocessparams.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdalinuxprocessparams.go
@@ -1,0 +1,40 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaLinuxProcessParams AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdalinuxprocessparams.html
+type ComponentVersion_LambdaLinuxProcessParams struct {
+
+	// ContainerParams AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdalinuxprocessparams.html#cfn-greengrassv2-componentversion-lambdalinuxprocessparams-containerparams
+	ContainerParams *ComponentVersion_LambdaContainerParams `json:"ContainerParams,omitempty"`
+
+	// IsolationMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdalinuxprocessparams.html#cfn-greengrassv2-componentversion-lambdalinuxprocessparams-isolationmode
+	IsolationMode string `json:"IsolationMode,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaLinuxProcessParams) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams"
+}

--- a/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdavolumemount.go
+++ b/cloudformation/greengrassv2/aws-greengrassv2-componentversion_lambdavolumemount.go
@@ -1,0 +1,50 @@
+package greengrassv2
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ComponentVersion_LambdaVolumeMount AWS CloudFormation Resource (AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdavolumemount.html
+type ComponentVersion_LambdaVolumeMount struct {
+
+	// AddGroupOwner AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdavolumemount.html#cfn-greengrassv2-componentversion-lambdavolumemount-addgroupowner
+	AddGroupOwner bool `json:"AddGroupOwner,omitempty"`
+
+	// DestinationPath AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdavolumemount.html#cfn-greengrassv2-componentversion-lambdavolumemount-destinationpath
+	DestinationPath string `json:"DestinationPath,omitempty"`
+
+	// Permission AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdavolumemount.html#cfn-greengrassv2-componentversion-lambdavolumemount-permission
+	Permission string `json:"Permission,omitempty"`
+
+	// SourcePath AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-greengrassv2-componentversion-lambdavolumemount.html#cfn-greengrassv2-componentversion-lambdavolumemount-sourcepath
+	SourcePath string `json:"SourcePath,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ComponentVersion_LambdaVolumeMount) AWSCloudFormationType() string {
+	return "AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount"
+}

--- a/cloudformation/iot/aws-iot-topicruledestination.go
+++ b/cloudformation/iot/aws-iot-topicruledestination.go
@@ -22,6 +22,11 @@ type TopicRuleDestination struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-topicruledestination.html#cfn-iot-topicruledestination-status
 	Status string `json:"Status,omitempty"`
 
+	// VpcProperties AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-topicruledestination.html#cfn-iot-topicruledestination-vpcproperties
+	VpcProperties *TopicRuleDestination_VpcDestinationProperties `json:"VpcProperties,omitempty"`
+
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 

--- a/cloudformation/iot/aws-iot-topicruledestination_vpcdestinationproperties.go
+++ b/cloudformation/iot/aws-iot-topicruledestination_vpcdestinationproperties.go
@@ -1,0 +1,50 @@
+package iot
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// TopicRuleDestination_VpcDestinationProperties AWS CloudFormation Resource (AWS::IoT::TopicRuleDestination.VpcDestinationProperties)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-topicruledestination-vpcdestinationproperties.html
+type TopicRuleDestination_VpcDestinationProperties struct {
+
+	// RoleArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-topicruledestination-vpcdestinationproperties.html#cfn-iot-topicruledestination-vpcdestinationproperties-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// SecurityGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-topicruledestination-vpcdestinationproperties.html#cfn-iot-topicruledestination-vpcdestinationproperties-securitygroups
+	SecurityGroups []string `json:"SecurityGroups,omitempty"`
+
+	// SubnetIds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-topicruledestination-vpcdestinationproperties.html#cfn-iot-topicruledestination-vpcdestinationproperties-subnetids
+	SubnetIds []string `json:"SubnetIds,omitempty"`
+
+	// VpcId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-topicruledestination-vpcdestinationproperties.html#cfn-iot-topicruledestination-vpcdestinationproperties-vpcid
+	VpcId string `json:"VpcId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *TopicRuleDestination_VpcDestinationProperties) AWSCloudFormationType() string {
+	return "AWS::IoT::TopicRuleDestination.VpcDestinationProperties"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy.go
@@ -1,0 +1,116 @@
+package iotsitewise
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPolicy AWS CloudFormation Resource (AWS::IoTSiteWise::AccessPolicy)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-accesspolicy.html
+type AccessPolicy struct {
+
+	// AccessPolicyIdentity AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-accesspolicy.html#cfn-iotsitewise-accesspolicy-accesspolicyidentity
+	AccessPolicyIdentity *AccessPolicy_AccessPolicyIdentity `json:"AccessPolicyIdentity,omitempty"`
+
+	// AccessPolicyPermission AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-accesspolicy.html#cfn-iotsitewise-accesspolicy-accesspolicypermission
+	AccessPolicyPermission string `json:"AccessPolicyPermission,omitempty"`
+
+	// AccessPolicyResource AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-accesspolicy.html#cfn-iotsitewise-accesspolicy-accesspolicyresource
+	AccessPolicyResource *AccessPolicy_AccessPolicyResource `json:"AccessPolicyResource,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPolicy) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::AccessPolicy"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r AccessPolicy) MarshalJSON() ([]byte, error) {
+	type Properties AccessPolicy
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *AccessPolicy) UnmarshalJSON(b []byte) error {
+	type Properties AccessPolicy
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = AccessPolicy(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_accesspolicyidentity.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_accesspolicyidentity.go
@@ -1,0 +1,35 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPolicy_AccessPolicyIdentity AWS CloudFormation Resource (AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-accesspolicyidentity.html
+type AccessPolicy_AccessPolicyIdentity struct {
+
+	// User AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-accesspolicyidentity.html#cfn-iotsitewise-accesspolicy-accesspolicyidentity-user
+	User *AccessPolicy_User `json:"User,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPolicy_AccessPolicyIdentity) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_accesspolicyresource.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_accesspolicyresource.go
@@ -1,0 +1,40 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPolicy_AccessPolicyResource AWS CloudFormation Resource (AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-accesspolicyresource.html
+type AccessPolicy_AccessPolicyResource struct {
+
+	// Portal AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-accesspolicyresource.html#cfn-iotsitewise-accesspolicy-accesspolicyresource-portal
+	Portal *AccessPolicy_Portal `json:"Portal,omitempty"`
+
+	// Project AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-accesspolicyresource.html#cfn-iotsitewise-accesspolicy-accesspolicyresource-project
+	Project *AccessPolicy_Project `json:"Project,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPolicy_AccessPolicyResource) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_portal.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_portal.go
@@ -1,0 +1,35 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPolicy_Portal AWS CloudFormation Resource (AWS::IoTSiteWise::AccessPolicy.Portal)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-portal.html
+type AccessPolicy_Portal struct {
+
+	// id AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-portal.html#cfn-iotsitewise-accesspolicy-portal-id
+	id string `json:"id,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPolicy_Portal) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::AccessPolicy.Portal"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_project.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_project.go
@@ -1,0 +1,35 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPolicy_Project AWS CloudFormation Resource (AWS::IoTSiteWise::AccessPolicy.Project)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-project.html
+type AccessPolicy_Project struct {
+
+	// id AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-project.html#cfn-iotsitewise-accesspolicy-project-id
+	id string `json:"id,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPolicy_Project) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::AccessPolicy.Project"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_user.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-accesspolicy_user.go
@@ -1,0 +1,35 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// AccessPolicy_User AWS CloudFormation Resource (AWS::IoTSiteWise::AccessPolicy.User)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-user.html
+type AccessPolicy_User struct {
+
+	// id AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-accesspolicy-user.html#cfn-iotsitewise-accesspolicy-user-id
+	id string `json:"id,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *AccessPolicy_User) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::AccessPolicy.User"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-dashboard.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-dashboard.go
@@ -1,0 +1,127 @@
+package iotsitewise
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Dashboard AWS CloudFormation Resource (AWS::IoTSiteWise::Dashboard)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-dashboard.html
+type Dashboard struct {
+
+	// DashboardDefinition AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-dashboard.html#cfn-iotsitewise-dashboard-dashboarddefinition
+	DashboardDefinition string `json:"DashboardDefinition,omitempty"`
+
+	// DashboardDescription AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-dashboard.html#cfn-iotsitewise-dashboard-dashboarddescription
+	DashboardDescription string `json:"DashboardDescription,omitempty"`
+
+	// DashboardName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-dashboard.html#cfn-iotsitewise-dashboard-dashboardname
+	DashboardName string `json:"DashboardName,omitempty"`
+
+	// ProjectId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-dashboard.html#cfn-iotsitewise-dashboard-projectid
+	ProjectId string `json:"ProjectId,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-dashboard.html#cfn-iotsitewise-dashboard-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Dashboard) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::Dashboard"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Dashboard) MarshalJSON() ([]byte, error) {
+	type Properties Dashboard
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Dashboard) UnmarshalJSON(b []byte) error {
+	type Properties Dashboard
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Dashboard(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-portal.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-portal.go
@@ -1,0 +1,127 @@
+package iotsitewise
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Portal AWS CloudFormation Resource (AWS::IoTSiteWise::Portal)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-portal.html
+type Portal struct {
+
+	// PortalContactEmail AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-portal.html#cfn-iotsitewise-portal-portalcontactemail
+	PortalContactEmail string `json:"PortalContactEmail,omitempty"`
+
+	// PortalDescription AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-portal.html#cfn-iotsitewise-portal-portaldescription
+	PortalDescription string `json:"PortalDescription,omitempty"`
+
+	// PortalName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-portal.html#cfn-iotsitewise-portal-portalname
+	PortalName string `json:"PortalName,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-portal.html#cfn-iotsitewise-portal-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-portal.html#cfn-iotsitewise-portal-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Portal) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::Portal"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Portal) MarshalJSON() ([]byte, error) {
+	type Properties Portal
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Portal) UnmarshalJSON(b []byte) error {
+	type Properties Portal
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Portal(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-portal_monitorerrordetails.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-portal_monitorerrordetails.go
@@ -1,0 +1,40 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Portal_MonitorErrorDetails AWS CloudFormation Resource (AWS::IoTSiteWise::Portal.MonitorErrorDetails)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-portal-monitorerrordetails.html
+type Portal_MonitorErrorDetails struct {
+
+	// code AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-portal-monitorerrordetails.html#cfn-iotsitewise-portal-monitorerrordetails-code
+	code string `json:"code,omitempty"`
+
+	// message AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-portal-monitorerrordetails.html#cfn-iotsitewise-portal-monitorerrordetails-message
+	message string `json:"message,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Portal_MonitorErrorDetails) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::Portal.MonitorErrorDetails"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-portal_portalstatus.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-portal_portalstatus.go
@@ -1,0 +1,40 @@
+package iotsitewise
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Portal_PortalStatus AWS CloudFormation Resource (AWS::IoTSiteWise::Portal.PortalStatus)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-portal-portalstatus.html
+type Portal_PortalStatus struct {
+
+	// error AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-portal-portalstatus.html#cfn-iotsitewise-portal-portalstatus-error
+	error *Portal_MonitorErrorDetails `json:"error,omitempty"`
+
+	// state AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotsitewise-portal-portalstatus.html#cfn-iotsitewise-portal-portalstatus-state
+	state string `json:"state,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Portal_PortalStatus) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::Portal.PortalStatus"
+}

--- a/cloudformation/iotsitewise/aws-iotsitewise-project.go
+++ b/cloudformation/iotsitewise/aws-iotsitewise-project.go
@@ -1,0 +1,122 @@
+package iotsitewise
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Project AWS CloudFormation Resource (AWS::IoTSiteWise::Project)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-project.html
+type Project struct {
+
+	// PortalId AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-project.html#cfn-iotsitewise-project-portalid
+	PortalId string `json:"PortalId,omitempty"`
+
+	// ProjectDescription AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-project.html#cfn-iotsitewise-project-projectdescription
+	ProjectDescription string `json:"ProjectDescription,omitempty"`
+
+	// ProjectName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-project.html#cfn-iotsitewise-project-projectname
+	ProjectName string `json:"ProjectName,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotsitewise-project.html#cfn-iotsitewise-project-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Project) AWSCloudFormationType() string {
+	return "AWS::IoTSiteWise::Project"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Project) MarshalJSON() ([]byte, error) {
+	type Properties Project
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Project) UnmarshalJSON(b []byte) error {
+	type Properties Project
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Project(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotwireless/aws-iotwireless-destination.go
+++ b/cloudformation/iotwireless/aws-iotwireless-destination.go
@@ -1,0 +1,137 @@
+package iotwireless
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Destination AWS CloudFormation Resource (AWS::IoTWireless::Destination)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html
+type Destination struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-description
+	Description string `json:"Description,omitempty"`
+
+	// Expression AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-expression
+	Expression string `json:"Expression,omitempty"`
+
+	// ExpressionType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-expressiontype
+	ExpressionType string `json:"ExpressionType,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-name
+	Name string `json:"Name,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-destination.html#cfn-iotwireless-destination-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Destination) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::Destination"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Destination) MarshalJSON() ([]byte, error) {
+	type Properties Destination
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Destination) UnmarshalJSON(b []byte) error {
+	type Properties Destination
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Destination(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotwireless/aws-iotwireless-deviceprofile.go
+++ b/cloudformation/iotwireless/aws-iotwireless-deviceprofile.go
@@ -1,0 +1,122 @@
+package iotwireless
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// DeviceProfile AWS CloudFormation Resource (AWS::IoTWireless::DeviceProfile)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-deviceprofile.html
+type DeviceProfile struct {
+
+	// LoRaWANDeviceProfile AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-deviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile
+	LoRaWANDeviceProfile *DeviceProfile_LoRaWANDeviceProfile `json:"LoRaWANDeviceProfile,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-deviceprofile.html#cfn-iotwireless-deviceprofile-name
+	Name string `json:"Name,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-deviceprofile.html#cfn-iotwireless-deviceprofile-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-deviceprofile.html#cfn-iotwireless-deviceprofile-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DeviceProfile) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::DeviceProfile"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r DeviceProfile) MarshalJSON() ([]byte, error) {
+	type Properties DeviceProfile
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *DeviceProfile) UnmarshalJSON(b []byte) error {
+	type Properties DeviceProfile
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = DeviceProfile(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotwireless/aws-iotwireless-deviceprofile_lorawandeviceprofile.go
+++ b/cloudformation/iotwireless/aws-iotwireless-deviceprofile_lorawandeviceprofile.go
@@ -1,0 +1,100 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DeviceProfile_LoRaWANDeviceProfile AWS CloudFormation Resource (AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html
+type DeviceProfile_LoRaWANDeviceProfile struct {
+
+	// ClassBTimeout AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-classbtimeout
+	ClassBTimeout int `json:"ClassBTimeout,omitempty"`
+
+	// ClassCTimeout AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-classctimeout
+	ClassCTimeout int `json:"ClassCTimeout,omitempty"`
+
+	// MacVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-macversion
+	MacVersion string `json:"MacVersion,omitempty"`
+
+	// MaxDutyCycle AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-maxdutycycle
+	MaxDutyCycle int `json:"MaxDutyCycle,omitempty"`
+
+	// MaxEirp AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-maxeirp
+	MaxEirp int `json:"MaxEirp,omitempty"`
+
+	// PingSlotDr AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-pingslotdr
+	PingSlotDr int `json:"PingSlotDr,omitempty"`
+
+	// PingSlotFreq AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-pingslotfreq
+	PingSlotFreq int `json:"PingSlotFreq,omitempty"`
+
+	// PingSlotPeriod AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-pingslotperiod
+	PingSlotPeriod int `json:"PingSlotPeriod,omitempty"`
+
+	// RegParamsRevision AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-regparamsrevision
+	RegParamsRevision string `json:"RegParamsRevision,omitempty"`
+
+	// RfRegion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-rfregion
+	RfRegion string `json:"RfRegion,omitempty"`
+
+	// Supports32BitFCnt AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-supports32bitfcnt
+	Supports32BitFCnt bool `json:"Supports32BitFCnt,omitempty"`
+
+	// SupportsClassB AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-supportsclassb
+	SupportsClassB bool `json:"SupportsClassB,omitempty"`
+
+	// SupportsClassC AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-supportsclassc
+	SupportsClassC bool `json:"SupportsClassC,omitempty"`
+
+	// SupportsJoin AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-deviceprofile-lorawandeviceprofile.html#cfn-iotwireless-deviceprofile-lorawandeviceprofile-supportsjoin
+	SupportsJoin bool `json:"SupportsJoin,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DeviceProfile_LoRaWANDeviceProfile) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-serviceprofile.go
+++ b/cloudformation/iotwireless/aws-iotwireless-serviceprofile.go
@@ -1,0 +1,127 @@
+package iotwireless
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// ServiceProfile AWS CloudFormation Resource (AWS::IoTWireless::ServiceProfile)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-serviceprofile.html
+type ServiceProfile struct {
+
+	// LoRaWANGetServiceProfileInfo AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-serviceprofile.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo
+	LoRaWANGetServiceProfileInfo *ServiceProfile_LoRaWANGetServiceProfileInfo `json:"LoRaWANGetServiceProfileInfo,omitempty"`
+
+	// LoRaWANServiceProfile AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-serviceprofile.html#cfn-iotwireless-serviceprofile-lorawanserviceprofile
+	LoRaWANServiceProfile *ServiceProfile_LoRaWANServiceProfile `json:"LoRaWANServiceProfile,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-serviceprofile.html#cfn-iotwireless-serviceprofile-name
+	Name string `json:"Name,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-serviceprofile.html#cfn-iotwireless-serviceprofile-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-serviceprofile.html#cfn-iotwireless-serviceprofile-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ServiceProfile) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::ServiceProfile"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ServiceProfile) MarshalJSON() ([]byte, error) {
+	type Properties ServiceProfile
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ServiceProfile) UnmarshalJSON(b []byte) error {
+	type Properties ServiceProfile
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ServiceProfile(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotwireless/aws-iotwireless-serviceprofile_lorawangetserviceprofileinfo.go
+++ b/cloudformation/iotwireless/aws-iotwireless-serviceprofile_lorawangetserviceprofileinfo.go
@@ -1,0 +1,125 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ServiceProfile_LoRaWANGetServiceProfileInfo AWS CloudFormation Resource (AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html
+type ServiceProfile_LoRaWANGetServiceProfileInfo struct {
+
+	// AddGwMetadata AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-addgwmetadata
+	AddGwMetadata bool `json:"AddGwMetadata,omitempty"`
+
+	// ChannelMask AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-channelmask
+	ChannelMask string `json:"ChannelMask,omitempty"`
+
+	// DevStatusReqFreq AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-devstatusreqfreq
+	DevStatusReqFreq int `json:"DevStatusReqFreq,omitempty"`
+
+	// DlBucketSize AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-dlbucketsize
+	DlBucketSize int `json:"DlBucketSize,omitempty"`
+
+	// DlRate AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-dlrate
+	DlRate int `json:"DlRate,omitempty"`
+
+	// DlRatePolicy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-dlratepolicy
+	DlRatePolicy string `json:"DlRatePolicy,omitempty"`
+
+	// DrMax AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-drmax
+	DrMax int `json:"DrMax,omitempty"`
+
+	// DrMin AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-drmin
+	DrMin int `json:"DrMin,omitempty"`
+
+	// HrAllowed AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-hrallowed
+	HrAllowed bool `json:"HrAllowed,omitempty"`
+
+	// MinGwDiversity AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-mingwdiversity
+	MinGwDiversity int `json:"MinGwDiversity,omitempty"`
+
+	// NwkGeoLoc AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-nwkgeoloc
+	NwkGeoLoc bool `json:"NwkGeoLoc,omitempty"`
+
+	// PrAllowed AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-prallowed
+	PrAllowed bool `json:"PrAllowed,omitempty"`
+
+	// RaAllowed AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-raallowed
+	RaAllowed bool `json:"RaAllowed,omitempty"`
+
+	// ReportDevStatusBattery AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-reportdevstatusbattery
+	ReportDevStatusBattery bool `json:"ReportDevStatusBattery,omitempty"`
+
+	// ReportDevStatusMargin AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-reportdevstatusmargin
+	ReportDevStatusMargin bool `json:"ReportDevStatusMargin,omitempty"`
+
+	// TargetPer AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-targetper
+	TargetPer int `json:"TargetPer,omitempty"`
+
+	// UlBucketSize AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-ulbucketsize
+	UlBucketSize int `json:"UlBucketSize,omitempty"`
+
+	// UlRate AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-ulrate
+	UlRate int `json:"UlRate,omitempty"`
+
+	// UlRatePolicy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawangetserviceprofileinfo.html#cfn-iotwireless-serviceprofile-lorawangetserviceprofileinfo-ulratepolicy
+	UlRatePolicy string `json:"UlRatePolicy,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ServiceProfile_LoRaWANGetServiceProfileInfo) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-serviceprofile_lorawanserviceprofile.go
+++ b/cloudformation/iotwireless/aws-iotwireless-serviceprofile_lorawanserviceprofile.go
@@ -1,0 +1,35 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ServiceProfile_LoRaWANServiceProfile AWS CloudFormation Resource (AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawanserviceprofile.html
+type ServiceProfile_LoRaWANServiceProfile struct {
+
+	// AddGwMetadata AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-serviceprofile-lorawanserviceprofile.html#cfn-iotwireless-serviceprofile-lorawanserviceprofile-addgwmetadata
+	AddGwMetadata bool `json:"AddGwMetadata,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ServiceProfile_LoRaWANServiceProfile) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice.go
@@ -1,0 +1,137 @@
+package iotwireless
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// WirelessDevice AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html
+type WirelessDevice struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-description
+	Description string `json:"Description,omitempty"`
+
+	// DestinationName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-destinationname
+	DestinationName string `json:"DestinationName,omitempty"`
+
+	// LoRaWANDevice AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-lorawandevice
+	LoRaWANDevice *WirelessDevice_LoRaWANDevice `json:"LoRaWANDevice,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-name
+	Name string `json:"Name,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessdevice.html#cfn-iotwireless-wirelessdevice-type
+	Type string `json:"Type,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r WirelessDevice) MarshalJSON() ([]byte, error) {
+	type Properties WirelessDevice
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *WirelessDevice) UnmarshalJSON(b []byte) error {
+	type Properties WirelessDevice
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = WirelessDevice(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_abpv10x.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_abpv10x.go
@@ -1,0 +1,40 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_AbpV10X AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.AbpV10X)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-abpv10x.html
+type WirelessDevice_AbpV10X struct {
+
+	// DevAddr AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-abpv10x.html#cfn-iotwireless-wirelessdevice-abpv10x-devaddr
+	DevAddr string `json:"DevAddr,omitempty"`
+
+	// SessionKeys AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-abpv10x.html#cfn-iotwireless-wirelessdevice-abpv10x-sessionkeys
+	SessionKeys *WirelessDevice_SessionKeysAbpV10X `json:"SessionKeys,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_AbpV10X) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.AbpV10X"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_abpv11.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_abpv11.go
@@ -1,0 +1,40 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_AbpV11 AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.AbpV11)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-abpv11.html
+type WirelessDevice_AbpV11 struct {
+
+	// DevAddr AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-abpv11.html#cfn-iotwireless-wirelessdevice-abpv11-devaddr
+	DevAddr string `json:"DevAddr,omitempty"`
+
+	// SessionKeys AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-abpv11.html#cfn-iotwireless-wirelessdevice-abpv11-sessionkeys
+	SessionKeys *WirelessDevice_SessionKeysAbpV11 `json:"SessionKeys,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_AbpV11) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.AbpV11"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_lorawandevice.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_lorawandevice.go
@@ -1,0 +1,65 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_LoRaWANDevice AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.LoRaWANDevice)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html
+type WirelessDevice_LoRaWANDevice struct {
+
+	// AbpV10X AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-abpv10x
+	AbpV10X *WirelessDevice_AbpV10X `json:"AbpV10X,omitempty"`
+
+	// AbpV11 AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-abpv11
+	AbpV11 *WirelessDevice_AbpV11 `json:"AbpV11,omitempty"`
+
+	// DevEui AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-deveui
+	DevEui string `json:"DevEui,omitempty"`
+
+	// DeviceProfileId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-deviceprofileid
+	DeviceProfileId string `json:"DeviceProfileId,omitempty"`
+
+	// OtaaV10X AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-otaav10x
+	OtaaV10X *WirelessDevice_OtaaV10X `json:"OtaaV10X,omitempty"`
+
+	// OtaaV11 AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-otaav11
+	OtaaV11 *WirelessDevice_OtaaV11 `json:"OtaaV11,omitempty"`
+
+	// ServiceProfileId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-lorawandevice.html#cfn-iotwireless-wirelessdevice-lorawandevice-serviceprofileid
+	ServiceProfileId string `json:"ServiceProfileId,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_LoRaWANDevice) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.LoRaWANDevice"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_otaav10x.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_otaav10x.go
@@ -1,0 +1,40 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_OtaaV10X AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.OtaaV10X)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav10x.html
+type WirelessDevice_OtaaV10X struct {
+
+	// AppEui AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav10x.html#cfn-iotwireless-wirelessdevice-otaav10x-appeui
+	AppEui string `json:"AppEui,omitempty"`
+
+	// AppKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav10x.html#cfn-iotwireless-wirelessdevice-otaav10x-appkey
+	AppKey string `json:"AppKey,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_OtaaV10X) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.OtaaV10X"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_otaav11.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_otaav11.go
@@ -1,0 +1,45 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_OtaaV11 AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.OtaaV11)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav11.html
+type WirelessDevice_OtaaV11 struct {
+
+	// AppKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav11.html#cfn-iotwireless-wirelessdevice-otaav11-appkey
+	AppKey string `json:"AppKey,omitempty"`
+
+	// JoinEui AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav11.html#cfn-iotwireless-wirelessdevice-otaav11-joineui
+	JoinEui string `json:"JoinEui,omitempty"`
+
+	// NwkKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-otaav11.html#cfn-iotwireless-wirelessdevice-otaav11-nwkkey
+	NwkKey string `json:"NwkKey,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_OtaaV11) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.OtaaV11"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_sessionkeysabpv10x.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_sessionkeysabpv10x.go
@@ -1,0 +1,40 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_SessionKeysAbpV10X AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv10x.html
+type WirelessDevice_SessionKeysAbpV10X struct {
+
+	// AppSKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv10x.html#cfn-iotwireless-wirelessdevice-sessionkeysabpv10x-appskey
+	AppSKey string `json:"AppSKey,omitempty"`
+
+	// NwkSKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv10x.html#cfn-iotwireless-wirelessdevice-sessionkeysabpv10x-nwkskey
+	NwkSKey string `json:"NwkSKey,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_SessionKeysAbpV10X) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_sessionkeysabpv11.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessdevice_sessionkeysabpv11.go
@@ -1,0 +1,50 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessDevice_SessionKeysAbpV11 AWS CloudFormation Resource (AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv11.html
+type WirelessDevice_SessionKeysAbpV11 struct {
+
+	// AppSKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv11.html#cfn-iotwireless-wirelessdevice-sessionkeysabpv11-appskey
+	AppSKey string `json:"AppSKey,omitempty"`
+
+	// FNwkSIntKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv11.html#cfn-iotwireless-wirelessdevice-sessionkeysabpv11-fnwksintkey
+	FNwkSIntKey string `json:"FNwkSIntKey,omitempty"`
+
+	// NwkSEncKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv11.html#cfn-iotwireless-wirelessdevice-sessionkeysabpv11-nwksenckey
+	NwkSEncKey string `json:"NwkSEncKey,omitempty"`
+
+	// SNwkSIntKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessdevice-sessionkeysabpv11.html#cfn-iotwireless-wirelessdevice-sessionkeysabpv11-snwksintkey
+	SNwkSIntKey string `json:"SNwkSIntKey,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessDevice_SessionKeysAbpV11) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11"
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessgateway.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessgateway.go
@@ -1,0 +1,132 @@
+package iotwireless
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// WirelessGateway AWS CloudFormation Resource (AWS::IoTWireless::WirelessGateway)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html
+type WirelessGateway struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html#cfn-iotwireless-wirelessgateway-description
+	Description string `json:"Description,omitempty"`
+
+	// LoRaWANGateway AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html#cfn-iotwireless-wirelessgateway-lorawangateway
+	LoRaWANGateway *WirelessGateway_LoRaWANGateway `json:"LoRaWANGateway,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html#cfn-iotwireless-wirelessgateway-name
+	Name string `json:"Name,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html#cfn-iotwireless-wirelessgateway-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html#cfn-iotwireless-wirelessgateway-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// ThingName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iotwireless-wirelessgateway.html#cfn-iotwireless-wirelessgateway-thingname
+	ThingName string `json:"ThingName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessGateway) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessGateway"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r WirelessGateway) MarshalJSON() ([]byte, error) {
+	type Properties WirelessGateway
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *WirelessGateway) UnmarshalJSON(b []byte) error {
+	type Properties WirelessGateway
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = WirelessGateway(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/iotwireless/aws-iotwireless-wirelessgateway_lorawangateway.go
+++ b/cloudformation/iotwireless/aws-iotwireless-wirelessgateway_lorawangateway.go
@@ -1,0 +1,40 @@
+package iotwireless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// WirelessGateway_LoRaWANGateway AWS CloudFormation Resource (AWS::IoTWireless::WirelessGateway.LoRaWANGateway)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessgateway-lorawangateway.html
+type WirelessGateway_LoRaWANGateway struct {
+
+	// GatewayEui AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessgateway-lorawangateway.html#cfn-iotwireless-wirelessgateway-lorawangateway-gatewayeui
+	GatewayEui string `json:"GatewayEui,omitempty"`
+
+	// RfRegion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iotwireless-wirelessgateway-lorawangateway.html#cfn-iotwireless-wirelessgateway-lorawangateway-rfregion
+	RfRegion string `json:"RfRegion,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *WirelessGateway_LoRaWANGateway) AWSCloudFormationType() string {
+	return "AWS::IoTWireless::WirelessGateway.LoRaWANGateway"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceattachmentconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceattachmentconfiguration.go
@@ -1,0 +1,40 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceAttachmentConfiguration AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmentconfiguration.html
+type DataSource_ConfluenceAttachmentConfiguration struct {
+
+	// AttachmentFieldMappings AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmentconfiguration.html#cfn-kendra-datasource-confluenceattachmentconfiguration-attachmentfieldmappings
+	AttachmentFieldMappings *DataSource_ConfluenceAttachmentFieldMappingsList `json:"AttachmentFieldMappings,omitempty"`
+
+	// CrawlAttachments AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmentconfiguration.html#cfn-kendra-datasource-confluenceattachmentconfiguration-crawlattachments
+	CrawlAttachments bool `json:"CrawlAttachments,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceAttachmentConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceattachmentfieldmappingslist.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceattachmentfieldmappingslist.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceAttachmentFieldMappingsList AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmentfieldmappingslist.html
+type DataSource_ConfluenceAttachmentFieldMappingsList struct {
+
+	// ConfluenceAttachmentFieldMappingsList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmentfieldmappingslist.html#cfn-kendra-datasource-confluenceattachmentfieldmappingslist-confluenceattachmentfieldmappingslist
+	ConfluenceAttachmentFieldMappingsList []DataSource_ConfluenceAttachmentToIndexFieldMapping `json:"ConfluenceAttachmentFieldMappingsList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceAttachmentFieldMappingsList) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceattachmenttoindexfieldmapping.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceattachmenttoindexfieldmapping.go
@@ -1,0 +1,45 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceAttachmentToIndexFieldMapping AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmenttoindexfieldmapping.html
+type DataSource_ConfluenceAttachmentToIndexFieldMapping struct {
+
+	// DataSourceFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmenttoindexfieldmapping.html#cfn-kendra-datasource-confluenceattachmenttoindexfieldmapping-datasourcefieldname
+	DataSourceFieldName string `json:"DataSourceFieldName,omitempty"`
+
+	// DateFieldFormat AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmenttoindexfieldmapping.html#cfn-kendra-datasource-confluenceattachmenttoindexfieldmapping-datefieldformat
+	DateFieldFormat string `json:"DateFieldFormat,omitempty"`
+
+	// IndexFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceattachmenttoindexfieldmapping.html#cfn-kendra-datasource-confluenceattachmenttoindexfieldmapping-indexfieldname
+	IndexFieldName string `json:"IndexFieldName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceAttachmentToIndexFieldMapping) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceblogconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceblogconfiguration.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceBlogConfiguration AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceBlogConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogconfiguration.html
+type DataSource_ConfluenceBlogConfiguration struct {
+
+	// BlogFieldMappings AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogconfiguration.html#cfn-kendra-datasource-confluenceblogconfiguration-blogfieldmappings
+	BlogFieldMappings *DataSource_ConfluenceBlogFieldMappingsList `json:"BlogFieldMappings,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceBlogConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceBlogConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceblogfieldmappingslist.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceblogfieldmappingslist.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceBlogFieldMappingsList AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogfieldmappingslist.html
+type DataSource_ConfluenceBlogFieldMappingsList struct {
+
+	// ConfluenceBlogFieldMappingsList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogfieldmappingslist.html#cfn-kendra-datasource-confluenceblogfieldmappingslist-confluenceblogfieldmappingslist
+	ConfluenceBlogFieldMappingsList []DataSource_ConfluenceBlogToIndexFieldMapping `json:"ConfluenceBlogFieldMappingsList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceBlogFieldMappingsList) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceblogtoindexfieldmapping.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceblogtoindexfieldmapping.go
@@ -1,0 +1,45 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceBlogToIndexFieldMapping AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogtoindexfieldmapping.html
+type DataSource_ConfluenceBlogToIndexFieldMapping struct {
+
+	// DataSourceFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogtoindexfieldmapping.html#cfn-kendra-datasource-confluenceblogtoindexfieldmapping-datasourcefieldname
+	DataSourceFieldName string `json:"DataSourceFieldName,omitempty"`
+
+	// DateFieldFormat AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogtoindexfieldmapping.html#cfn-kendra-datasource-confluenceblogtoindexfieldmapping-datefieldformat
+	DateFieldFormat string `json:"DateFieldFormat,omitempty"`
+
+	// IndexFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceblogtoindexfieldmapping.html#cfn-kendra-datasource-confluenceblogtoindexfieldmapping-indexfieldname
+	IndexFieldName string `json:"IndexFieldName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceBlogToIndexFieldMapping) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluenceconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluenceconfiguration.go
@@ -1,0 +1,80 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceConfiguration AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html
+type DataSource_ConfluenceConfiguration struct {
+
+	// AttachmentConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-attachmentconfiguration
+	AttachmentConfiguration *DataSource_ConfluenceAttachmentConfiguration `json:"AttachmentConfiguration,omitempty"`
+
+	// BlogConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-blogconfiguration
+	BlogConfiguration *DataSource_ConfluenceBlogConfiguration `json:"BlogConfiguration,omitempty"`
+
+	// ExclusionPatterns AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-exclusionpatterns
+	ExclusionPatterns *DataSource_DataSourceInclusionsExclusionsStrings `json:"ExclusionPatterns,omitempty"`
+
+	// InclusionPatterns AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-inclusionpatterns
+	InclusionPatterns *DataSource_DataSourceInclusionsExclusionsStrings `json:"InclusionPatterns,omitempty"`
+
+	// PageConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-pageconfiguration
+	PageConfiguration *DataSource_ConfluencePageConfiguration `json:"PageConfiguration,omitempty"`
+
+	// SecretArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-secretarn
+	SecretArn string `json:"SecretArn,omitempty"`
+
+	// ServerUrl AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-serverurl
+	ServerUrl string `json:"ServerUrl,omitempty"`
+
+	// SpaceConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-spaceconfiguration
+	SpaceConfiguration *DataSource_ConfluenceSpaceConfiguration `json:"SpaceConfiguration,omitempty"`
+
+	// Version AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-version
+	Version string `json:"Version,omitempty"`
+
+	// VpcConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluenceconfiguration.html#cfn-kendra-datasource-confluenceconfiguration-vpcconfiguration
+	VpcConfiguration *DataSource_DataSourceVpcConfiguration `json:"VpcConfiguration,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencepageconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencepageconfiguration.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluencePageConfiguration AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluencePageConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepageconfiguration.html
+type DataSource_ConfluencePageConfiguration struct {
+
+	// PageFieldMappings AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepageconfiguration.html#cfn-kendra-datasource-confluencepageconfiguration-pagefieldmappings
+	PageFieldMappings *DataSource_ConfluencePageFieldMappingsList `json:"PageFieldMappings,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluencePageConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluencePageConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencepagefieldmappingslist.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencepagefieldmappingslist.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluencePageFieldMappingsList AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluencePageFieldMappingsList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepagefieldmappingslist.html
+type DataSource_ConfluencePageFieldMappingsList struct {
+
+	// ConfluencePageFieldMappingsList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepagefieldmappingslist.html#cfn-kendra-datasource-confluencepagefieldmappingslist-confluencepagefieldmappingslist
+	ConfluencePageFieldMappingsList []DataSource_ConfluencePageToIndexFieldMapping `json:"ConfluencePageFieldMappingsList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluencePageFieldMappingsList) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluencePageFieldMappingsList"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencepagetoindexfieldmapping.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencepagetoindexfieldmapping.go
@@ -1,0 +1,45 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluencePageToIndexFieldMapping AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepagetoindexfieldmapping.html
+type DataSource_ConfluencePageToIndexFieldMapping struct {
+
+	// DataSourceFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepagetoindexfieldmapping.html#cfn-kendra-datasource-confluencepagetoindexfieldmapping-datasourcefieldname
+	DataSourceFieldName string `json:"DataSourceFieldName,omitempty"`
+
+	// DateFieldFormat AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepagetoindexfieldmapping.html#cfn-kendra-datasource-confluencepagetoindexfieldmapping-datefieldformat
+	DateFieldFormat string `json:"DateFieldFormat,omitempty"`
+
+	// IndexFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencepagetoindexfieldmapping.html#cfn-kendra-datasource-confluencepagetoindexfieldmapping-indexfieldname
+	IndexFieldName string `json:"IndexFieldName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluencePageToIndexFieldMapping) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencespaceconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencespaceconfiguration.go
@@ -1,0 +1,55 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceSpaceConfiguration AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceSpaceConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespaceconfiguration.html
+type DataSource_ConfluenceSpaceConfiguration struct {
+
+	// CrawlArchivedSpaces AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespaceconfiguration.html#cfn-kendra-datasource-confluencespaceconfiguration-crawlarchivedspaces
+	CrawlArchivedSpaces bool `json:"CrawlArchivedSpaces,omitempty"`
+
+	// CrawlPersonalSpaces AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespaceconfiguration.html#cfn-kendra-datasource-confluencespaceconfiguration-crawlpersonalspaces
+	CrawlPersonalSpaces bool `json:"CrawlPersonalSpaces,omitempty"`
+
+	// ExcludeSpaces AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespaceconfiguration.html#cfn-kendra-datasource-confluencespaceconfiguration-excludespaces
+	ExcludeSpaces *DataSource_ConfluenceSpaceList `json:"ExcludeSpaces,omitempty"`
+
+	// IncludeSpaces AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespaceconfiguration.html#cfn-kendra-datasource-confluencespaceconfiguration-includespaces
+	IncludeSpaces *DataSource_ConfluenceSpaceList `json:"IncludeSpaces,omitempty"`
+
+	// SpaceFieldMappings AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespaceconfiguration.html#cfn-kendra-datasource-confluencespaceconfiguration-spacefieldmappings
+	SpaceFieldMappings *DataSource_ConfluenceSpaceFieldMappingsList `json:"SpaceFieldMappings,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceSpaceConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceSpaceConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencespacefieldmappingslist.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencespacefieldmappingslist.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceSpaceFieldMappingsList AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacefieldmappingslist.html
+type DataSource_ConfluenceSpaceFieldMappingsList struct {
+
+	// ConfluenceSpaceFieldMappingsList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacefieldmappingslist.html#cfn-kendra-datasource-confluencespacefieldmappingslist-confluencespacefieldmappingslist
+	ConfluenceSpaceFieldMappingsList []DataSource_ConfluenceSpaceToIndexFieldMapping `json:"ConfluenceSpaceFieldMappingsList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceSpaceFieldMappingsList) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencespacelist.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencespacelist.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceSpaceList AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceSpaceList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacelist.html
+type DataSource_ConfluenceSpaceList struct {
+
+	// ConfluenceSpaceList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacelist.html#cfn-kendra-datasource-confluencespacelist-confluencespacelist
+	ConfluenceSpaceList []string `json:"ConfluenceSpaceList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceSpaceList) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceSpaceList"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_confluencespacetoindexfieldmapping.go
+++ b/cloudformation/kendra/aws-kendra-datasource_confluencespacetoindexfieldmapping.go
@@ -1,0 +1,45 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataSource_ConfluenceSpaceToIndexFieldMapping AWS CloudFormation Resource (AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacetoindexfieldmapping.html
+type DataSource_ConfluenceSpaceToIndexFieldMapping struct {
+
+	// DataSourceFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacetoindexfieldmapping.html#cfn-kendra-datasource-confluencespacetoindexfieldmapping-datasourcefieldname
+	DataSourceFieldName string `json:"DataSourceFieldName,omitempty"`
+
+	// DateFieldFormat AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacetoindexfieldmapping.html#cfn-kendra-datasource-confluencespacetoindexfieldmapping-datefieldformat
+	DateFieldFormat string `json:"DateFieldFormat,omitempty"`
+
+	// IndexFieldName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-confluencespacetoindexfieldmapping.html#cfn-kendra-datasource-confluencespacetoindexfieldmapping-indexfieldname
+	IndexFieldName string `json:"IndexFieldName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataSource_ConfluenceSpaceToIndexFieldMapping) AWSCloudFormationType() string {
+	return "AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping"
+}

--- a/cloudformation/kendra/aws-kendra-datasource_datasourceconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_datasourceconfiguration.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-datasourceconfiguration.html
 type DataSource_DataSourceConfiguration struct {
 
+	// ConfluenceConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-datasourceconfiguration.html#cfn-kendra-datasource-datasourceconfiguration-confluenceconfiguration
+	ConfluenceConfiguration *DataSource_ConfluenceConfiguration `json:"ConfluenceConfiguration,omitempty"`
+
 	// DatabaseConfiguration AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-datasourceconfiguration.html#cfn-kendra-datasource-datasourceconfiguration-databaseconfiguration

--- a/cloudformation/kendra/aws-kendra-datasource_onedriveconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_onedriveconfiguration.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-onedriveconfiguration.html
 type DataSource_OneDriveConfiguration struct {
 
+	// DisableLocalGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-onedriveconfiguration.html#cfn-kendra-datasource-onedriveconfiguration-disablelocalgroups
+	DisableLocalGroups bool `json:"DisableLocalGroups,omitempty"`
+
 	// ExclusionPatterns AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-onedriveconfiguration.html#cfn-kendra-datasource-onedriveconfiguration-exclusionpatterns

--- a/cloudformation/kendra/aws-kendra-datasource_sharepointconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-datasource_sharepointconfiguration.go
@@ -13,6 +13,11 @@ type DataSource_SharePointConfiguration struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-sharepointconfiguration.html#cfn-kendra-datasource-sharepointconfiguration-crawlattachments
 	CrawlAttachments bool `json:"CrawlAttachments,omitempty"`
 
+	// DisableLocalGroups AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-sharepointconfiguration.html#cfn-kendra-datasource-sharepointconfiguration-disablelocalgroups
+	DisableLocalGroups bool `json:"DisableLocalGroups,omitempty"`
+
 	// DocumentTitleFieldName AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-datasource-sharepointconfiguration.html#cfn-kendra-datasource-sharepointconfiguration-documenttitlefieldname

--- a/cloudformation/kendra/aws-kendra-index.go
+++ b/cloudformation/kendra/aws-kendra-index.go
@@ -52,6 +52,16 @@ type Index struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-index.html#cfn-kendra-index-tags
 	Tags *Index_TagList `json:"Tags,omitempty"`
 
+	// UserContextPolicy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-index.html#cfn-kendra-index-usercontextpolicy
+	UserContextPolicy string `json:"UserContextPolicy,omitempty"`
+
+	// UserTokenConfigurations AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-index.html#cfn-kendra-index-usertokenconfigurations
+	UserTokenConfigurations *Index_UserTokenConfigurationList `json:"UserTokenConfigurations,omitempty"`
+
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 

--- a/cloudformation/kendra/aws-kendra-index_jsontokentypeconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-index_jsontokentypeconfiguration.go
@@ -1,0 +1,40 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Index_JsonTokenTypeConfiguration AWS CloudFormation Resource (AWS::Kendra::Index.JsonTokenTypeConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jsontokentypeconfiguration.html
+type Index_JsonTokenTypeConfiguration struct {
+
+	// GroupAttributeField AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jsontokentypeconfiguration.html#cfn-kendra-index-jsontokentypeconfiguration-groupattributefield
+	GroupAttributeField string `json:"GroupAttributeField,omitempty"`
+
+	// UserNameAttributeField AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jsontokentypeconfiguration.html#cfn-kendra-index-jsontokentypeconfiguration-usernameattributefield
+	UserNameAttributeField string `json:"UserNameAttributeField,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Index_JsonTokenTypeConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::Index.JsonTokenTypeConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-index_jwttokentypeconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-index_jwttokentypeconfiguration.go
@@ -1,0 +1,65 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Index_JwtTokenTypeConfiguration AWS CloudFormation Resource (AWS::Kendra::Index.JwtTokenTypeConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html
+type Index_JwtTokenTypeConfiguration struct {
+
+	// ClaimRegex AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-claimregex
+	ClaimRegex string `json:"ClaimRegex,omitempty"`
+
+	// GroupAttributeField AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-groupattributefield
+	GroupAttributeField string `json:"GroupAttributeField,omitempty"`
+
+	// Issuer AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-issuer
+	Issuer string `json:"Issuer,omitempty"`
+
+	// KeyLocation AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-keylocation
+	KeyLocation string `json:"KeyLocation,omitempty"`
+
+	// SecretManagerArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-secretmanagerarn
+	SecretManagerArn string `json:"SecretManagerArn,omitempty"`
+
+	// URL AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-url
+	URL string `json:"URL,omitempty"`
+
+	// UserNameAttributeField AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-jwttokentypeconfiguration.html#cfn-kendra-index-jwttokentypeconfiguration-usernameattributefield
+	UserNameAttributeField string `json:"UserNameAttributeField,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Index_JwtTokenTypeConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::Index.JwtTokenTypeConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-index_usertokenconfiguration.go
+++ b/cloudformation/kendra/aws-kendra-index_usertokenconfiguration.go
@@ -1,0 +1,40 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Index_UserTokenConfiguration AWS CloudFormation Resource (AWS::Kendra::Index.UserTokenConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-usertokenconfiguration.html
+type Index_UserTokenConfiguration struct {
+
+	// JsonTokenTypeConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-usertokenconfiguration.html#cfn-kendra-index-usertokenconfiguration-jsontokentypeconfiguration
+	JsonTokenTypeConfiguration *Index_JsonTokenTypeConfiguration `json:"JsonTokenTypeConfiguration,omitempty"`
+
+	// JwtTokenTypeConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-usertokenconfiguration.html#cfn-kendra-index-usertokenconfiguration-jwttokentypeconfiguration
+	JwtTokenTypeConfiguration *Index_JwtTokenTypeConfiguration `json:"JwtTokenTypeConfiguration,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Index_UserTokenConfiguration) AWSCloudFormationType() string {
+	return "AWS::Kendra::Index.UserTokenConfiguration"
+}

--- a/cloudformation/kendra/aws-kendra-index_usertokenconfigurationlist.go
+++ b/cloudformation/kendra/aws-kendra-index_usertokenconfigurationlist.go
@@ -1,0 +1,35 @@
+package kendra
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Index_UserTokenConfigurationList AWS CloudFormation Resource (AWS::Kendra::Index.UserTokenConfigurationList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-usertokenconfigurationlist.html
+type Index_UserTokenConfigurationList struct {
+
+	// UserTokenConfigurationList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kendra-index-usertokenconfigurationlist.html#cfn-kendra-index-usertokenconfigurationlist-usertokenconfigurationlist
+	UserTokenConfigurationList []Index_UserTokenConfiguration `json:"UserTokenConfigurationList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Index_UserTokenConfigurationList) AWSCloudFormationType() string {
+	return "AWS::Kendra::Index.UserTokenConfigurationList"
+}

--- a/cloudformation/lambda/aws-lambda-eventsourcemapping.go
+++ b/cloudformation/lambda/aws-lambda-eventsourcemapping.go
@@ -33,7 +33,7 @@ type EventSourceMapping struct {
 	Enabled bool `json:"Enabled,omitempty"`
 
 	// EventSourceArn AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-eventsourcearn
 	EventSourceArn string `json:"EventSourceArn,omitempty"`
 
@@ -41,6 +41,11 @@ type EventSourceMapping struct {
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-functionname
 	FunctionName string `json:"FunctionName,omitempty"`
+
+	// FunctionResponseTypes AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-functionresponsetypes
+	FunctionResponseTypes []string `json:"FunctionResponseTypes,omitempty"`
 
 	// MaximumBatchingWindowInSeconds AWS CloudFormation Property
 	// Required: false
@@ -71,6 +76,11 @@ type EventSourceMapping struct {
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-queues
 	Queues []string `json:"Queues,omitempty"`
+
+	// SelfManagedEventSource AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-selfmanagedeventsource
+	SelfManagedEventSource *EventSourceMapping_SelfManagedEventSource `json:"SelfManagedEventSource,omitempty"`
 
 	// SourceAccessConfigurations AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/lambda/aws-lambda-eventsourcemapping_endpoints.go
+++ b/cloudformation/lambda/aws-lambda-eventsourcemapping_endpoints.go
@@ -1,0 +1,35 @@
+package lambda
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// EventSourceMapping_Endpoints AWS CloudFormation Resource (AWS::Lambda::EventSourceMapping.Endpoints)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventsourcemapping-endpoints.html
+type EventSourceMapping_Endpoints struct {
+
+	// KafkaBootstrapServers AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventsourcemapping-endpoints.html#cfn-lambda-eventsourcemapping-endpoints-kafkabootstrapservers
+	KafkaBootstrapServers []string `json:"KafkaBootstrapServers,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *EventSourceMapping_Endpoints) AWSCloudFormationType() string {
+	return "AWS::Lambda::EventSourceMapping.Endpoints"
+}

--- a/cloudformation/lambda/aws-lambda-eventsourcemapping_selfmanagedeventsource.go
+++ b/cloudformation/lambda/aws-lambda-eventsourcemapping_selfmanagedeventsource.go
@@ -1,0 +1,35 @@
+package lambda
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// EventSourceMapping_SelfManagedEventSource AWS CloudFormation Resource (AWS::Lambda::EventSourceMapping.SelfManagedEventSource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventsourcemapping-selfmanagedeventsource.html
+type EventSourceMapping_SelfManagedEventSource struct {
+
+	// Endpoints AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventsourcemapping-selfmanagedeventsource.html#cfn-lambda-eventsourcemapping-selfmanagedeventsource-endpoints
+	Endpoints *EventSourceMapping_Endpoints `json:"Endpoints,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *EventSourceMapping_SelfManagedEventSource) AWSCloudFormationType() string {
+	return "AWS::Lambda::EventSourceMapping.SelfManagedEventSource"
+}

--- a/cloudformation/lambda/aws-lambda-function.go
+++ b/cloudformation/lambda/aws-lambda-function.go
@@ -49,9 +49,14 @@ type Function struct {
 	FunctionName string `json:"FunctionName,omitempty"`
 
 	// Handler AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-handler
 	Handler string `json:"Handler,omitempty"`
+
+	// ImageConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig
+	ImageConfig *Function_ImageConfig `json:"ImageConfig,omitempty"`
 
 	// KmsKeyArn AWS CloudFormation Property
 	// Required: false
@@ -68,6 +73,11 @@ type Function struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize
 	MemorySize int `json:"MemorySize,omitempty"`
 
+	// PackageType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-packagetype
+	PackageType string `json:"PackageType,omitempty"`
+
 	// ReservedConcurrentExecutions AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions
@@ -79,7 +89,7 @@ type Function struct {
 	Role string `json:"Role,omitempty"`
 
 	// Runtime AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime
 	Runtime string `json:"Runtime,omitempty"`
 

--- a/cloudformation/lambda/aws-lambda-function_code.go
+++ b/cloudformation/lambda/aws-lambda-function_code.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html
 type Function_Code struct {
 
+	// ImageUri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-imageuri
+	ImageUri string `json:"ImageUri,omitempty"`
+
 	// S3Bucket AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-s3bucket

--- a/cloudformation/lambda/aws-lambda-function_imageconfig.go
+++ b/cloudformation/lambda/aws-lambda-function_imageconfig.go
@@ -1,0 +1,45 @@
+package lambda
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Function_ImageConfig AWS CloudFormation Resource (AWS::Lambda::Function.ImageConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-imageconfig.html
+type Function_ImageConfig struct {
+
+	// Command AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-imageconfig.html#cfn-lambda-function-imageconfig-command
+	Command []string `json:"Command,omitempty"`
+
+	// EntryPoint AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-imageconfig.html#cfn-lambda-function-imageconfig-entrypoint
+	EntryPoint []string `json:"EntryPoint,omitempty"`
+
+	// WorkingDirectory AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-imageconfig.html#cfn-lambda-function-imageconfig-workingdirectory
+	WorkingDirectory string `json:"WorkingDirectory,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Function_ImageConfig) AWSCloudFormationType() string {
+	return "AWS::Lambda::Function.ImageConfig"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant.go
@@ -1,0 +1,196 @@
+package licensemanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Grant AWS CloudFormation Resource (AWS::LicenseManager::Grant)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html
+type Grant struct {
+
+	// AllowedOperations AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-allowedoperations
+	AllowedOperations *Grant_AllowedOperationList `json:"AllowedOperations,omitempty"`
+
+	// ClientToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-clienttoken
+	ClientToken string `json:"ClientToken,omitempty"`
+
+	// Filters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-filters
+	Filters *Grant_FilterList `json:"Filters,omitempty"`
+
+	// GrantArns AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-grantarns
+	GrantArns *Grant_ArnList `json:"GrantArns,omitempty"`
+
+	// GrantName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-grantname
+	GrantName string `json:"GrantName,omitempty"`
+
+	// GrantStatus AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-grantstatus
+	GrantStatus string `json:"GrantStatus,omitempty"`
+
+	// GrantedOperations AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-grantedoperations
+	GrantedOperations *Grant_AllowedOperationList `json:"GrantedOperations,omitempty"`
+
+	// GranteePrincipalArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-granteeprincipalarn
+	GranteePrincipalArn string `json:"GranteePrincipalArn,omitempty"`
+
+	// HomeRegion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-homeregion
+	HomeRegion string `json:"HomeRegion,omitempty"`
+
+	// LicenseArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-licensearn
+	LicenseArn string `json:"LicenseArn,omitempty"`
+
+	// MaxResults AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-maxresults
+	MaxResults int `json:"MaxResults,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// ParentArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-parentarn
+	ParentArn string `json:"ParentArn,omitempty"`
+
+	// Principals AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-principals
+	Principals *Grant_ArnList `json:"Principals,omitempty"`
+
+	// SourceVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-sourceversion
+	SourceVersion string `json:"SourceVersion,omitempty"`
+
+	// Status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-status
+	Status string `json:"Status,omitempty"`
+
+	// StatusReason AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-statusreason
+	StatusReason string `json:"StatusReason,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-tags
+	Tags *Grant_TagList `json:"Tags,omitempty"`
+
+	// Version AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-grant.html#cfn-licensemanager-grant-version
+	Version string `json:"Version,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Grant) MarshalJSON() ([]byte, error) {
+	type Properties Grant
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Grant) UnmarshalJSON(b []byte) error {
+	type Properties Grant
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Grant(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant_allowedoperationlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant_allowedoperationlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Grant_AllowedOperationList AWS CloudFormation Resource (AWS::LicenseManager::Grant.AllowedOperationList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-allowedoperationlist.html
+type Grant_AllowedOperationList struct {
+
+	// AllowedOperationList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-allowedoperationlist.html#cfn-licensemanager-grant-allowedoperationlist-allowedoperationlist
+	AllowedOperationList []string `json:"AllowedOperationList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant_AllowedOperationList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant.AllowedOperationList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant_arnlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant_arnlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Grant_ArnList AWS CloudFormation Resource (AWS::LicenseManager::Grant.ArnList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-arnlist.html
+type Grant_ArnList struct {
+
+	// ArnList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-arnlist.html#cfn-licensemanager-grant-arnlist-arnlist
+	ArnList []string `json:"ArnList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant_ArnList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant.ArnList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant_filter.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant_filter.go
@@ -1,0 +1,40 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Grant_Filter AWS CloudFormation Resource (AWS::LicenseManager::Grant.Filter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-filter.html
+type Grant_Filter struct {
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-filter.html#cfn-licensemanager-grant-filter-name
+	Name string `json:"Name,omitempty"`
+
+	// Values AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-filter.html#cfn-licensemanager-grant-filter-values
+	Values *Grant_StringList `json:"Values,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant_Filter) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant.Filter"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant_filterlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant_filterlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Grant_FilterList AWS CloudFormation Resource (AWS::LicenseManager::Grant.FilterList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-filterlist.html
+type Grant_FilterList struct {
+
+	// FilterList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-filterlist.html#cfn-licensemanager-grant-filterlist-filterlist
+	FilterList []Grant_Filter `json:"FilterList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant_FilterList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant.FilterList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant_stringlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant_stringlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Grant_StringList AWS CloudFormation Resource (AWS::LicenseManager::Grant.StringList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-stringlist.html
+type Grant_StringList struct {
+
+	// StringList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-stringlist.html#cfn-licensemanager-grant-stringlist-stringlist
+	StringList []string `json:"StringList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant_StringList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant.StringList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-grant_taglist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-grant_taglist.go
@@ -1,0 +1,36 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Grant_TagList AWS CloudFormation Resource (AWS::LicenseManager::Grant.TagList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-taglist.html
+type Grant_TagList struct {
+
+	// TagList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-grant-taglist.html#cfn-licensemanager-grant-taglist-taglist
+	TagList []tags.Tag `json:"TagList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Grant_TagList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::Grant.TagList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license.go
@@ -1,0 +1,196 @@
+package licensemanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License AWS CloudFormation Resource (AWS::LicenseManager::License)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html
+type License struct {
+
+	// Beneficiary AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-beneficiary
+	Beneficiary string `json:"Beneficiary,omitempty"`
+
+	// ClientToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-clienttoken
+	ClientToken string `json:"ClientToken,omitempty"`
+
+	// ConsumptionConfiguration AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-consumptionconfiguration
+	ConsumptionConfiguration *License_ConsumptionConfiguration `json:"ConsumptionConfiguration,omitempty"`
+
+	// Entitlements AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-entitlements
+	Entitlements *License_EntitlementList `json:"Entitlements,omitempty"`
+
+	// Filters AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-filters
+	Filters *License_FilterList `json:"Filters,omitempty"`
+
+	// HomeRegion AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-homeregion
+	HomeRegion string `json:"HomeRegion,omitempty"`
+
+	// Issuer AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-issuer
+	Issuer *License_IssuerData `json:"Issuer,omitempty"`
+
+	// LicenseArns AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-licensearns
+	LicenseArns *License_ArnList `json:"LicenseArns,omitempty"`
+
+	// LicenseMetadata AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-licensemetadata
+	LicenseMetadata *License_MetadataList `json:"LicenseMetadata,omitempty"`
+
+	// LicenseName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-licensename
+	LicenseName string `json:"LicenseName,omitempty"`
+
+	// MaxResults AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-maxresults
+	MaxResults int `json:"MaxResults,omitempty"`
+
+	// NextToken AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-nexttoken
+	NextToken string `json:"NextToken,omitempty"`
+
+	// ProductName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-productname
+	ProductName string `json:"ProductName,omitempty"`
+
+	// ProductSKU AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-productsku
+	ProductSKU string `json:"ProductSKU,omitempty"`
+
+	// SourceVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-sourceversion
+	SourceVersion string `json:"SourceVersion,omitempty"`
+
+	// Status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-status
+	Status string `json:"Status,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-tags
+	Tags *License_TagList `json:"Tags,omitempty"`
+
+	// Validity AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-validity
+	Validity *License_ValidityDateFormat `json:"Validity,omitempty"`
+
+	// Version AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-licensemanager-license.html#cfn-licensemanager-license-version
+	Version string `json:"Version,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r License) MarshalJSON() ([]byte, error) {
+	type Properties License
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *License) UnmarshalJSON(b []byte) error {
+	type Properties License
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = License(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_arnlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_arnlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_ArnList AWS CloudFormation Resource (AWS::LicenseManager::License.ArnList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-arnlist.html
+type License_ArnList struct {
+
+	// ArnList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-arnlist.html#cfn-licensemanager-license-arnlist-arnlist
+	ArnList []string `json:"ArnList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_ArnList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.ArnList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_borrowconfiguration.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_borrowconfiguration.go
@@ -1,0 +1,40 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_BorrowConfiguration AWS CloudFormation Resource (AWS::LicenseManager::License.BorrowConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-borrowconfiguration.html
+type License_BorrowConfiguration struct {
+
+	// AllowEarlyCheckIn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-borrowconfiguration.html#cfn-licensemanager-license-borrowconfiguration-allowearlycheckin
+	AllowEarlyCheckIn bool `json:"AllowEarlyCheckIn"`
+
+	// MaxTimeToLiveInMinutes AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-borrowconfiguration.html#cfn-licensemanager-license-borrowconfiguration-maxtimetoliveinminutes
+	MaxTimeToLiveInMinutes int `json:"MaxTimeToLiveInMinutes"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_BorrowConfiguration) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.BorrowConfiguration"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_consumptionconfiguration.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_consumptionconfiguration.go
@@ -1,0 +1,45 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_ConsumptionConfiguration AWS CloudFormation Resource (AWS::LicenseManager::License.ConsumptionConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-consumptionconfiguration.html
+type License_ConsumptionConfiguration struct {
+
+	// BorrowConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-consumptionconfiguration.html#cfn-licensemanager-license-consumptionconfiguration-borrowconfiguration
+	BorrowConfiguration *License_BorrowConfiguration `json:"BorrowConfiguration,omitempty"`
+
+	// ProvisionalConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-consumptionconfiguration.html#cfn-licensemanager-license-consumptionconfiguration-provisionalconfiguration
+	ProvisionalConfiguration *License_ProvisionalConfiguration `json:"ProvisionalConfiguration,omitempty"`
+
+	// RenewType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-consumptionconfiguration.html#cfn-licensemanager-license-consumptionconfiguration-renewtype
+	RenewType string `json:"RenewType,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_ConsumptionConfiguration) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.ConsumptionConfiguration"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_entitlement.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_entitlement.go
@@ -1,0 +1,65 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_Entitlement AWS CloudFormation Resource (AWS::LicenseManager::License.Entitlement)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html
+type License_Entitlement struct {
+
+	// AllowCheckIn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-allowcheckin
+	AllowCheckIn bool `json:"AllowCheckIn,omitempty"`
+
+	// CheckoutRules AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-checkoutrules
+	CheckoutRules *License_RuleList `json:"CheckoutRules,omitempty"`
+
+	// MaxCount AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-maxcount
+	MaxCount int `json:"MaxCount,omitempty"`
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-name
+	Name string `json:"Name,omitempty"`
+
+	// Overage AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-overage
+	Overage bool `json:"Overage,omitempty"`
+
+	// Unit AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-unit
+	Unit string `json:"Unit,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlement.html#cfn-licensemanager-license-entitlement-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_Entitlement) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.Entitlement"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_entitlementlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_entitlementlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_EntitlementList AWS CloudFormation Resource (AWS::LicenseManager::License.EntitlementList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlementlist.html
+type License_EntitlementList struct {
+
+	// EntitlementList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-entitlementlist.html#cfn-licensemanager-license-entitlementlist-entitlementlist
+	EntitlementList []License_Entitlement `json:"EntitlementList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_EntitlementList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.EntitlementList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_filter.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_filter.go
@@ -1,0 +1,40 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_Filter AWS CloudFormation Resource (AWS::LicenseManager::License.Filter)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-filter.html
+type License_Filter struct {
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-filter.html#cfn-licensemanager-license-filter-name
+	Name string `json:"Name,omitempty"`
+
+	// Values AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-filter.html#cfn-licensemanager-license-filter-values
+	Values *License_StringList `json:"Values,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_Filter) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.Filter"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_filterlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_filterlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_FilterList AWS CloudFormation Resource (AWS::LicenseManager::License.FilterList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-filterlist.html
+type License_FilterList struct {
+
+	// FilterList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-filterlist.html#cfn-licensemanager-license-filterlist-filterlist
+	FilterList []License_Filter `json:"FilterList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_FilterList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.FilterList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_issuerdata.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_issuerdata.go
@@ -1,0 +1,40 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_IssuerData AWS CloudFormation Resource (AWS::LicenseManager::License.IssuerData)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-issuerdata.html
+type License_IssuerData struct {
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-issuerdata.html#cfn-licensemanager-license-issuerdata-name
+	Name string `json:"Name,omitempty"`
+
+	// SignKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-issuerdata.html#cfn-licensemanager-license-issuerdata-signkey
+	SignKey string `json:"SignKey,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_IssuerData) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.IssuerData"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_metadata.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_metadata.go
@@ -1,0 +1,40 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_Metadata AWS CloudFormation Resource (AWS::LicenseManager::License.Metadata)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-metadata.html
+type License_Metadata struct {
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-metadata.html#cfn-licensemanager-license-metadata-name
+	Name string `json:"Name,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-metadata.html#cfn-licensemanager-license-metadata-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_Metadata) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.Metadata"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_metadatalist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_metadatalist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_MetadataList AWS CloudFormation Resource (AWS::LicenseManager::License.MetadataList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-metadatalist.html
+type License_MetadataList struct {
+
+	// MetadataList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-metadatalist.html#cfn-licensemanager-license-metadatalist-metadatalist
+	MetadataList []License_Metadata `json:"MetadataList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_MetadataList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.MetadataList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_provisionalconfiguration.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_provisionalconfiguration.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_ProvisionalConfiguration AWS CloudFormation Resource (AWS::LicenseManager::License.ProvisionalConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-provisionalconfiguration.html
+type License_ProvisionalConfiguration struct {
+
+	// MaxTimeToLiveInMinutes AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-provisionalconfiguration.html#cfn-licensemanager-license-provisionalconfiguration-maxtimetoliveinminutes
+	MaxTimeToLiveInMinutes int `json:"MaxTimeToLiveInMinutes"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_ProvisionalConfiguration) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.ProvisionalConfiguration"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_rule.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_rule.go
@@ -1,0 +1,45 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_Rule AWS CloudFormation Resource (AWS::LicenseManager::License.Rule)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-rule.html
+type License_Rule struct {
+
+	// Name AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-rule.html#cfn-licensemanager-license-rule-name
+	Name string `json:"Name,omitempty"`
+
+	// Unit AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-rule.html#cfn-licensemanager-license-rule-unit
+	Unit string `json:"Unit,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-rule.html#cfn-licensemanager-license-rule-value
+	Value string `json:"Value,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_Rule) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.Rule"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_rulelist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_rulelist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_RuleList AWS CloudFormation Resource (AWS::LicenseManager::License.RuleList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-rulelist.html
+type License_RuleList struct {
+
+	// RuleList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-rulelist.html#cfn-licensemanager-license-rulelist-rulelist
+	RuleList []License_Rule `json:"RuleList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_RuleList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.RuleList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_stringlist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_stringlist.go
@@ -1,0 +1,35 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_StringList AWS CloudFormation Resource (AWS::LicenseManager::License.StringList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-stringlist.html
+type License_StringList struct {
+
+	// StringList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-stringlist.html#cfn-licensemanager-license-stringlist-stringlist
+	StringList []string `json:"StringList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_StringList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.StringList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_taglist.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_taglist.go
@@ -1,0 +1,36 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// License_TagList AWS CloudFormation Resource (AWS::LicenseManager::License.TagList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-taglist.html
+type License_TagList struct {
+
+	// TagList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-taglist.html#cfn-licensemanager-license-taglist-taglist
+	TagList []tags.Tag `json:"TagList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_TagList) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.TagList"
+}

--- a/cloudformation/licensemanager/aws-licensemanager-license_validitydateformat.go
+++ b/cloudformation/licensemanager/aws-licensemanager-license_validitydateformat.go
@@ -1,0 +1,40 @@
+package licensemanager
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// License_ValidityDateFormat AWS CloudFormation Resource (AWS::LicenseManager::License.ValidityDateFormat)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-validitydateformat.html
+type License_ValidityDateFormat struct {
+
+	// Begin AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-validitydateformat.html#cfn-licensemanager-license-validitydateformat-begin
+	Begin string `json:"Begin,omitempty"`
+
+	// End AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-licensemanager-license-validitydateformat.html#cfn-licensemanager-license-validitydateformat-end
+	End string `json:"End,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *License_ValidityDateFormat) AWSCloudFormationType() string {
+	return "AWS::LicenseManager::License.ValidityDateFormat"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment.go
+++ b/cloudformation/mwaa/aws-mwaa-environment.go
@@ -1,0 +1,191 @@
+package mwaa
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment AWS CloudFormation Resource (AWS::MWAA::Environment)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html
+type Environment struct {
+
+	// AirflowConfigurationOptions AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-airflowconfigurationoptions
+	AirflowConfigurationOptions *Environment_AirflowConfigurationOptions `json:"AirflowConfigurationOptions,omitempty"`
+
+	// AirflowVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-airflowversion
+	AirflowVersion string `json:"AirflowVersion,omitempty"`
+
+	// DagS3Path AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-dags3path
+	DagS3Path string `json:"DagS3Path,omitempty"`
+
+	// EnvironmentClass AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-environmentclass
+	EnvironmentClass string `json:"EnvironmentClass,omitempty"`
+
+	// ExecutionRoleArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-executionrolearn
+	ExecutionRoleArn string `json:"ExecutionRoleArn,omitempty"`
+
+	// KmsKey AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-kmskey
+	KmsKey string `json:"KmsKey,omitempty"`
+
+	// LoggingConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-loggingconfiguration
+	LoggingConfiguration *Environment_LoggingConfiguration `json:"LoggingConfiguration,omitempty"`
+
+	// MaxWorkers AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-maxworkers
+	MaxWorkers int `json:"MaxWorkers,omitempty"`
+
+	// NetworkConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-networkconfiguration
+	NetworkConfiguration *Environment_NetworkConfiguration `json:"NetworkConfiguration,omitempty"`
+
+	// PluginsS3ObjectVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-pluginss3objectversion
+	PluginsS3ObjectVersion string `json:"PluginsS3ObjectVersion,omitempty"`
+
+	// PluginsS3Path AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-pluginss3path
+	PluginsS3Path string `json:"PluginsS3Path,omitempty"`
+
+	// RequirementsS3ObjectVersion AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-requirementss3objectversion
+	RequirementsS3ObjectVersion string `json:"RequirementsS3ObjectVersion,omitempty"`
+
+	// RequirementsS3Path AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-requirementss3path
+	RequirementsS3Path string `json:"RequirementsS3Path,omitempty"`
+
+	// SourceBucketArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-sourcebucketarn
+	SourceBucketArn string `json:"SourceBucketArn,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-tags
+	Tags *Environment_TagMap `json:"Tags,omitempty"`
+
+	// WebserverAccessMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-webserveraccessmode
+	WebserverAccessMode string `json:"WebserverAccessMode,omitempty"`
+
+	// WebserverUrl AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-webserverurl
+	WebserverUrl string `json:"WebserverUrl,omitempty"`
+
+	// WeeklyMaintenanceWindowStart AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-mwaa-environment.html#cfn-mwaa-environment-weeklymaintenancewindowstart
+	WeeklyMaintenanceWindowStart string `json:"WeeklyMaintenanceWindowStart,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Environment) MarshalJSON() ([]byte, error) {
+	type Properties Environment
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Environment) UnmarshalJSON(b []byte) error {
+	type Properties Environment
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Environment(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_airflowconfigurationoptions.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_airflowconfigurationoptions.go
@@ -1,0 +1,30 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_AirflowConfigurationOptions AWS CloudFormation Resource (AWS::MWAA::Environment.AirflowConfigurationOptions)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-airflowconfigurationoptions.html
+type Environment_AirflowConfigurationOptions struct {
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_AirflowConfigurationOptions) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.AirflowConfigurationOptions"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_lastupdate.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_lastupdate.go
@@ -1,0 +1,45 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_LastUpdate AWS CloudFormation Resource (AWS::MWAA::Environment.LastUpdate)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-lastupdate.html
+type Environment_LastUpdate struct {
+
+	// CreatedAt AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-lastupdate.html#cfn-mwaa-environment-lastupdate-createdat
+	CreatedAt string `json:"CreatedAt,omitempty"`
+
+	// Error AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-lastupdate.html#cfn-mwaa-environment-lastupdate-error
+	Error *Environment_UpdateError `json:"Error,omitempty"`
+
+	// Status AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-lastupdate.html#cfn-mwaa-environment-lastupdate-status
+	Status string `json:"Status,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_LastUpdate) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.LastUpdate"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_loggingconfiguration.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_loggingconfiguration.go
@@ -1,0 +1,55 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_LoggingConfiguration AWS CloudFormation Resource (AWS::MWAA::Environment.LoggingConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-loggingconfiguration.html
+type Environment_LoggingConfiguration struct {
+
+	// DagProcessingLogs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-loggingconfiguration.html#cfn-mwaa-environment-loggingconfiguration-dagprocessinglogs
+	DagProcessingLogs *Environment_ModuleLoggingConfiguration `json:"DagProcessingLogs,omitempty"`
+
+	// SchedulerLogs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-loggingconfiguration.html#cfn-mwaa-environment-loggingconfiguration-schedulerlogs
+	SchedulerLogs *Environment_ModuleLoggingConfiguration `json:"SchedulerLogs,omitempty"`
+
+	// TaskLogs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-loggingconfiguration.html#cfn-mwaa-environment-loggingconfiguration-tasklogs
+	TaskLogs *Environment_ModuleLoggingConfiguration `json:"TaskLogs,omitempty"`
+
+	// WebserverLogs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-loggingconfiguration.html#cfn-mwaa-environment-loggingconfiguration-webserverlogs
+	WebserverLogs *Environment_ModuleLoggingConfiguration `json:"WebserverLogs,omitempty"`
+
+	// WorkerLogs AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-loggingconfiguration.html#cfn-mwaa-environment-loggingconfiguration-workerlogs
+	WorkerLogs *Environment_ModuleLoggingConfiguration `json:"WorkerLogs,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_LoggingConfiguration) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.LoggingConfiguration"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_moduleloggingconfiguration.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_moduleloggingconfiguration.go
@@ -1,0 +1,45 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_ModuleLoggingConfiguration AWS CloudFormation Resource (AWS::MWAA::Environment.ModuleLoggingConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-moduleloggingconfiguration.html
+type Environment_ModuleLoggingConfiguration struct {
+
+	// CloudWatchLogGroupArn AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-moduleloggingconfiguration.html#cfn-mwaa-environment-moduleloggingconfiguration-cloudwatchloggrouparn
+	CloudWatchLogGroupArn string `json:"CloudWatchLogGroupArn,omitempty"`
+
+	// Enabled AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-moduleloggingconfiguration.html#cfn-mwaa-environment-moduleloggingconfiguration-enabled
+	Enabled bool `json:"Enabled,omitempty"`
+
+	// LogLevel AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-moduleloggingconfiguration.html#cfn-mwaa-environment-moduleloggingconfiguration-loglevel
+	LogLevel string `json:"LogLevel,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_ModuleLoggingConfiguration) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.ModuleLoggingConfiguration"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_networkconfiguration.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_networkconfiguration.go
@@ -1,0 +1,40 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_NetworkConfiguration AWS CloudFormation Resource (AWS::MWAA::Environment.NetworkConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-networkconfiguration.html
+type Environment_NetworkConfiguration struct {
+
+	// SecurityGroupIds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-networkconfiguration.html#cfn-mwaa-environment-networkconfiguration-securitygroupids
+	SecurityGroupIds *Environment_SecurityGroupList `json:"SecurityGroupIds,omitempty"`
+
+	// SubnetIds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-networkconfiguration.html#cfn-mwaa-environment-networkconfiguration-subnetids
+	SubnetIds *Environment_SubnetList `json:"SubnetIds,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_NetworkConfiguration) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.NetworkConfiguration"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_securitygrouplist.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_securitygrouplist.go
@@ -1,0 +1,35 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_SecurityGroupList AWS CloudFormation Resource (AWS::MWAA::Environment.SecurityGroupList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-securitygrouplist.html
+type Environment_SecurityGroupList struct {
+
+	// SecurityGroupList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-securitygrouplist.html#cfn-mwaa-environment-securitygrouplist-securitygrouplist
+	SecurityGroupList []string `json:"SecurityGroupList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_SecurityGroupList) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.SecurityGroupList"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_subnetlist.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_subnetlist.go
@@ -1,0 +1,35 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_SubnetList AWS CloudFormation Resource (AWS::MWAA::Environment.SubnetList)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-subnetlist.html
+type Environment_SubnetList struct {
+
+	// SubnetList AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-subnetlist.html#cfn-mwaa-environment-subnetlist-subnetlist
+	SubnetList []string `json:"SubnetList,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_SubnetList) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.SubnetList"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_tagmap.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_tagmap.go
@@ -1,0 +1,30 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_TagMap AWS CloudFormation Resource (AWS::MWAA::Environment.TagMap)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-tagmap.html
+type Environment_TagMap struct {
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_TagMap) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.TagMap"
+}

--- a/cloudformation/mwaa/aws-mwaa-environment_updateerror.go
+++ b/cloudformation/mwaa/aws-mwaa-environment_updateerror.go
@@ -1,0 +1,40 @@
+package mwaa
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Environment_UpdateError AWS CloudFormation Resource (AWS::MWAA::Environment.UpdateError)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-updateerror.html
+type Environment_UpdateError struct {
+
+	// ErrorCode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-updateerror.html#cfn-mwaa-environment-updateerror-errorcode
+	ErrorCode string `json:"ErrorCode,omitempty"`
+
+	// ErrorMessage AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mwaa-environment-updateerror.html#cfn-mwaa-environment-updateerror-errormessage
+	ErrorMessage string `json:"ErrorMessage,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Environment_UpdateError) AWSCloudFormationType() string {
+	return "AWS::MWAA::Environment.UpdateError"
+}

--- a/cloudformation/networkfirewall/aws-networkfirewall-firewall.go
+++ b/cloudformation/networkfirewall/aws-networkfirewall-firewall.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // Firewall AWS CloudFormation Resource (AWS::NetworkFirewall::Firewall)
@@ -50,7 +51,7 @@ type Firewall struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-firewall.html#cfn-networkfirewall-firewall-tags
-	Tags *Firewall_Tags `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// VpcId AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/networkfirewall/aws-networkfirewall-firewallpolicy.go
+++ b/cloudformation/networkfirewall/aws-networkfirewall-firewallpolicy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // FirewallPolicy AWS CloudFormation Resource (AWS::NetworkFirewall::FirewallPolicy)
@@ -30,7 +31,7 @@ type FirewallPolicy struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-firewallpolicy.html#cfn-networkfirewall-firewallpolicy-tags
-	Tags *FirewallPolicy_Tags `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/networkfirewall/aws-networkfirewall-loggingconfiguration.go
+++ b/cloudformation/networkfirewall/aws-networkfirewall-loggingconfiguration.go
@@ -12,6 +12,16 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-loggingconfiguration.html
 type LoggingConfiguration struct {
 
+	// FirewallArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-loggingconfiguration.html#cfn-networkfirewall-loggingconfiguration-firewallarn
+	FirewallArn string `json:"FirewallArn,omitempty"`
+
+	// FirewallName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-loggingconfiguration.html#cfn-networkfirewall-loggingconfiguration-firewallname
+	FirewallName string `json:"FirewallName,omitempty"`
+
 	// LoggingConfiguration AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-loggingconfiguration.html#cfn-networkfirewall-loggingconfiguration-loggingconfiguration

--- a/cloudformation/networkfirewall/aws-networkfirewall-rulegroup.go
+++ b/cloudformation/networkfirewall/aws-networkfirewall-rulegroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // RuleGroup AWS CloudFormation Resource (AWS::NetworkFirewall::RuleGroup)
@@ -27,11 +28,6 @@ type RuleGroup struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-rulegroup.html#cfn-networkfirewall-rulegroup-rulegroup
 	RuleGroup *RuleGroup_RuleGroup `json:"RuleGroup,omitempty"`
 
-	// RuleGroupId AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-rulegroup.html#cfn-networkfirewall-rulegroup-rulegroupid
-	RuleGroupId string `json:"RuleGroupId,omitempty"`
-
 	// RuleGroupName AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-rulegroup.html#cfn-networkfirewall-rulegroup-rulegroupname
@@ -40,7 +36,7 @@ type RuleGroup struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-networkfirewall-rulegroup.html#cfn-networkfirewall-rulegroup-tags
-	Tags *RuleGroup_Tags `json:"Tags,omitempty"`
+	Tags []tags.Tag `json:"Tags,omitempty"`
 
 	// Type AWS CloudFormation Property
 	// Required: true

--- a/cloudformation/s3/aws-s3-bucket_serversideencryptionrule.go
+++ b/cloudformation/s3/aws-s3-bucket_serversideencryptionrule.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html
 type Bucket_ServerSideEncryptionRule struct {
 
+	// BucketKeyEnabled AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html#cfn-s3-bucket-serversideencryptionrule-bucketkeyenabled
+	BucketKeyEnabled bool `json:"BucketKeyEnabled,omitempty"`
+
 	// ServerSideEncryptionByDefault AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html#cfn-s3-bucket-serversideencryptionrule-serversideencryptionbydefault

--- a/cloudformation/s3/aws-s3-bucket_sourceselectioncriteria.go
+++ b/cloudformation/s3/aws-s3-bucket_sourceselectioncriteria.go
@@ -8,6 +8,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-sourceselectioncriteria.html
 type Bucket_SourceSelectionCriteria struct {
 
+	// ReplicaModifications AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-sourceselectioncriteria.html#cfn-s3-bucket-sourceselectioncriteria-replicamodifications
+	ReplicaModifications *Bucket_ReplicaModifications `json:"ReplicaModifications,omitempty"`
+
 	// SseKmsEncryptedObjects AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-sourceselectioncriteria.html#cfn-s3-bucket-sourceselectioncriteria-ssekmsencryptedobjects

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition.go
@@ -1,0 +1,152 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// DataQualityJobDefinition AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html
+type DataQualityJobDefinition struct {
+
+	// DataQualityAppSpecification AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification
+	DataQualityAppSpecification *DataQualityJobDefinition_DataQualityAppSpecification `json:"DataQualityAppSpecification,omitempty"`
+
+	// DataQualityBaselineConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig
+	DataQualityBaselineConfig *DataQualityJobDefinition_DataQualityBaselineConfig `json:"DataQualityBaselineConfig,omitempty"`
+
+	// DataQualityJobInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityjobinput
+	DataQualityJobInput *DataQualityJobDefinition_DataQualityJobInput `json:"DataQualityJobInput,omitempty"`
+
+	// DataQualityJobOutputConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityjoboutputconfig
+	DataQualityJobOutputConfig *DataQualityJobDefinition_MonitoringOutputConfig `json:"DataQualityJobOutputConfig,omitempty"`
+
+	// JobDefinitionName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-jobdefinitionname
+	JobDefinitionName string `json:"JobDefinitionName,omitempty"`
+
+	// JobResources AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-jobresources
+	JobResources *DataQualityJobDefinition_MonitoringResources `json:"JobResources,omitempty"`
+
+	// NetworkConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-networkconfig
+	NetworkConfig *DataQualityJobDefinition_NetworkConfig `json:"NetworkConfig,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// StoppingCondition AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-stoppingcondition
+	StoppingCondition *DataQualityJobDefinition_StoppingCondition `json:"StoppingCondition,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-dataqualityjobdefinition.html#cfn-sagemaker-dataqualityjobdefinition-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r DataQualityJobDefinition) MarshalJSON() ([]byte, error) {
+	type Properties DataQualityJobDefinition
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *DataQualityJobDefinition) UnmarshalJSON(b []byte) error {
+	type Properties DataQualityJobDefinition
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = DataQualityJobDefinition(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_clusterconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_clusterconfig.go
@@ -1,0 +1,50 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_ClusterConfig AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.ClusterConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-clusterconfig.html
+type DataQualityJobDefinition_ClusterConfig struct {
+
+	// InstanceCount AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-clusterconfig.html#cfn-sagemaker-dataqualityjobdefinition-clusterconfig-instancecount
+	InstanceCount int `json:"InstanceCount"`
+
+	// InstanceType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-clusterconfig.html#cfn-sagemaker-dataqualityjobdefinition-clusterconfig-instancetype
+	InstanceType string `json:"InstanceType,omitempty"`
+
+	// VolumeKmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-clusterconfig.html#cfn-sagemaker-dataqualityjobdefinition-clusterconfig-volumekmskeyid
+	VolumeKmsKeyId string `json:"VolumeKmsKeyId,omitempty"`
+
+	// VolumeSizeInGB AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-clusterconfig.html#cfn-sagemaker-dataqualityjobdefinition-clusterconfig-volumesizeingb
+	VolumeSizeInGB int `json:"VolumeSizeInGB"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_ClusterConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.ClusterConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_constraintsresource.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_constraintsresource.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_ConstraintsResource AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-constraintsresource.html
+type DataQualityJobDefinition_ConstraintsResource struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-constraintsresource.html#cfn-sagemaker-dataqualityjobdefinition-constraintsresource-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_ConstraintsResource) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_dataqualityappspecification.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_dataqualityappspecification.go
@@ -1,0 +1,60 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_DataQualityAppSpecification AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html
+type DataQualityJobDefinition_DataQualityAppSpecification struct {
+
+	// ContainerArguments AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification-containerarguments
+	ContainerArguments []string `json:"ContainerArguments,omitempty"`
+
+	// ContainerEntrypoint AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification-containerentrypoint
+	ContainerEntrypoint []string `json:"ContainerEntrypoint,omitempty"`
+
+	// Environment AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification-environment
+	Environment *DataQualityJobDefinition_Environment `json:"Environment,omitempty"`
+
+	// ImageUri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification-imageuri
+	ImageUri string `json:"ImageUri,omitempty"`
+
+	// PostAnalyticsProcessorSourceUri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification-postanalyticsprocessorsourceuri
+	PostAnalyticsProcessorSourceUri string `json:"PostAnalyticsProcessorSourceUri,omitempty"`
+
+	// RecordPreprocessorSourceUri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityappspecification.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityappspecification-recordpreprocessorsourceuri
+	RecordPreprocessorSourceUri string `json:"RecordPreprocessorSourceUri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_DataQualityAppSpecification) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_dataqualitybaselineconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_dataqualitybaselineconfig.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_DataQualityBaselineConfig AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig.html
+type DataQualityJobDefinition_DataQualityBaselineConfig struct {
+
+	// BaseliningJobName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig.html#cfn-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig-baseliningjobname
+	BaseliningJobName string `json:"BaseliningJobName,omitempty"`
+
+	// ConstraintsResource AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig.html#cfn-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig-constraintsresource
+	ConstraintsResource *DataQualityJobDefinition_ConstraintsResource `json:"ConstraintsResource,omitempty"`
+
+	// StatisticsResource AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig.html#cfn-sagemaker-dataqualityjobdefinition-dataqualitybaselineconfig-statisticsresource
+	StatisticsResource *DataQualityJobDefinition_StatisticsResource `json:"StatisticsResource,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_DataQualityBaselineConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_dataqualityjobinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_dataqualityjobinput.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_DataQualityJobInput AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityjobinput.html
+type DataQualityJobDefinition_DataQualityJobInput struct {
+
+	// EndpointInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-dataqualityjobinput.html#cfn-sagemaker-dataqualityjobdefinition-dataqualityjobinput-endpointinput
+	EndpointInput *DataQualityJobDefinition_EndpointInput `json:"EndpointInput,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_DataQualityJobInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_endpointinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_endpointinput.go
@@ -1,0 +1,50 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_EndpointInput AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.EndpointInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-endpointinput.html
+type DataQualityJobDefinition_EndpointInput struct {
+
+	// EndpointName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-endpointinput.html#cfn-sagemaker-dataqualityjobdefinition-endpointinput-endpointname
+	EndpointName string `json:"EndpointName,omitempty"`
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-endpointinput.html#cfn-sagemaker-dataqualityjobdefinition-endpointinput-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// S3DataDistributionType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-endpointinput.html#cfn-sagemaker-dataqualityjobdefinition-endpointinput-s3datadistributiontype
+	S3DataDistributionType string `json:"S3DataDistributionType,omitempty"`
+
+	// S3InputMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-endpointinput.html#cfn-sagemaker-dataqualityjobdefinition-endpointinput-s3inputmode
+	S3InputMode string `json:"S3InputMode,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_EndpointInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.EndpointInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_environment.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_environment.go
@@ -1,0 +1,30 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_Environment AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.Environment)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-environment.html
+type DataQualityJobDefinition_Environment struct {
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_Environment) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.Environment"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_monitoringoutput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_monitoringoutput.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_MonitoringOutput AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringoutput.html
+type DataQualityJobDefinition_MonitoringOutput struct {
+
+	// S3Output AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringoutput.html#cfn-sagemaker-dataqualityjobdefinition-monitoringoutput-s3output
+	S3Output *DataQualityJobDefinition_S3Output `json:"S3Output,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_MonitoringOutput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_monitoringoutputconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_monitoringoutputconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_MonitoringOutputConfig AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringoutputconfig.html
+type DataQualityJobDefinition_MonitoringOutputConfig struct {
+
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-dataqualityjobdefinition-monitoringoutputconfig-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
+	// MonitoringOutputs AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-dataqualityjobdefinition-monitoringoutputconfig-monitoringoutputs
+	MonitoringOutputs []DataQualityJobDefinition_MonitoringOutput `json:"MonitoringOutputs,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_MonitoringOutputConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_monitoringresources.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_monitoringresources.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_MonitoringResources AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.MonitoringResources)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringresources.html
+type DataQualityJobDefinition_MonitoringResources struct {
+
+	// ClusterConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-monitoringresources.html#cfn-sagemaker-dataqualityjobdefinition-monitoringresources-clusterconfig
+	ClusterConfig *DataQualityJobDefinition_ClusterConfig `json:"ClusterConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_MonitoringResources) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.MonitoringResources"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_networkconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_networkconfig.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_NetworkConfig AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.NetworkConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-networkconfig.html
+type DataQualityJobDefinition_NetworkConfig struct {
+
+	// EnableInterContainerTrafficEncryption AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-networkconfig.html#cfn-sagemaker-dataqualityjobdefinition-networkconfig-enableintercontainertrafficencryption
+	EnableInterContainerTrafficEncryption bool `json:"EnableInterContainerTrafficEncryption,omitempty"`
+
+	// EnableNetworkIsolation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-networkconfig.html#cfn-sagemaker-dataqualityjobdefinition-networkconfig-enablenetworkisolation
+	EnableNetworkIsolation bool `json:"EnableNetworkIsolation,omitempty"`
+
+	// VpcConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-networkconfig.html#cfn-sagemaker-dataqualityjobdefinition-networkconfig-vpcconfig
+	VpcConfig *DataQualityJobDefinition_VpcConfig `json:"VpcConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_NetworkConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.NetworkConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_s3output.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_s3output.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_S3Output AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.S3Output)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-s3output.html
+type DataQualityJobDefinition_S3Output struct {
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-s3output.html#cfn-sagemaker-dataqualityjobdefinition-s3output-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// S3UploadMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-s3output.html#cfn-sagemaker-dataqualityjobdefinition-s3output-s3uploadmode
+	S3UploadMode string `json:"S3UploadMode,omitempty"`
+
+	// S3Uri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-s3output.html#cfn-sagemaker-dataqualityjobdefinition-s3output-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_S3Output) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.S3Output"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_statisticsresource.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_statisticsresource.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_StatisticsResource AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.StatisticsResource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-statisticsresource.html
+type DataQualityJobDefinition_StatisticsResource struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-statisticsresource.html#cfn-sagemaker-dataqualityjobdefinition-statisticsresource-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_StatisticsResource) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.StatisticsResource"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_stoppingcondition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_stoppingcondition.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_StoppingCondition AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.StoppingCondition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-stoppingcondition.html
+type DataQualityJobDefinition_StoppingCondition struct {
+
+	// MaxRuntimeInSeconds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-stoppingcondition.html#cfn-sagemaker-dataqualityjobdefinition-stoppingcondition-maxruntimeinseconds
+	MaxRuntimeInSeconds int `json:"MaxRuntimeInSeconds"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_StoppingCondition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.StoppingCondition"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_vpcconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-dataqualityjobdefinition_vpcconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DataQualityJobDefinition_VpcConfig AWS CloudFormation Resource (AWS::SageMaker::DataQualityJobDefinition.VpcConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-vpcconfig.html
+type DataQualityJobDefinition_VpcConfig struct {
+
+	// SecurityGroupIds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-vpcconfig.html#cfn-sagemaker-dataqualityjobdefinition-vpcconfig-securitygroupids
+	SecurityGroupIds []string `json:"SecurityGroupIds,omitempty"`
+
+	// Subnets AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-dataqualityjobdefinition-vpcconfig.html#cfn-sagemaker-dataqualityjobdefinition-vpcconfig-subnets
+	Subnets []string `json:"Subnets,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DataQualityJobDefinition_VpcConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DataQualityJobDefinition.VpcConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-device.go
+++ b/cloudformation/sagemaker/aws-sagemaker-device.go
@@ -1,0 +1,111 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Device AWS CloudFormation Resource (AWS::SageMaker::Device)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-device.html
+type Device struct {
+
+	// Device AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-device.html#cfn-sagemaker-device-device
+	Device interface{} `json:"Device,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-device.html#cfn-sagemaker-device-tags
+	Tags `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Device) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Device"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Device) MarshalJSON() ([]byte, error) {
+	type Properties Device
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Device) UnmarshalJSON(b []byte) error {
+	type Properties Device
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Device(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-device.go
+++ b/cloudformation/sagemaker/aws-sagemaker-device.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // Device AWS CloudFormation Resource (AWS::SageMaker::Device)
@@ -20,7 +21,7 @@ type Device struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-device.html#cfn-sagemaker-device-tags
-	Tags `json:"Tags,omitempty"`
+	Tags tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/sagemaker/aws-sagemaker-device_device.go
+++ b/cloudformation/sagemaker/aws-sagemaker-device_device.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Device_Device AWS CloudFormation Resource (AWS::SageMaker::Device.Device)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-device-device.html
+type Device_Device struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-device-device.html#cfn-sagemaker-device-device-description
+	Description string `json:"Description,omitempty"`
+
+	// DeviceName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-device-device.html#cfn-sagemaker-device-device-devicename
+	DeviceName string `json:"DeviceName,omitempty"`
+
+	// IotThingName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-device-device.html#cfn-sagemaker-device-device-iotthingname
+	IotThingName string `json:"IotThingName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Device_Device) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Device.Device"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-devicefleet.go
+++ b/cloudformation/sagemaker/aws-sagemaker-devicefleet.go
@@ -1,0 +1,121 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DeviceFleet AWS CloudFormation Resource (AWS::SageMaker::DeviceFleet)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-devicefleet.html
+type DeviceFleet struct {
+
+	// Description AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-devicefleet.html#cfn-sagemaker-devicefleet-description
+	Description string `json:"Description,omitempty"`
+
+	// OutputConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-devicefleet.html#cfn-sagemaker-devicefleet-outputconfig
+	OutputConfig *DeviceFleet_EdgeOutputConfig `json:"OutputConfig,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-devicefleet.html#cfn-sagemaker-devicefleet-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-devicefleet.html#cfn-sagemaker-devicefleet-tags
+	Tags `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DeviceFleet) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DeviceFleet"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r DeviceFleet) MarshalJSON() ([]byte, error) {
+	type Properties DeviceFleet
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *DeviceFleet) UnmarshalJSON(b []byte) error {
+	type Properties DeviceFleet
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = DeviceFleet(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-devicefleet.go
+++ b/cloudformation/sagemaker/aws-sagemaker-devicefleet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
 )
 
 // DeviceFleet AWS CloudFormation Resource (AWS::SageMaker::DeviceFleet)
@@ -30,7 +31,7 @@ type DeviceFleet struct {
 	// Tags AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-devicefleet.html#cfn-sagemaker-devicefleet-tags
-	Tags `json:"Tags,omitempty"`
+	Tags tags.Tag `json:"Tags,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`

--- a/cloudformation/sagemaker/aws-sagemaker-devicefleet_edgeoutputconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-devicefleet_edgeoutputconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// DeviceFleet_EdgeOutputConfig AWS CloudFormation Resource (AWS::SageMaker::DeviceFleet.EdgeOutputConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-devicefleet-edgeoutputconfig.html
+type DeviceFleet_EdgeOutputConfig struct {
+
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-devicefleet-edgeoutputconfig.html#cfn-sagemaker-devicefleet-edgeoutputconfig-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
+	// S3OutputLocation AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-devicefleet-edgeoutputconfig.html#cfn-sagemaker-devicefleet-edgeoutputconfig-s3outputlocation
+	S3OutputLocation string `json:"S3OutputLocation,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *DeviceFleet_EdgeOutputConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::DeviceFleet.EdgeOutputConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint.go
@@ -13,6 +13,11 @@ import (
 // See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpoint.html
 type Endpoint struct {
 
+	// DeploymentConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpoint.html#cfn-sagemaker-endpoint-deploymentconfig
+	DeploymentConfig *Endpoint_DeploymentConfig `json:"DeploymentConfig,omitempty"`
+
 	// EndpointConfigName AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpoint.html#cfn-sagemaker-endpoint-endpointconfigname

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint_alarm.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint_alarm.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Endpoint_Alarm AWS CloudFormation Resource (AWS::SageMaker::Endpoint.Alarm)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-alarm.html
+type Endpoint_Alarm struct {
+
+	// AlarmName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-alarm.html#cfn-sagemaker-endpoint-alarm-alarmname
+	AlarmName string `json:"AlarmName,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Endpoint_Alarm) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Endpoint.Alarm"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint_autorollbackconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint_autorollbackconfig.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Endpoint_AutoRollbackConfig AWS CloudFormation Resource (AWS::SageMaker::Endpoint.AutoRollbackConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-autorollbackconfig.html
+type Endpoint_AutoRollbackConfig struct {
+
+	// Alarms AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-autorollbackconfig.html#cfn-sagemaker-endpoint-autorollbackconfig-alarms
+	Alarms []Endpoint_Alarm `json:"Alarms,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Endpoint_AutoRollbackConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Endpoint.AutoRollbackConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint_bluegreenupdatepolicy.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint_bluegreenupdatepolicy.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Endpoint_BlueGreenUpdatePolicy AWS CloudFormation Resource (AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-bluegreenupdatepolicy.html
+type Endpoint_BlueGreenUpdatePolicy struct {
+
+	// MaximumExecutionTimeoutInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-bluegreenupdatepolicy.html#cfn-sagemaker-endpoint-bluegreenupdatepolicy-maximumexecutiontimeoutinseconds
+	MaximumExecutionTimeoutInSeconds int `json:"MaximumExecutionTimeoutInSeconds,omitempty"`
+
+	// TerminationWaitInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-bluegreenupdatepolicy.html#cfn-sagemaker-endpoint-bluegreenupdatepolicy-terminationwaitinseconds
+	TerminationWaitInSeconds int `json:"TerminationWaitInSeconds,omitempty"`
+
+	// TrafficRoutingConfiguration AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-bluegreenupdatepolicy.html#cfn-sagemaker-endpoint-bluegreenupdatepolicy-trafficroutingconfiguration
+	TrafficRoutingConfiguration *Endpoint_TrafficRoutingConfig `json:"TrafficRoutingConfiguration,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Endpoint_BlueGreenUpdatePolicy) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint_capacitysize.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint_capacitysize.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Endpoint_CapacitySize AWS CloudFormation Resource (AWS::SageMaker::Endpoint.CapacitySize)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-capacitysize.html
+type Endpoint_CapacitySize struct {
+
+	// Type AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-capacitysize.html#cfn-sagemaker-endpoint-capacitysize-type
+	Type string `json:"Type,omitempty"`
+
+	// Value AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-capacitysize.html#cfn-sagemaker-endpoint-capacitysize-value
+	Value int `json:"Value"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Endpoint_CapacitySize) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Endpoint.CapacitySize"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint_deploymentconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint_deploymentconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Endpoint_DeploymentConfig AWS CloudFormation Resource (AWS::SageMaker::Endpoint.DeploymentConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-deploymentconfig.html
+type Endpoint_DeploymentConfig struct {
+
+	// AutoRollbackConfiguration AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-deploymentconfig.html#cfn-sagemaker-endpoint-deploymentconfig-autorollbackconfiguration
+	AutoRollbackConfiguration *Endpoint_AutoRollbackConfig `json:"AutoRollbackConfiguration,omitempty"`
+
+	// BlueGreenUpdatePolicy AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-deploymentconfig.html#cfn-sagemaker-endpoint-deploymentconfig-bluegreenupdatepolicy
+	BlueGreenUpdatePolicy *Endpoint_BlueGreenUpdatePolicy `json:"BlueGreenUpdatePolicy,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Endpoint_DeploymentConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Endpoint.DeploymentConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-endpoint_trafficroutingconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-endpoint_trafficroutingconfig.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Endpoint_TrafficRoutingConfig AWS CloudFormation Resource (AWS::SageMaker::Endpoint.TrafficRoutingConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-trafficroutingconfig.html
+type Endpoint_TrafficRoutingConfig struct {
+
+	// CanarySize AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-trafficroutingconfig.html#cfn-sagemaker-endpoint-trafficroutingconfig-canarysize
+	CanarySize *Endpoint_CapacitySize `json:"CanarySize,omitempty"`
+
+	// Type AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-trafficroutingconfig.html#cfn-sagemaker-endpoint-trafficroutingconfig-type
+	Type string `json:"Type,omitempty"`
+
+	// WaitIntervalInSeconds AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-endpoint-trafficroutingconfig.html#cfn-sagemaker-endpoint-trafficroutingconfig-waitintervalinseconds
+	WaitIntervalInSeconds int `json:"WaitIntervalInSeconds,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Endpoint_TrafficRoutingConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Endpoint.TrafficRoutingConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition.go
@@ -1,0 +1,152 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// ModelBiasJobDefinition AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html
+type ModelBiasJobDefinition struct {
+
+	// JobDefinitionName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-jobdefinitionname
+	JobDefinitionName string `json:"JobDefinitionName,omitempty"`
+
+	// JobResources AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-jobresources
+	JobResources *ModelBiasJobDefinition_MonitoringResources `json:"JobResources,omitempty"`
+
+	// ModelBiasAppSpecification AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasappspecification
+	ModelBiasAppSpecification *ModelBiasJobDefinition_ModelBiasAppSpecification `json:"ModelBiasAppSpecification,omitempty"`
+
+	// ModelBiasBaselineConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasbaselineconfig
+	ModelBiasBaselineConfig *ModelBiasJobDefinition_ModelBiasBaselineConfig `json:"ModelBiasBaselineConfig,omitempty"`
+
+	// ModelBiasJobInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasjobinput
+	ModelBiasJobInput *ModelBiasJobDefinition_ModelBiasJobInput `json:"ModelBiasJobInput,omitempty"`
+
+	// ModelBiasJobOutputConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasjoboutputconfig
+	ModelBiasJobOutputConfig *ModelBiasJobDefinition_MonitoringOutputConfig `json:"ModelBiasJobOutputConfig,omitempty"`
+
+	// NetworkConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-networkconfig
+	NetworkConfig *ModelBiasJobDefinition_NetworkConfig `json:"NetworkConfig,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// StoppingCondition AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-stoppingcondition
+	StoppingCondition *ModelBiasJobDefinition_StoppingCondition `json:"StoppingCondition,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelbiasjobdefinition.html#cfn-sagemaker-modelbiasjobdefinition-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ModelBiasJobDefinition) MarshalJSON() ([]byte, error) {
+	type Properties ModelBiasJobDefinition
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ModelBiasJobDefinition) UnmarshalJSON(b []byte) error {
+	type Properties ModelBiasJobDefinition
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ModelBiasJobDefinition(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_clusterconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_clusterconfig.go
@@ -1,0 +1,50 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_ClusterConfig AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-clusterconfig.html
+type ModelBiasJobDefinition_ClusterConfig struct {
+
+	// InstanceCount AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-clusterconfig.html#cfn-sagemaker-modelbiasjobdefinition-clusterconfig-instancecount
+	InstanceCount int `json:"InstanceCount"`
+
+	// InstanceType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-clusterconfig.html#cfn-sagemaker-modelbiasjobdefinition-clusterconfig-instancetype
+	InstanceType string `json:"InstanceType,omitempty"`
+
+	// VolumeKmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-clusterconfig.html#cfn-sagemaker-modelbiasjobdefinition-clusterconfig-volumekmskeyid
+	VolumeKmsKeyId string `json:"VolumeKmsKeyId,omitempty"`
+
+	// VolumeSizeInGB AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-clusterconfig.html#cfn-sagemaker-modelbiasjobdefinition-clusterconfig-volumesizeingb
+	VolumeSizeInGB int `json:"VolumeSizeInGB"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_ClusterConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_constraintsresource.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_constraintsresource.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_ConstraintsResource AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-constraintsresource.html
+type ModelBiasJobDefinition_ConstraintsResource struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-constraintsresource.html#cfn-sagemaker-modelbiasjobdefinition-constraintsresource-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_ConstraintsResource) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_endpointinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_endpointinput.go
@@ -1,0 +1,80 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_EndpointInput AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.EndpointInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html
+type ModelBiasJobDefinition_EndpointInput struct {
+
+	// EndTimeOffset AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-endtimeoffset
+	EndTimeOffset string `json:"EndTimeOffset,omitempty"`
+
+	// EndpointName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-endpointname
+	EndpointName string `json:"EndpointName,omitempty"`
+
+	// FeaturesAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-featuresattribute
+	FeaturesAttribute string `json:"FeaturesAttribute,omitempty"`
+
+	// InferenceAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-inferenceattribute
+	InferenceAttribute string `json:"InferenceAttribute,omitempty"`
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// ProbabilityAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-probabilityattribute
+	ProbabilityAttribute string `json:"ProbabilityAttribute,omitempty"`
+
+	// ProbabilityThresholdAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-probabilitythresholdattribute
+	ProbabilityThresholdAttribute float64 `json:"ProbabilityThresholdAttribute,omitempty"`
+
+	// S3DataDistributionType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-s3datadistributiontype
+	S3DataDistributionType string `json:"S3DataDistributionType,omitempty"`
+
+	// S3InputMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-s3inputmode
+	S3InputMode string `json:"S3InputMode,omitempty"`
+
+	// StartTimeOffset AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-endpointinput.html#cfn-sagemaker-modelbiasjobdefinition-endpointinput-starttimeoffset
+	StartTimeOffset string `json:"StartTimeOffset,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_EndpointInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.EndpointInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_environment.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_environment.go
@@ -1,0 +1,30 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_Environment AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.Environment)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-environment.html
+type ModelBiasJobDefinition_Environment struct {
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_Environment) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.Environment"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_modelbiasappspecification.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_modelbiasappspecification.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_ModelBiasAppSpecification AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasappspecification.html
+type ModelBiasJobDefinition_ModelBiasAppSpecification struct {
+
+	// ConfigUri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasappspecification.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasappspecification-configuri
+	ConfigUri string `json:"ConfigUri,omitempty"`
+
+	// Environment AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasappspecification.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasappspecification-environment
+	Environment *ModelBiasJobDefinition_Environment `json:"Environment,omitempty"`
+
+	// ImageUri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasappspecification.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasappspecification-imageuri
+	ImageUri string `json:"ImageUri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_ModelBiasAppSpecification) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_modelbiasbaselineconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_modelbiasbaselineconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_ModelBiasBaselineConfig AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasbaselineconfig.html
+type ModelBiasJobDefinition_ModelBiasBaselineConfig struct {
+
+	// BaseliningJobName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasbaselineconfig.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasbaselineconfig-baseliningjobname
+	BaseliningJobName string `json:"BaseliningJobName,omitempty"`
+
+	// ConstraintsResource AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasbaselineconfig.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasbaselineconfig-constraintsresource
+	ConstraintsResource *ModelBiasJobDefinition_ConstraintsResource `json:"ConstraintsResource,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_ModelBiasBaselineConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_modelbiasjobinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_modelbiasjobinput.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_ModelBiasJobInput AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasjobinput.html
+type ModelBiasJobDefinition_ModelBiasJobInput struct {
+
+	// EndpointInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasjobinput.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasjobinput-endpointinput
+	EndpointInput *ModelBiasJobDefinition_EndpointInput `json:"EndpointInput,omitempty"`
+
+	// GroundTruthS3Input AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-modelbiasjobinput.html#cfn-sagemaker-modelbiasjobdefinition-modelbiasjobinput-groundtruths3input
+	GroundTruthS3Input *ModelBiasJobDefinition_MonitoringGroundTruthS3Input `json:"GroundTruthS3Input,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_ModelBiasJobInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringgroundtruths3input.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringgroundtruths3input.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_MonitoringGroundTruthS3Input AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringgroundtruths3input.html
+type ModelBiasJobDefinition_MonitoringGroundTruthS3Input struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringgroundtruths3input.html#cfn-sagemaker-modelbiasjobdefinition-monitoringgroundtruths3input-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_MonitoringGroundTruthS3Input) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringoutput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringoutput.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_MonitoringOutput AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringoutput.html
+type ModelBiasJobDefinition_MonitoringOutput struct {
+
+	// S3Output AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringoutput.html#cfn-sagemaker-modelbiasjobdefinition-monitoringoutput-s3output
+	S3Output *ModelBiasJobDefinition_S3Output `json:"S3Output,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_MonitoringOutput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringoutputconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringoutputconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_MonitoringOutputConfig AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringoutputconfig.html
+type ModelBiasJobDefinition_MonitoringOutputConfig struct {
+
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-modelbiasjobdefinition-monitoringoutputconfig-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
+	// MonitoringOutputs AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-modelbiasjobdefinition-monitoringoutputconfig-monitoringoutputs
+	MonitoringOutputs []ModelBiasJobDefinition_MonitoringOutput `json:"MonitoringOutputs,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_MonitoringOutputConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringresources.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_monitoringresources.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_MonitoringResources AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringresources.html
+type ModelBiasJobDefinition_MonitoringResources struct {
+
+	// ClusterConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-monitoringresources.html#cfn-sagemaker-modelbiasjobdefinition-monitoringresources-clusterconfig
+	ClusterConfig *ModelBiasJobDefinition_ClusterConfig `json:"ClusterConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_MonitoringResources) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_networkconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_networkconfig.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_NetworkConfig AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-networkconfig.html
+type ModelBiasJobDefinition_NetworkConfig struct {
+
+	// EnableInterContainerTrafficEncryption AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-networkconfig.html#cfn-sagemaker-modelbiasjobdefinition-networkconfig-enableintercontainertrafficencryption
+	EnableInterContainerTrafficEncryption bool `json:"EnableInterContainerTrafficEncryption,omitempty"`
+
+	// EnableNetworkIsolation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-networkconfig.html#cfn-sagemaker-modelbiasjobdefinition-networkconfig-enablenetworkisolation
+	EnableNetworkIsolation bool `json:"EnableNetworkIsolation,omitempty"`
+
+	// VpcConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-networkconfig.html#cfn-sagemaker-modelbiasjobdefinition-networkconfig-vpcconfig
+	VpcConfig *ModelBiasJobDefinition_VpcConfig `json:"VpcConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_NetworkConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_s3output.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_s3output.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_S3Output AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.S3Output)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-s3output.html
+type ModelBiasJobDefinition_S3Output struct {
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-s3output.html#cfn-sagemaker-modelbiasjobdefinition-s3output-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// S3UploadMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-s3output.html#cfn-sagemaker-modelbiasjobdefinition-s3output-s3uploadmode
+	S3UploadMode string `json:"S3UploadMode,omitempty"`
+
+	// S3Uri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-s3output.html#cfn-sagemaker-modelbiasjobdefinition-s3output-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_S3Output) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.S3Output"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_stoppingcondition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_stoppingcondition.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_StoppingCondition AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-stoppingcondition.html
+type ModelBiasJobDefinition_StoppingCondition struct {
+
+	// MaxRuntimeInSeconds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-stoppingcondition.html#cfn-sagemaker-modelbiasjobdefinition-stoppingcondition-maxruntimeinseconds
+	MaxRuntimeInSeconds int `json:"MaxRuntimeInSeconds"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_StoppingCondition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_vpcconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelbiasjobdefinition_vpcconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelBiasJobDefinition_VpcConfig AWS CloudFormation Resource (AWS::SageMaker::ModelBiasJobDefinition.VpcConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-vpcconfig.html
+type ModelBiasJobDefinition_VpcConfig struct {
+
+	// SecurityGroupIds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-vpcconfig.html#cfn-sagemaker-modelbiasjobdefinition-vpcconfig-securitygroupids
+	SecurityGroupIds []string `json:"SecurityGroupIds,omitempty"`
+
+	// Subnets AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelbiasjobdefinition-vpcconfig.html#cfn-sagemaker-modelbiasjobdefinition-vpcconfig-subnets
+	Subnets []string `json:"Subnets,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelBiasJobDefinition_VpcConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelBiasJobDefinition.VpcConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition.go
@@ -1,0 +1,152 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// ModelExplainabilityJobDefinition AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html
+type ModelExplainabilityJobDefinition struct {
+
+	// JobDefinitionName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-jobdefinitionname
+	JobDefinitionName string `json:"JobDefinitionName,omitempty"`
+
+	// JobResources AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-jobresources
+	JobResources *ModelExplainabilityJobDefinition_MonitoringResources `json:"JobResources,omitempty"`
+
+	// ModelExplainabilityAppSpecification AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification
+	ModelExplainabilityAppSpecification *ModelExplainabilityJobDefinition_ModelExplainabilityAppSpecification `json:"ModelExplainabilityAppSpecification,omitempty"`
+
+	// ModelExplainabilityBaselineConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilitybaselineconfig
+	ModelExplainabilityBaselineConfig *ModelExplainabilityJobDefinition_ModelExplainabilityBaselineConfig `json:"ModelExplainabilityBaselineConfig,omitempty"`
+
+	// ModelExplainabilityJobInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityjobinput
+	ModelExplainabilityJobInput *ModelExplainabilityJobDefinition_ModelExplainabilityJobInput `json:"ModelExplainabilityJobInput,omitempty"`
+
+	// ModelExplainabilityJobOutputConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityjoboutputconfig
+	ModelExplainabilityJobOutputConfig *ModelExplainabilityJobDefinition_MonitoringOutputConfig `json:"ModelExplainabilityJobOutputConfig,omitempty"`
+
+	// NetworkConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-networkconfig
+	NetworkConfig *ModelExplainabilityJobDefinition_NetworkConfig `json:"NetworkConfig,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// StoppingCondition AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-stoppingcondition
+	StoppingCondition *ModelExplainabilityJobDefinition_StoppingCondition `json:"StoppingCondition,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelexplainabilityjobdefinition.html#cfn-sagemaker-modelexplainabilityjobdefinition-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ModelExplainabilityJobDefinition) MarshalJSON() ([]byte, error) {
+	type Properties ModelExplainabilityJobDefinition
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ModelExplainabilityJobDefinition) UnmarshalJSON(b []byte) error {
+	type Properties ModelExplainabilityJobDefinition
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ModelExplainabilityJobDefinition(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_clusterconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_clusterconfig.go
@@ -1,0 +1,50 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_ClusterConfig AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-clusterconfig.html
+type ModelExplainabilityJobDefinition_ClusterConfig struct {
+
+	// InstanceCount AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-clusterconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-clusterconfig-instancecount
+	InstanceCount int `json:"InstanceCount"`
+
+	// InstanceType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-clusterconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-clusterconfig-instancetype
+	InstanceType string `json:"InstanceType,omitempty"`
+
+	// VolumeKmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-clusterconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-clusterconfig-volumekmskeyid
+	VolumeKmsKeyId string `json:"VolumeKmsKeyId,omitempty"`
+
+	// VolumeSizeInGB AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-clusterconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-clusterconfig-volumesizeingb
+	VolumeSizeInGB int `json:"VolumeSizeInGB"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_ClusterConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_constraintsresource.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_constraintsresource.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_ConstraintsResource AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-constraintsresource.html
+type ModelExplainabilityJobDefinition_ConstraintsResource struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-constraintsresource.html#cfn-sagemaker-modelexplainabilityjobdefinition-constraintsresource-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_ConstraintsResource) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_endpointinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_endpointinput.go
@@ -1,0 +1,65 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_EndpointInput AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html
+type ModelExplainabilityJobDefinition_EndpointInput struct {
+
+	// EndpointName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-endpointname
+	EndpointName string `json:"EndpointName,omitempty"`
+
+	// FeaturesAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-featuresattribute
+	FeaturesAttribute string `json:"FeaturesAttribute,omitempty"`
+
+	// InferenceAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-inferenceattribute
+	InferenceAttribute string `json:"InferenceAttribute,omitempty"`
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// ProbabilityAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-probabilityattribute
+	ProbabilityAttribute string `json:"ProbabilityAttribute,omitempty"`
+
+	// S3DataDistributionType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-s3datadistributiontype
+	S3DataDistributionType string `json:"S3DataDistributionType,omitempty"`
+
+	// S3InputMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-endpointinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-endpointinput-s3inputmode
+	S3InputMode string `json:"S3InputMode,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_EndpointInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_environment.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_environment.go
@@ -1,0 +1,30 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_Environment AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.Environment)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-environment.html
+type ModelExplainabilityJobDefinition_Environment struct {
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_Environment) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.Environment"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_modelexplainabilityappspecification.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_modelexplainabilityappspecification.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_ModelExplainabilityAppSpecification AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification.html
+type ModelExplainabilityJobDefinition_ModelExplainabilityAppSpecification struct {
+
+	// ConfigUri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification-configuri
+	ConfigUri string `json:"ConfigUri,omitempty"`
+
+	// Environment AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification-environment
+	Environment *ModelExplainabilityJobDefinition_Environment `json:"Environment,omitempty"`
+
+	// ImageUri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityappspecification-imageuri
+	ImageUri string `json:"ImageUri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_ModelExplainabilityAppSpecification) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_modelexplainabilitybaselineconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_modelexplainabilitybaselineconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_ModelExplainabilityBaselineConfig AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilitybaselineconfig.html
+type ModelExplainabilityJobDefinition_ModelExplainabilityBaselineConfig struct {
+
+	// BaseliningJobName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilitybaselineconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilitybaselineconfig-baseliningjobname
+	BaseliningJobName string `json:"BaseliningJobName,omitempty"`
+
+	// ConstraintsResource AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilitybaselineconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilitybaselineconfig-constraintsresource
+	ConstraintsResource *ModelExplainabilityJobDefinition_ConstraintsResource `json:"ConstraintsResource,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_ModelExplainabilityBaselineConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_modelexplainabilityjobinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_modelexplainabilityjobinput.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_ModelExplainabilityJobInput AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityjobinput.html
+type ModelExplainabilityJobDefinition_ModelExplainabilityJobInput struct {
+
+	// EndpointInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityjobinput.html#cfn-sagemaker-modelexplainabilityjobdefinition-modelexplainabilityjobinput-endpointinput
+	EndpointInput *ModelExplainabilityJobDefinition_EndpointInput `json:"EndpointInput,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_ModelExplainabilityJobInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_monitoringoutput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_monitoringoutput.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_MonitoringOutput AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringoutput.html
+type ModelExplainabilityJobDefinition_MonitoringOutput struct {
+
+	// S3Output AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringoutput.html#cfn-sagemaker-modelexplainabilityjobdefinition-monitoringoutput-s3output
+	S3Output *ModelExplainabilityJobDefinition_S3Output `json:"S3Output,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_MonitoringOutput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_monitoringoutputconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_monitoringoutputconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_MonitoringOutputConfig AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringoutputconfig.html
+type ModelExplainabilityJobDefinition_MonitoringOutputConfig struct {
+
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-monitoringoutputconfig-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
+	// MonitoringOutputs AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-monitoringoutputconfig-monitoringoutputs
+	MonitoringOutputs []ModelExplainabilityJobDefinition_MonitoringOutput `json:"MonitoringOutputs,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_MonitoringOutputConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_monitoringresources.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_monitoringresources.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_MonitoringResources AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringresources.html
+type ModelExplainabilityJobDefinition_MonitoringResources struct {
+
+	// ClusterConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-monitoringresources.html#cfn-sagemaker-modelexplainabilityjobdefinition-monitoringresources-clusterconfig
+	ClusterConfig *ModelExplainabilityJobDefinition_ClusterConfig `json:"ClusterConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_MonitoringResources) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_networkconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_networkconfig.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_NetworkConfig AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-networkconfig.html
+type ModelExplainabilityJobDefinition_NetworkConfig struct {
+
+	// EnableInterContainerTrafficEncryption AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-networkconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-networkconfig-enableintercontainertrafficencryption
+	EnableInterContainerTrafficEncryption bool `json:"EnableInterContainerTrafficEncryption,omitempty"`
+
+	// EnableNetworkIsolation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-networkconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-networkconfig-enablenetworkisolation
+	EnableNetworkIsolation bool `json:"EnableNetworkIsolation,omitempty"`
+
+	// VpcConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-networkconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-networkconfig-vpcconfig
+	VpcConfig *ModelExplainabilityJobDefinition_VpcConfig `json:"VpcConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_NetworkConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_s3output.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_s3output.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_S3Output AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-s3output.html
+type ModelExplainabilityJobDefinition_S3Output struct {
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-s3output.html#cfn-sagemaker-modelexplainabilityjobdefinition-s3output-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// S3UploadMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-s3output.html#cfn-sagemaker-modelexplainabilityjobdefinition-s3output-s3uploadmode
+	S3UploadMode string `json:"S3UploadMode,omitempty"`
+
+	// S3Uri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-s3output.html#cfn-sagemaker-modelexplainabilityjobdefinition-s3output-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_S3Output) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_stoppingcondition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_stoppingcondition.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_StoppingCondition AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-stoppingcondition.html
+type ModelExplainabilityJobDefinition_StoppingCondition struct {
+
+	// MaxRuntimeInSeconds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-stoppingcondition.html#cfn-sagemaker-modelexplainabilityjobdefinition-stoppingcondition-maxruntimeinseconds
+	MaxRuntimeInSeconds int `json:"MaxRuntimeInSeconds"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_StoppingCondition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_vpcconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelexplainabilityjobdefinition_vpcconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelExplainabilityJobDefinition_VpcConfig AWS CloudFormation Resource (AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-vpcconfig.html
+type ModelExplainabilityJobDefinition_VpcConfig struct {
+
+	// SecurityGroupIds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-vpcconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-vpcconfig-securitygroupids
+	SecurityGroupIds []string `json:"SecurityGroupIds,omitempty"`
+
+	// Subnets AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelexplainabilityjobdefinition-vpcconfig.html#cfn-sagemaker-modelexplainabilityjobdefinition-vpcconfig-subnets
+	Subnets []string `json:"Subnets,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelExplainabilityJobDefinition_VpcConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelpackagegroup.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelpackagegroup.go
@@ -1,0 +1,122 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// ModelPackageGroup AWS CloudFormation Resource (AWS::SageMaker::ModelPackageGroup)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelpackagegroup.html
+type ModelPackageGroup struct {
+
+	// ModelPackageGroupDescription AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelpackagegroup.html#cfn-sagemaker-modelpackagegroup-modelpackagegroupdescription
+	ModelPackageGroupDescription string `json:"ModelPackageGroupDescription,omitempty"`
+
+	// ModelPackageGroupName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelpackagegroup.html#cfn-sagemaker-modelpackagegroup-modelpackagegroupname
+	ModelPackageGroupName string `json:"ModelPackageGroupName,omitempty"`
+
+	// ModelPackageGroupPolicy AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelpackagegroup.html#cfn-sagemaker-modelpackagegroup-modelpackagegrouppolicy
+	ModelPackageGroupPolicy interface{} `json:"ModelPackageGroupPolicy,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelpackagegroup.html#cfn-sagemaker-modelpackagegroup-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelPackageGroup) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelPackageGroup"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ModelPackageGroup) MarshalJSON() ([]byte, error) {
+	type Properties ModelPackageGroup
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ModelPackageGroup) UnmarshalJSON(b []byte) error {
+	type Properties ModelPackageGroup
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ModelPackageGroup(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition.go
@@ -1,0 +1,152 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// ModelQualityJobDefinition AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html
+type ModelQualityJobDefinition struct {
+
+	// JobDefinitionName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-jobdefinitionname
+	JobDefinitionName string `json:"JobDefinitionName,omitempty"`
+
+	// JobResources AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-jobresources
+	JobResources *ModelQualityJobDefinition_MonitoringResources `json:"JobResources,omitempty"`
+
+	// ModelQualityAppSpecification AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification
+	ModelQualityAppSpecification *ModelQualityJobDefinition_ModelQualityAppSpecification `json:"ModelQualityAppSpecification,omitempty"`
+
+	// ModelQualityBaselineConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-modelqualitybaselineconfig
+	ModelQualityBaselineConfig *ModelQualityJobDefinition_ModelQualityBaselineConfig `json:"ModelQualityBaselineConfig,omitempty"`
+
+	// ModelQualityJobInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityjobinput
+	ModelQualityJobInput *ModelQualityJobDefinition_ModelQualityJobInput `json:"ModelQualityJobInput,omitempty"`
+
+	// ModelQualityJobOutputConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityjoboutputconfig
+	ModelQualityJobOutputConfig *ModelQualityJobDefinition_MonitoringOutputConfig `json:"ModelQualityJobOutputConfig,omitempty"`
+
+	// NetworkConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-networkconfig
+	NetworkConfig *ModelQualityJobDefinition_NetworkConfig `json:"NetworkConfig,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// StoppingCondition AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-stoppingcondition
+	StoppingCondition *ModelQualityJobDefinition_StoppingCondition `json:"StoppingCondition,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-modelqualityjobdefinition.html#cfn-sagemaker-modelqualityjobdefinition-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r ModelQualityJobDefinition) MarshalJSON() ([]byte, error) {
+	type Properties ModelQualityJobDefinition
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *ModelQualityJobDefinition) UnmarshalJSON(b []byte) error {
+	type Properties ModelQualityJobDefinition
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = ModelQualityJobDefinition(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_clusterconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_clusterconfig.go
@@ -1,0 +1,50 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_ClusterConfig AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-clusterconfig.html
+type ModelQualityJobDefinition_ClusterConfig struct {
+
+	// InstanceCount AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-clusterconfig.html#cfn-sagemaker-modelqualityjobdefinition-clusterconfig-instancecount
+	InstanceCount int `json:"InstanceCount"`
+
+	// InstanceType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-clusterconfig.html#cfn-sagemaker-modelqualityjobdefinition-clusterconfig-instancetype
+	InstanceType string `json:"InstanceType,omitempty"`
+
+	// VolumeKmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-clusterconfig.html#cfn-sagemaker-modelqualityjobdefinition-clusterconfig-volumekmskeyid
+	VolumeKmsKeyId string `json:"VolumeKmsKeyId,omitempty"`
+
+	// VolumeSizeInGB AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-clusterconfig.html#cfn-sagemaker-modelqualityjobdefinition-clusterconfig-volumesizeingb
+	VolumeSizeInGB int `json:"VolumeSizeInGB"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_ClusterConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_constraintsresource.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_constraintsresource.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_ConstraintsResource AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-constraintsresource.html
+type ModelQualityJobDefinition_ConstraintsResource struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-constraintsresource.html#cfn-sagemaker-modelqualityjobdefinition-constraintsresource-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_ConstraintsResource) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_endpointinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_endpointinput.go
@@ -1,0 +1,75 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_EndpointInput AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.EndpointInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html
+type ModelQualityJobDefinition_EndpointInput struct {
+
+	// EndTimeOffset AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-endtimeoffset
+	EndTimeOffset string `json:"EndTimeOffset,omitempty"`
+
+	// EndpointName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-endpointname
+	EndpointName string `json:"EndpointName,omitempty"`
+
+	// InferenceAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-inferenceattribute
+	InferenceAttribute string `json:"InferenceAttribute,omitempty"`
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// ProbabilityAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-probabilityattribute
+	ProbabilityAttribute string `json:"ProbabilityAttribute,omitempty"`
+
+	// ProbabilityThresholdAttribute AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-probabilitythresholdattribute
+	ProbabilityThresholdAttribute float64 `json:"ProbabilityThresholdAttribute,omitempty"`
+
+	// S3DataDistributionType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-s3datadistributiontype
+	S3DataDistributionType string `json:"S3DataDistributionType,omitempty"`
+
+	// S3InputMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-s3inputmode
+	S3InputMode string `json:"S3InputMode,omitempty"`
+
+	// StartTimeOffset AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-endpointinput.html#cfn-sagemaker-modelqualityjobdefinition-endpointinput-starttimeoffset
+	StartTimeOffset string `json:"StartTimeOffset,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_EndpointInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.EndpointInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_environment.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_environment.go
@@ -1,0 +1,30 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_Environment AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.Environment)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-environment.html
+type ModelQualityJobDefinition_Environment struct {
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_Environment) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.Environment"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_modelqualityappspecification.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_modelqualityappspecification.go
@@ -1,0 +1,65 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_ModelQualityAppSpecification AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html
+type ModelQualityJobDefinition_ModelQualityAppSpecification struct {
+
+	// ContainerArguments AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-containerarguments
+	ContainerArguments []string `json:"ContainerArguments,omitempty"`
+
+	// ContainerEntrypoint AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-containerentrypoint
+	ContainerEntrypoint []string `json:"ContainerEntrypoint,omitempty"`
+
+	// Environment AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-environment
+	Environment *ModelQualityJobDefinition_Environment `json:"Environment,omitempty"`
+
+	// ImageUri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-imageuri
+	ImageUri string `json:"ImageUri,omitempty"`
+
+	// PostAnalyticsProcessorSourceUri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-postanalyticsprocessorsourceuri
+	PostAnalyticsProcessorSourceUri string `json:"PostAnalyticsProcessorSourceUri,omitempty"`
+
+	// ProblemType AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-problemtype
+	ProblemType string `json:"ProblemType,omitempty"`
+
+	// RecordPreprocessorSourceUri AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityappspecification.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityappspecification-recordpreprocessorsourceuri
+	RecordPreprocessorSourceUri string `json:"RecordPreprocessorSourceUri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_ModelQualityAppSpecification) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_modelqualitybaselineconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_modelqualitybaselineconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_ModelQualityBaselineConfig AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualitybaselineconfig.html
+type ModelQualityJobDefinition_ModelQualityBaselineConfig struct {
+
+	// BaseliningJobName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualitybaselineconfig.html#cfn-sagemaker-modelqualityjobdefinition-modelqualitybaselineconfig-baseliningjobname
+	BaseliningJobName string `json:"BaseliningJobName,omitempty"`
+
+	// ConstraintsResource AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualitybaselineconfig.html#cfn-sagemaker-modelqualityjobdefinition-modelqualitybaselineconfig-constraintsresource
+	ConstraintsResource *ModelQualityJobDefinition_ConstraintsResource `json:"ConstraintsResource,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_ModelQualityBaselineConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_modelqualityjobinput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_modelqualityjobinput.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_ModelQualityJobInput AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityjobinput.html
+type ModelQualityJobDefinition_ModelQualityJobInput struct {
+
+	// EndpointInput AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityjobinput.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityjobinput-endpointinput
+	EndpointInput *ModelQualityJobDefinition_EndpointInput `json:"EndpointInput,omitempty"`
+
+	// GroundTruthS3Input AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-modelqualityjobinput.html#cfn-sagemaker-modelqualityjobdefinition-modelqualityjobinput-groundtruths3input
+	GroundTruthS3Input *ModelQualityJobDefinition_MonitoringGroundTruthS3Input `json:"GroundTruthS3Input,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_ModelQualityJobInput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringgroundtruths3input.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringgroundtruths3input.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_MonitoringGroundTruthS3Input AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringgroundtruths3input.html
+type ModelQualityJobDefinition_MonitoringGroundTruthS3Input struct {
+
+	// S3Uri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringgroundtruths3input.html#cfn-sagemaker-modelqualityjobdefinition-monitoringgroundtruths3input-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_MonitoringGroundTruthS3Input) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringoutput.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringoutput.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_MonitoringOutput AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringoutput.html
+type ModelQualityJobDefinition_MonitoringOutput struct {
+
+	// S3Output AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringoutput.html#cfn-sagemaker-modelqualityjobdefinition-monitoringoutput-s3output
+	S3Output *ModelQualityJobDefinition_S3Output `json:"S3Output,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_MonitoringOutput) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringoutputconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringoutputconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_MonitoringOutputConfig AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringoutputconfig.html
+type ModelQualityJobDefinition_MonitoringOutputConfig struct {
+
+	// KmsKeyId AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-modelqualityjobdefinition-monitoringoutputconfig-kmskeyid
+	KmsKeyId string `json:"KmsKeyId,omitempty"`
+
+	// MonitoringOutputs AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringoutputconfig.html#cfn-sagemaker-modelqualityjobdefinition-monitoringoutputconfig-monitoringoutputs
+	MonitoringOutputs []ModelQualityJobDefinition_MonitoringOutput `json:"MonitoringOutputs,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_MonitoringOutputConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringresources.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_monitoringresources.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_MonitoringResources AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringresources.html
+type ModelQualityJobDefinition_MonitoringResources struct {
+
+	// ClusterConfig AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-monitoringresources.html#cfn-sagemaker-modelqualityjobdefinition-monitoringresources-clusterconfig
+	ClusterConfig *ModelQualityJobDefinition_ClusterConfig `json:"ClusterConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_MonitoringResources) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_networkconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_networkconfig.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_NetworkConfig AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-networkconfig.html
+type ModelQualityJobDefinition_NetworkConfig struct {
+
+	// EnableInterContainerTrafficEncryption AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-networkconfig.html#cfn-sagemaker-modelqualityjobdefinition-networkconfig-enableintercontainertrafficencryption
+	EnableInterContainerTrafficEncryption bool `json:"EnableInterContainerTrafficEncryption,omitempty"`
+
+	// EnableNetworkIsolation AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-networkconfig.html#cfn-sagemaker-modelqualityjobdefinition-networkconfig-enablenetworkisolation
+	EnableNetworkIsolation bool `json:"EnableNetworkIsolation,omitempty"`
+
+	// VpcConfig AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-networkconfig.html#cfn-sagemaker-modelqualityjobdefinition-networkconfig-vpcconfig
+	VpcConfig *ModelQualityJobDefinition_VpcConfig `json:"VpcConfig,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_NetworkConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_s3output.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_s3output.go
@@ -1,0 +1,45 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_S3Output AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.S3Output)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-s3output.html
+type ModelQualityJobDefinition_S3Output struct {
+
+	// LocalPath AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-s3output.html#cfn-sagemaker-modelqualityjobdefinition-s3output-localpath
+	LocalPath string `json:"LocalPath,omitempty"`
+
+	// S3UploadMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-s3output.html#cfn-sagemaker-modelqualityjobdefinition-s3output-s3uploadmode
+	S3UploadMode string `json:"S3UploadMode,omitempty"`
+
+	// S3Uri AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-s3output.html#cfn-sagemaker-modelqualityjobdefinition-s3output-s3uri
+	S3Uri string `json:"S3Uri,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_S3Output) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.S3Output"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_stoppingcondition.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_stoppingcondition.go
@@ -1,0 +1,35 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_StoppingCondition AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-stoppingcondition.html
+type ModelQualityJobDefinition_StoppingCondition struct {
+
+	// MaxRuntimeInSeconds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-stoppingcondition.html#cfn-sagemaker-modelqualityjobdefinition-stoppingcondition-maxruntimeinseconds
+	MaxRuntimeInSeconds int `json:"MaxRuntimeInSeconds"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_StoppingCondition) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_vpcconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-modelqualityjobdefinition_vpcconfig.go
@@ -1,0 +1,40 @@
+package sagemaker
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// ModelQualityJobDefinition_VpcConfig AWS CloudFormation Resource (AWS::SageMaker::ModelQualityJobDefinition.VpcConfig)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-vpcconfig.html
+type ModelQualityJobDefinition_VpcConfig struct {
+
+	// SecurityGroupIds AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-vpcconfig.html#cfn-sagemaker-modelqualityjobdefinition-vpcconfig-securitygroupids
+	SecurityGroupIds []string `json:"SecurityGroupIds,omitempty"`
+
+	// Subnets AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-modelqualityjobdefinition-vpcconfig.html#cfn-sagemaker-modelqualityjobdefinition-vpcconfig-subnets
+	Subnets []string `json:"Subnets,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *ModelQualityJobDefinition_VpcConfig) AWSCloudFormationType() string {
+	return "AWS::SageMaker::ModelQualityJobDefinition.VpcConfig"
+}

--- a/cloudformation/sagemaker/aws-sagemaker-monitoringschedule.go
+++ b/cloudformation/sagemaker/aws-sagemaker-monitoringschedule.go
@@ -28,11 +28,6 @@ type MonitoringSchedule struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-monitoringschedule.html#cfn-sagemaker-monitoringschedule-lastmonitoringexecutionsummary
 	LastMonitoringExecutionSummary *MonitoringSchedule_MonitoringExecutionSummary `json:"LastMonitoringExecutionSummary,omitempty"`
 
-	// MonitoringScheduleArn AWS CloudFormation Property
-	// Required: false
-	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-monitoringschedule.html#cfn-sagemaker-monitoringschedule-monitoringschedulearn
-	MonitoringScheduleArn string `json:"MonitoringScheduleArn,omitempty"`
-
 	// MonitoringScheduleConfig AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-monitoringschedule.html#cfn-sagemaker-monitoringschedule-monitoringscheduleconfig

--- a/cloudformation/sagemaker/aws-sagemaker-monitoringschedule_monitoringscheduleconfig.go
+++ b/cloudformation/sagemaker/aws-sagemaker-monitoringschedule_monitoringscheduleconfig.go
@@ -9,9 +9,19 @@ import (
 type MonitoringSchedule_MonitoringScheduleConfig struct {
 
 	// MonitoringJobDefinition AWS CloudFormation Property
-	// Required: true
+	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-monitoringschedule-monitoringscheduleconfig.html#cfn-sagemaker-monitoringschedule-monitoringscheduleconfig-monitoringjobdefinition
 	MonitoringJobDefinition *MonitoringSchedule_MonitoringJobDefinition `json:"MonitoringJobDefinition,omitempty"`
+
+	// MonitoringJobDefinitionName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-monitoringschedule-monitoringscheduleconfig.html#cfn-sagemaker-monitoringschedule-monitoringscheduleconfig-monitoringjobdefinitionname
+	MonitoringJobDefinitionName string `json:"MonitoringJobDefinitionName,omitempty"`
+
+	// MonitoringType AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-monitoringschedule-monitoringscheduleconfig.html#cfn-sagemaker-monitoringschedule-monitoringscheduleconfig-monitoringtype
+	MonitoringType string `json:"MonitoringType,omitempty"`
 
 	// ScheduleConfig AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/sagemaker/aws-sagemaker-pipeline.go
+++ b/cloudformation/sagemaker/aws-sagemaker-pipeline.go
@@ -1,0 +1,132 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Pipeline AWS CloudFormation Resource (AWS::SageMaker::Pipeline)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html
+type Pipeline struct {
+
+	// PipelineDefinition AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html#cfn-sagemaker-pipeline-pipelinedefinition
+	PipelineDefinition interface{} `json:"PipelineDefinition,omitempty"`
+
+	// PipelineDescription AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html#cfn-sagemaker-pipeline-pipelinedescription
+	PipelineDescription string `json:"PipelineDescription,omitempty"`
+
+	// PipelineDisplayName AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html#cfn-sagemaker-pipeline-pipelinedisplayname
+	PipelineDisplayName string `json:"PipelineDisplayName,omitempty"`
+
+	// PipelineName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html#cfn-sagemaker-pipeline-pipelinename
+	PipelineName string `json:"PipelineName,omitempty"`
+
+	// RoleArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html#cfn-sagemaker-pipeline-rolearn
+	RoleArn string `json:"RoleArn,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-pipeline.html#cfn-sagemaker-pipeline-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Pipeline) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Pipeline"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Pipeline) MarshalJSON() ([]byte, error) {
+	type Properties Pipeline
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Pipeline) UnmarshalJSON(b []byte) error {
+	type Properties Pipeline
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Pipeline(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/sagemaker/aws-sagemaker-project.go
+++ b/cloudformation/sagemaker/aws-sagemaker-project.go
@@ -1,0 +1,122 @@
+package sagemaker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+	"github.com/awslabs/goformation/v4/cloudformation/tags"
+)
+
+// Project AWS CloudFormation Resource (AWS::SageMaker::Project)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-project.html
+type Project struct {
+
+	// ProjectDescription AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-project.html#cfn-sagemaker-project-projectdescription
+	ProjectDescription string `json:"ProjectDescription,omitempty"`
+
+	// ProjectName AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-project.html#cfn-sagemaker-project-projectname
+	ProjectName string `json:"ProjectName,omitempty"`
+
+	// ServiceCatalogProvisioningDetails AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-project.html#cfn-sagemaker-project-servicecatalogprovisioningdetails
+	ServiceCatalogProvisioningDetails interface{} `json:"ServiceCatalogProvisioningDetails,omitempty"`
+
+	// Tags AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-project.html#cfn-sagemaker-project-tags
+	Tags []tags.Tag `json:"Tags,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Project) AWSCloudFormationType() string {
+	return "AWS::SageMaker::Project"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r Project) MarshalJSON() ([]byte, error) {
+	type Properties Project
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *Project) UnmarshalJSON(b []byte) error {
+	type Properties Project
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = Project(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/serverless/aws-serverless-function.go
+++ b/cloudformation/serverless/aws-serverless-function.go
@@ -87,6 +87,11 @@ type Function struct {
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
 	Policies *Function_Policies `json:"Policies,omitempty"`
 
+	// ProvisionedConcurrencyConfig AWS CloudFormation Property
+	// Required: false
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+	ProvisionedConcurrencyConfig *Function_ProvisionedConcurrencyConfig `json:"ProvisionedConcurrencyConfig,omitempty"`
+
 	// ReservedConcurrentExecutions AWS CloudFormation Property
 	// Required: false
 	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/cloudformation/serverless/aws-serverless-function_provisionedconcurrencyconfig.go
+++ b/cloudformation/serverless/aws-serverless-function_provisionedconcurrencyconfig.go
@@ -1,0 +1,35 @@
+package serverless
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// Function_ProvisionedConcurrencyConfig AWS CloudFormation Resource (AWS::Serverless::Function.ProvisionedConcurrencyConfig)
+// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#provisioned-concurrency-config-object
+type Function_ProvisionedConcurrencyConfig struct {
+
+	// ProvisionedConcurrentExecutions AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#provisioned-concurrency-config-object
+	ProvisionedConcurrentExecutions string `json:"ProvisionedConcurrentExecutions,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *Function_ProvisionedConcurrencyConfig) AWSCloudFormationType() string {
+	return "AWS::Serverless::Function.ProvisionedConcurrencyConfig"
+}

--- a/cloudformation/sso/aws-sso-instanceaccesscontrolattributeconfiguration.go
+++ b/cloudformation/sso/aws-sso-instanceaccesscontrolattributeconfiguration.go
@@ -1,0 +1,111 @@
+package sso
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/awslabs/goformation/v4/cloudformation/policies"
+)
+
+// InstanceAccessControlAttributeConfiguration AWS CloudFormation Resource (AWS::SSO::InstanceAccessControlAttributeConfiguration)
+// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-instanceaccesscontrolattributeconfiguration.html
+type InstanceAccessControlAttributeConfiguration struct {
+
+	// InstanceAccessControlAttributeConfiguration AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-instanceaccesscontrolattributeconfiguration.html#cfn-sso-instanceaccesscontrolattributeconfiguration-instanceaccesscontrolattributeconfiguration
+	InstanceAccessControlAttributeConfiguration interface{} `json:"InstanceAccessControlAttributeConfiguration,omitempty"`
+
+	// InstanceArn AWS CloudFormation Property
+	// Required: true
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-instanceaccesscontrolattributeconfiguration.html#cfn-sso-instanceaccesscontrolattributeconfiguration-instancearn
+	InstanceArn string `json:"InstanceArn,omitempty"`
+
+	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
+	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
+
+	// AWSCloudFormationUpdateReplacePolicy represents a CloudFormation UpdateReplacePolicy
+	AWSCloudFormationUpdateReplacePolicy policies.UpdateReplacePolicy `json:"-"`
+
+	// AWSCloudFormationDependsOn stores the logical ID of the resources to be created before this resource
+	AWSCloudFormationDependsOn []string `json:"-"`
+
+	// AWSCloudFormationMetadata stores structured data associated with this resource
+	AWSCloudFormationMetadata map[string]interface{} `json:"-"`
+
+	// AWSCloudFormationCondition stores the logical ID of the condition that must be satisfied for this resource to be created
+	AWSCloudFormationCondition string `json:"-"`
+}
+
+// AWSCloudFormationType returns the AWS CloudFormation resource type
+func (r *InstanceAccessControlAttributeConfiguration) AWSCloudFormationType() string {
+	return "AWS::SSO::InstanceAccessControlAttributeConfiguration"
+}
+
+// MarshalJSON is a custom JSON marshalling hook that embeds this object into
+// an AWS CloudFormation JSON resource's 'Properties' field and adds a 'Type'.
+func (r InstanceAccessControlAttributeConfiguration) MarshalJSON() ([]byte, error) {
+	type Properties InstanceAccessControlAttributeConfiguration
+	return json.Marshal(&struct {
+		Type                string
+		Properties          Properties
+		DependsOn           []string                     `json:"DependsOn,omitempty"`
+		Metadata            map[string]interface{}       `json:"Metadata,omitempty"`
+		DeletionPolicy      policies.DeletionPolicy      `json:"DeletionPolicy,omitempty"`
+		UpdateReplacePolicy policies.UpdateReplacePolicy `json:"UpdateReplacePolicy,omitempty"`
+		Condition           string                       `json:"Condition,omitempty"`
+	}{
+		Type:                r.AWSCloudFormationType(),
+		Properties:          (Properties)(r),
+		DependsOn:           r.AWSCloudFormationDependsOn,
+		Metadata:            r.AWSCloudFormationMetadata,
+		DeletionPolicy:      r.AWSCloudFormationDeletionPolicy,
+		UpdateReplacePolicy: r.AWSCloudFormationUpdateReplacePolicy,
+		Condition:           r.AWSCloudFormationCondition,
+	})
+}
+
+// UnmarshalJSON is a custom JSON unmarshalling hook that strips the outer
+// AWS CloudFormation resource object, and just keeps the 'Properties' field.
+func (r *InstanceAccessControlAttributeConfiguration) UnmarshalJSON(b []byte) error {
+	type Properties InstanceAccessControlAttributeConfiguration
+	res := &struct {
+		Type                string
+		Properties          *Properties
+		DependsOn           []string
+		Metadata            map[string]interface{}
+		DeletionPolicy      string
+		UpdateReplacePolicy string
+		Condition           string
+	}{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields() // Force error if unknown field is found
+
+	if err := dec.Decode(&res); err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		return err
+	}
+
+	// If the resource has no Properties set, it could be nil
+	if res.Properties != nil {
+		*r = InstanceAccessControlAttributeConfiguration(*res.Properties)
+	}
+	if res.DependsOn != nil {
+		r.AWSCloudFormationDependsOn = res.DependsOn
+	}
+	if res.Metadata != nil {
+		r.AWSCloudFormationMetadata = res.Metadata
+	}
+	if res.DeletionPolicy != "" {
+		r.AWSCloudFormationDeletionPolicy = policies.DeletionPolicy(res.DeletionPolicy)
+	}
+	if res.UpdateReplacePolicy != "" {
+		r.AWSCloudFormationUpdateReplacePolicy = policies.UpdateReplacePolicy(res.UpdateReplacePolicy)
+	}
+	if res.Condition != "" {
+		r.AWSCloudFormationCondition = res.Condition
+	}
+	return nil
+}

--- a/cloudformation/transfer/aws-transfer-server_endpointdetails.go
+++ b/cloudformation/transfer/aws-transfer-server_endpointdetails.go
@@ -16,7 +16,7 @@ type Server_EndpointDetails struct {
 	// SecurityGroupIds AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-transfer-server-endpointdetails.html#cfn-transfer-server-endpointdetails-securitygroupids
-	SecurityGroupIds []Server_SecurityGroupId `json:"SecurityGroupIds,omitempty"`
+	SecurityGroupIds []string `json:"SecurityGroupIds,omitempty"`
 
 	// SubnetIds AWS CloudFormation Property
 	// Required: false

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -157,6 +157,12 @@
                     "Required": false,
                     "PrimitiveType": "Integer",
                     "UpdateType": "Immutable"
+                },
+                "ProvisionedConcurrencyConfig": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
+                    "Required": false,
+                    "Type": "ProvisionedConcurrencyConfig",
+                    "UpdateType": "Immutable"
                 }
             }
         },
@@ -1322,6 +1328,17 @@
                 },
                 "Value": {
                     "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter-s3key-rules.html",
+                    "Required": true,
+                    "PrimitiveType": "String",
+                    "UpdateType": "Immutable"
+                }
+            }
+        },
+        "AWS::Serverless::Function.ProvisionedConcurrencyConfig": {
+            "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#provisioned-concurrency-config-object",
+            "Properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#provisioned-concurrency-config-object",
                     "Required": true,
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"

--- a/schema/cloudformation.go
+++ b/schema/cloudformation.go
@@ -6168,6 +6168,9 @@ var CloudformationSchema = `{
                 },
                 "Snowflake": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SnowflakeDestinationProperties"
+                },
+                "Upsolver": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverDestinationProperties"
                 }
             },
             "type": "object"
@@ -6243,6 +6246,15 @@ var CloudformationSchema = `{
             "required": [
                 "Object"
             ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.IncrementalPullConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DatetimeTypeFieldName": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::AppFlow::Flow.InforNexusSourceProperties": {
@@ -6524,6 +6536,9 @@ var CloudformationSchema = `{
                 "ConnectorType": {
                     "type": "string"
                 },
+                "IncrementalPullConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.IncrementalPullConfig"
+                },
                 "SourceConnectorProperties": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SourceConnectorProperties"
                 }
@@ -6605,6 +6620,43 @@ var CloudformationSchema = `{
             },
             "required": [
                 "TriggerType"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketName": {
+                    "type": "string"
+                },
+                "BucketPrefix": {
+                    "type": "string"
+                },
+                "S3OutputFormatConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig"
+                }
+            },
+            "required": [
+                "BucketName",
+                "S3OutputFormatConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AggregationConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.AggregationConfig"
+                },
+                "FileType": {
+                    "type": "string"
+                },
+                "PrefixConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.PrefixConfig"
+                }
+            },
+            "required": [
+                "PrefixConfig"
             ],
             "type": "object"
         },
@@ -10886,6 +10938,9 @@ var CloudformationSchema = `{
                     },
                     "type": "array"
                 },
+                "JMXPrometheusExporter": {
+                    "$ref": "#/definitions/AWS::ApplicationInsights::Application.JMXPrometheusExporter"
+                },
                 "Logs": {
                     "items": {
                         "$ref": "#/definitions/AWS::ApplicationInsights::Application.Log"
@@ -10918,6 +10973,21 @@ var CloudformationSchema = `{
                 "ComponentName",
                 "ResourceList"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationInsights::Application.JMXPrometheusExporter": {
+            "additionalProperties": false,
+            "properties": {
+                "HostPort": {
+                    "type": "string"
+                },
+                "JMXURL": {
+                    "type": "string"
+                },
+                "PrometheusPort": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationInsights::Application.Log": {
@@ -11399,6 +11469,247 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::AuditManager::Assessment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "assessmentReportsDestination": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AssessmentReportsDestination"
+                        },
+                        "awsAccount": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "frameworkId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "roles": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Roles"
+                        },
+                        "scope": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Scope"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Tags"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AuditManager::Assessment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccount": {
+            "additionalProperties": false,
+            "properties": {
+                "emailAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccounts": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSAccounts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSService": {
+            "additionalProperties": false,
+            "properties": {
+                "serviceName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSServices": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSServices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSService"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AssessmentReportsDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "destination": {
+                    "type": "string"
+                },
+                "destinationType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegation": {
+            "additionalProperties": false,
+            "properties": {
+                "assessmentId": {
+                    "type": "string"
+                },
+                "assessmentName": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "controlSetId": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "type": "string"
+                },
+                "creationTime": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastUpdated": {
+                    "type": "number"
+                },
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegations": {
+            "additionalProperties": false,
+            "properties": {
+                "Delegations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Delegation"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Role": {
+            "additionalProperties": false,
+            "properties": {
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Roles": {
+            "additionalProperties": false,
+            "properties": {
+                "Roles": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Role"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Scope": {
+            "additionalProperties": false,
+            "properties": {
+                "awsAccounts": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccounts"
+                },
+                "awsServices": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSServices"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Tags": {
+            "additionalProperties": false,
+            "properties": {
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::AutoScaling::AutoScalingGroup": {
             "additionalProperties": false,
             "properties": {
@@ -11822,7 +12133,7 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "MetadataOptions": {
-                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOption"
+                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOptions"
                         },
                         "PlacementTenancy": {
                             "type": "string"
@@ -11915,7 +12226,7 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
-        "AWS::AutoScaling::LaunchConfiguration.MetadataOption": {
+        "AWS::AutoScaling::LaunchConfiguration.MetadataOptions": {
             "additionalProperties": false,
             "properties": {
                 "HttpEndpoint": {
@@ -13103,10 +13414,7 @@ var CloudformationSchema = `{
                 }
             },
             "required": [
-                "InstanceRole",
-                "InstanceTypes",
                 "MaxvCpus",
-                "MinvCpus",
                 "Subnets",
                 "Type"
             ],
@@ -13186,6 +13494,15 @@ var CloudformationSchema = `{
                         "Parameters": {
                             "type": "object"
                         },
+                        "PlatformCapabilities": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PropagateTags": {
+                            "type": "boolean"
+                        },
                         "RetryStrategy": {
                             "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
                         },
@@ -13243,6 +13560,9 @@ var CloudformationSchema = `{
                 "ExecutionRoleArn": {
                     "type": "string"
                 },
+                "FargatePlatformConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.FargatePlatformConfiguration"
+                },
                 "Image": {
                     "type": "string"
                 },
@@ -13266,6 +13586,9 @@ var CloudformationSchema = `{
                         "$ref": "#/definitions/AWS::Batch::JobDefinition.MountPoints"
                     },
                     "type": "array"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.NetworkConfiguration"
                 },
                 "Privileged": {
                     "type": "boolean"
@@ -13360,6 +13683,15 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Batch::JobDefinition.FargatePlatformConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PlatformVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Batch::JobDefinition.LinuxParameters": {
             "additionalProperties": false,
             "properties": {
@@ -13421,6 +13753,15 @@ var CloudformationSchema = `{
                     "type": "boolean"
                 },
                 "SourceVolume": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
                     "type": "string"
                 }
             },
@@ -14612,6 +14953,135 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::CloudFormation::ModuleDefaultVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Arn": {
+                            "type": "string"
+                        },
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "VersionId": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleDefaultVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::ModuleVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "ModulePackage": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ModuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::CloudFormation::Stack": {
             "additionalProperties": false,
             "properties": {
@@ -14782,6 +15252,10 @@ var CloudformationSchema = `{
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "PermissionModel",
+                        "StackSetName"
+                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -14800,7 +15274,8 @@ var CloudformationSchema = `{
                 }
             },
             "required": [
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
@@ -17360,6 +17835,9 @@ var CloudformationSchema = `{
                         "DomainName": {
                             "type": "string"
                         },
+                        "EncryptionKey": {
+                            "type": "string"
+                        },
                         "PermissionsPolicyDocument": {
                             "type": "object"
                         },
@@ -17431,6 +17909,12 @@ var CloudformationSchema = `{
                         "Description": {
                             "type": "string"
                         },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainOwner": {
+                            "type": "string"
+                        },
                         "ExternalConnections": {
                             "items": {
                                 "type": "string"
@@ -17457,6 +17941,7 @@ var CloudformationSchema = `{
                         }
                     },
                     "required": [
+                        "DomainName",
                         "RepositoryName"
                     ],
                     "type": "object"
@@ -19003,6 +19488,12 @@ var CloudformationSchema = `{
                         "Owner": {
                             "type": "string"
                         },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
                         "Type": {
                             "type": "string"
                         }
@@ -20335,6 +20826,30 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::Cognito::UserPool.CustomEmailSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.CustomSMSSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Cognito::UserPool.DeviceConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -20389,10 +20904,19 @@ var CloudformationSchema = `{
                 "CreateAuthChallenge": {
                     "type": "string"
                 },
+                "CustomEmailSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomEmailSender"
+                },
                 "CustomMessage": {
                     "type": "string"
                 },
+                "CustomSMSSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomSMSSender"
+                },
                 "DefineAuthChallenge": {
+                    "type": "string"
+                },
+                "KMSKeyID": {
                     "type": "string"
                 },
                 "PostAuthentication": {
@@ -22816,6 +23340,12 @@ var CloudformationSchema = `{
                         },
                         "State": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
@@ -25061,6 +25591,169 @@ var CloudformationSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Config": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig"
+                        }
+                    },
+                    "required": [
+                        "Config"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::NotificationChannel"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Sns": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TopicArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResourceCollectionFilter": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter"
+                        }
+                    },
+                    "required": [
+                        "ResourceCollectionFilter"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::ResourceCollection"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "StackNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudFormation": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter"
+                }
+            },
             "type": "object"
         },
         "AWS::DirectoryService::MicrosoftAD": {
@@ -27496,6 +28189,9 @@ var CloudformationSchema = `{
                             },
                             "type": "array"
                         },
+                        "EnclaveOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.EnclaveOptions"
+                        },
                         "HibernationOptions": {
                             "$ref": "#/definitions/AWS::EC2::Instance.HibernationOptions"
                         },
@@ -27737,6 +28433,15 @@ var CloudformationSchema = `{
             "required": [
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.EnclaveOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::Instance.HibernationOptions": {
@@ -28867,6 +29572,552 @@ var CloudformationSchema = `{
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FilterInArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetworkInsightsPathId": {
+                            "type": "string"
+                        },
+                        "StatusMessage": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkInsightsPathId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsAnalysis"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AlternatePathHint": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentArn": {
+                    "type": "string"
+                },
+                "ComponentId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Egress": {
+                    "type": "boolean"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "RuleAction": {
+                    "type": "string"
+                },
+                "RuleNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener": {
+            "additionalProperties": false,
+            "properties": {
+                "InstancePort": {
+                    "type": "number"
+                },
+                "LoadBalancerPort": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Address": {
+                    "type": "string"
+                },
+                "AvailabilityZone": {
+                    "type": "string"
+                },
+                "Instance": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Port": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "DestinationAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "DestinationPortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SourceAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SourcePortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "NatGatewayId": {
+                    "type": "string"
+                },
+                "NetworkInterfaceId": {
+                    "type": "string"
+                },
+                "Origin": {
+                    "type": "string"
+                },
+                "TransitGatewayId": {
+                    "type": "string"
+                },
+                "VpcPeeringConnectionId": {
+                    "type": "string"
+                },
+                "destinationCidr": {
+                    "type": "string"
+                },
+                "destinationPrefixListId": {
+                    "type": "string"
+                },
+                "egressOnlyInternetGatewayId": {
+                    "type": "string"
+                },
+                "gatewayId": {
+                    "type": "string"
+                },
+                "instanceId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "PrefixListId": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SecurityGroupId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.Explanation": {
+            "additionalProperties": false,
+            "properties": {
+                "Acl": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Address": {
+                    "type": "string"
+                },
+                "Addresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AttachedTo": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AvailabilityZones": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Cidrs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ClassicLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "CustomerGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Destination": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "ElasticLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "ExplanationCode": {
+                    "type": "string"
+                },
+                "IngressRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InternetGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerArn": {
+                    "type": "string"
+                },
+                "LoadBalancerListenerPort": {
+                    "type": "number"
+                },
+                "LoadBalancerTarget": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget"
+                },
+                "LoadBalancerTargetGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerTargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "LoadBalancerTargetPort": {
+                    "type": "number"
+                },
+                "MissingComponent": {
+                    "type": "string"
+                },
+                "NatGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "NetworkInterface": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "PacketField": {
+                    "type": "string"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "PortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "PrefixList": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Protocols": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "State": {
+                    "type": "string"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SubnetRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpcPeeringConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "vpcEndpoint": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PathComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "OutboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SequenceNumber": {
+                    "type": "number"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PortRange": {
+            "additionalProperties": false,
+            "properties": {
+                "From": {
+                    "type": "number"
+                },
+                "To": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsPath": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Destination": {
+                            "type": "string"
+                        },
+                        "DestinationIp": {
+                            "type": "string"
+                        },
+                        "DestinationPort": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "Source": {
+                            "type": "string"
+                        },
+                        "SourceIp": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Destination",
+                        "Protocol",
+                        "Source"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsPath"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::EC2::NetworkInterface": {
@@ -30062,6 +31313,9 @@ var CloudformationSchema = `{
                 "InstanceType": {
                     "type": "string"
                 },
+                "Priority": {
+                    "type": "number"
+                },
                 "SpotPrice": {
                     "type": "string"
                 },
@@ -30099,6 +31353,15 @@ var CloudformationSchema = `{
             "required": [
                 "PrivateIpAddress"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotCapacityRebalance": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplacementStrategy": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetLaunchSpecification": {
@@ -30198,6 +31461,9 @@ var CloudformationSchema = `{
                 "InstanceInterruptionBehavior": {
                     "type": "string"
                 },
+                "InstancePoolsToUseCount": {
+                    "type": "number"
+                },
                 "LaunchSpecifications": {
                     "items": {
                         "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetLaunchSpecification"
@@ -30213,8 +31479,23 @@ var CloudformationSchema = `{
                 "LoadBalancersConfig": {
                     "$ref": "#/definitions/AWS::EC2::SpotFleet.LoadBalancersConfig"
                 },
+                "OnDemandAllocationStrategy": {
+                    "type": "string"
+                },
+                "OnDemandMaxTotalPrice": {
+                    "type": "string"
+                },
+                "OnDemandTargetCapacity": {
+                    "type": "number"
+                },
                 "ReplaceUnhealthyInstances": {
                     "type": "boolean"
+                },
+                "SpotMaintenanceStrategies": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotMaintenanceStrategies"
+                },
+                "SpotMaxTotalPrice": {
+                    "type": "string"
                 },
                 "SpotPrice": {
                     "type": "string"
@@ -30252,6 +31533,15 @@ var CloudformationSchema = `{
                         "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotMaintenanceStrategies": {
+            "additionalProperties": false,
+            "properties": {
+                "CapacityRebalance": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotCapacityRebalance"
                 }
             },
             "type": "object"
@@ -32393,6 +33683,9 @@ var CloudformationSchema = `{
                             },
                             "type": "array"
                         },
+                        "Throughput": {
+                            "type": "number"
+                        },
                         "VolumeType": {
                             "type": "string"
                         }
@@ -32490,6 +33783,70 @@ var CloudformationSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECR::PublicRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryCatalogData": {
+                            "type": "object"
+                        },
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "RepositoryPolicyText": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECR::PublicRepository"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -33039,9 +34396,28 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::ECS::Service.DeploymentCircuitBreaker": {
+            "additionalProperties": false,
+            "properties": {
+                "Enable": {
+                    "type": "boolean"
+                },
+                "Rollback": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "Enable",
+                "Rollback"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::Service.DeploymentConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentCircuitBreaker": {
+                    "$ref": "#/definitions/AWS::ECS::Service.DeploymentCircuitBreaker"
+                },
                 "MaximumPercent": {
                     "type": "number"
                 },
@@ -34714,6 +36090,9 @@ var CloudformationSchema = `{
                     "additionalProperties": false,
                     "properties": {
                         "AmiType": {
+                            "type": "string"
+                        },
+                        "CapacityType": {
                             "type": "string"
                         },
                         "ClusterName": {
@@ -36708,6 +38087,12 @@ var CloudformationSchema = `{
                         },
                         "TransitEncryptionEnabled": {
                             "type": "boolean"
+                        },
+                        "UserGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -36961,6 +38346,232 @@ var CloudformationSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessString": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "NoPasswordRequired": {
+                            "type": "boolean"
+                        },
+                        "Passwords": {
+                            "$ref": "#/definitions/AWS::ElastiCache::User.PasswordList"
+                        },
+                        "UserId": {
+                            "type": "string"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserId",
+                        "UserName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::User"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.Authentication": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordCount": {
+                    "type": "number"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.PasswordList": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.UserGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "UserGroupId": {
+                            "type": "string"
+                        },
+                        "UserIds": {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup.UserIdList"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::UserGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.ReplicationGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplicationGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserGroupPendingChanges": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdsToAdd": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "UserIdsToRemove": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application": {
@@ -38962,6 +40573,15 @@ var CloudformationSchema = `{
         "AWS::Elasticsearch::Domain.DomainEndpointOptions": {
             "additionalProperties": false,
             "properties": {
+                "CustomEndpoint": {
+                    "type": "string"
+                },
+                "CustomEndpointCertificateArn": {
+                    "type": "string"
+                },
+                "CustomEndpointEnabled": {
+                    "type": "boolean"
+                },
                 "EnforceHTTPS": {
                     "type": "boolean"
                 },
@@ -39478,6 +41098,9 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "ArchiveName": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
@@ -42397,15 +44020,6 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
-        "AWS::Glue::Database.DataLakePrincipal": {
-            "additionalProperties": false,
-            "properties": {
-                "DataLakePrincipalIdentifier": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "AWS::Glue::Database.DatabaseIdentifier": {
             "additionalProperties": false,
             "properties": {
@@ -42421,12 +44035,6 @@ var CloudformationSchema = `{
         "AWS::Glue::Database.DatabaseInput": {
             "additionalProperties": false,
             "properties": {
-                "CreateTableDefaultPermissions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Glue::Database.PrincipalPrivileges"
-                    },
-                    "type": "array"
-                },
                 "Description": {
                     "type": "string"
                 },
@@ -42441,21 +44049,6 @@ var CloudformationSchema = `{
                 },
                 "TargetDatabase": {
                     "$ref": "#/definitions/AWS::Glue::Database.DatabaseIdentifier"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::Glue::Database.PrincipalPrivileges": {
-            "additionalProperties": false,
-            "properties": {
-                "Permissions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Principal": {
-                    "$ref": "#/definitions/AWS::Glue::Database.DataLakePrincipal"
                 }
             },
             "type": "object"
@@ -43054,6 +44647,36 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Glue::Partition.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Partition.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Partition.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43122,6 +44745,9 @@ var CloudformationSchema = `{
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Partition.SerdeInfo"
@@ -43702,6 +45328,36 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Glue::Table.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Table.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Table.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43770,6 +45426,9 @@ var CloudformationSchema = `{
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Table.SerdeInfo"
@@ -46115,6 +47774,271 @@ var CloudformationSchema = `{
                 "Subject",
                 "Target"
             ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InlineRecipe": {
+                            "type": "string"
+                        },
+                        "LambdaFunction": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource"
+                        },
+                        "Tags": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GreengrassV2::ComponentVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement": {
+            "additionalProperties": false,
+            "properties": {
+                "DependencyType": {
+                    "type": "string"
+                },
+                "VersionRequirement": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentPlatform": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaContainerParams": {
+            "additionalProperties": false,
+            "properties": {
+                "Devices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount"
+                    },
+                    "type": "array"
+                },
+                "MemorySizeInKB": {
+                    "type": "number"
+                },
+                "MountROSysfs": {
+                    "type": "boolean"
+                },
+                "Volumes": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Topic": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "EnvironmentVariables": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "EventSources": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaEventSource"
+                    },
+                    "type": "array"
+                },
+                "ExecArgs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "InputPayloadEncodingType": {
+                    "type": "string"
+                },
+                "LinuxProcessParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams"
+                },
+                "MaxIdleTimeInSeconds": {
+                    "type": "number"
+                },
+                "MaxInstancesCount": {
+                    "type": "number"
+                },
+                "MaxQueueSize": {
+                    "type": "number"
+                },
+                "Pinned": {
+                    "type": "boolean"
+                },
+                "StatusTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TimeoutInSeconds": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentDependencies": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ComponentLambdaParameters": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters"
+                },
+                "ComponentName": {
+                    "type": "string"
+                },
+                "ComponentPlatforms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentPlatform"
+                    },
+                    "type": "array"
+                },
+                "ComponentVersion": {
+                    "type": "string"
+                },
+                "LambdaArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaContainerParams"
+                },
+                "IsolationMode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "DestinationPath": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                },
+                "SourcePath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::GuardDuty::Detector": {
@@ -50104,6 +52028,9 @@ var CloudformationSchema = `{
                         },
                         "Status": {
                             "type": "string"
+                        },
+                        "VpcProperties": {
+                            "$ref": "#/definitions/AWS::IoT::TopicRuleDestination.VpcDestinationProperties"
                         }
                     },
                     "type": "object"
@@ -50132,6 +52059,30 @@ var CloudformationSchema = `{
             "additionalProperties": false,
             "properties": {
                 "ConfirmationUrl": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRuleDestination.VpcDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "RoleArn": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "VpcId": {
                     "type": "string"
                 }
             },
@@ -51615,6 +53566,124 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::IoTSiteWise::AccessPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessPolicyIdentity": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity"
+                        },
+                        "AccessPolicyPermission": {
+                            "type": "string"
+                        },
+                        "AccessPolicyResource": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource"
+                        }
+                    },
+                    "required": [
+                        "AccessPolicyIdentity",
+                        "AccessPolicyPermission",
+                        "AccessPolicyResource"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::AccessPolicy"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity": {
+            "additionalProperties": false,
+            "properties": {
+                "User": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.User"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource": {
+            "additionalProperties": false,
+            "properties": {
+                "Portal": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Portal"
+                },
+                "Project": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Project"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Project": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.User": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Asset": {
             "additionalProperties": false,
             "properties": {
@@ -51987,6 +54056,85 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Dashboard": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DashboardDefinition": {
+                            "type": "string"
+                        },
+                        "DashboardDescription": {
+                            "type": "string"
+                        },
+                        "DashboardName": {
+                            "type": "string"
+                        },
+                        "ProjectId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DashboardDefinition",
+                        "DashboardDescription",
+                        "DashboardName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Dashboard"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Gateway": {
             "additionalProperties": false,
             "properties": {
@@ -52104,6 +54252,187 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalContactEmail": {
+                            "type": "string"
+                        },
+                        "PortalDescription": {
+                            "type": "string"
+                        },
+                        "PortalName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalContactEmail",
+                        "PortalName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Portal"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.MonitorErrorDetails": {
+            "additionalProperties": false,
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.PortalStatus": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::Portal.MonitorErrorDetails"
+                },
+                "state": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "state"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalId": {
+                            "type": "string"
+                        },
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalId",
+                        "ProjectName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTThingsGraph::FlowTemplate": {
             "additionalProperties": false,
             "properties": {
@@ -52183,6 +54512,639 @@ var CloudformationSchema = `{
                 "Language",
                 "Text"
             ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::Destination": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Expression": {
+                            "type": "string"
+                        },
+                        "ExpressionType": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Expression",
+                        "ExpressionType",
+                        "Name",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::Destination"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANDeviceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::DeviceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "ClassBTimeout": {
+                    "type": "number"
+                },
+                "ClassCTimeout": {
+                    "type": "number"
+                },
+                "MacVersion": {
+                    "type": "string"
+                },
+                "MaxDutyCycle": {
+                    "type": "number"
+                },
+                "MaxEirp": {
+                    "type": "number"
+                },
+                "PingSlotDr": {
+                    "type": "number"
+                },
+                "PingSlotFreq": {
+                    "type": "number"
+                },
+                "PingSlotPeriod": {
+                    "type": "number"
+                },
+                "RegParamsRevision": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                },
+                "Supports32BitFCnt": {
+                    "type": "boolean"
+                },
+                "SupportsClassB": {
+                    "type": "boolean"
+                },
+                "SupportsClassC": {
+                    "type": "boolean"
+                },
+                "SupportsJoin": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANGetServiceProfileInfo": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo"
+                        },
+                        "LoRaWANServiceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::ServiceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                },
+                "ChannelMask": {
+                    "type": "string"
+                },
+                "DevStatusReqFreq": {
+                    "type": "number"
+                },
+                "DlBucketSize": {
+                    "type": "number"
+                },
+                "DlRate": {
+                    "type": "number"
+                },
+                "DlRatePolicy": {
+                    "type": "string"
+                },
+                "DrMax": {
+                    "type": "number"
+                },
+                "DrMin": {
+                    "type": "number"
+                },
+                "HrAllowed": {
+                    "type": "boolean"
+                },
+                "MinGwDiversity": {
+                    "type": "number"
+                },
+                "NwkGeoLoc": {
+                    "type": "boolean"
+                },
+                "PrAllowed": {
+                    "type": "boolean"
+                },
+                "RaAllowed": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusBattery": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusMargin": {
+                    "type": "boolean"
+                },
+                "TargetPer": {
+                    "type": "number"
+                },
+                "UlBucketSize": {
+                    "type": "number"
+                },
+                "UlRate": {
+                    "type": "number"
+                },
+                "UlRatePolicy": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DestinationName": {
+                            "type": "string"
+                        },
+                        "LoRaWANDevice": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.LoRaWANDevice"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessDevice"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.LoRaWANDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "AbpV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV10X"
+                },
+                "AbpV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV11"
+                },
+                "DevEui": {
+                    "type": "string"
+                },
+                "DeviceProfileId": {
+                    "type": "string"
+                },
+                "OtaaV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV10X"
+                },
+                "OtaaV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV11"
+                },
+                "ServiceProfileId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppEui": {
+                    "type": "string"
+                },
+                "AppKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppKey": {
+                    "type": "string"
+                },
+                "JoinEui": {
+                    "type": "string"
+                },
+                "NwkKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "NwkSKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "FNwkSIntKey": {
+                    "type": "string"
+                },
+                "NwkSEncKey": {
+                    "type": "string"
+                },
+                "SNwkSIntKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "LoRaWANGateway": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway.LoRaWANGateway"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LoRaWANGateway"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessGateway"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway.LoRaWANGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "GatewayEui": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::KMS::Alias": {
@@ -52481,6 +55443,234 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList"
+                },
+                "CrawlAttachments": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceAttachmentFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlogFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceBlogFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration"
+                },
+                "BlogConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogConfiguration"
+                },
+                "ExclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "InclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "PageConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageConfiguration"
+                },
+                "SecretArn": {
+                    "type": "string"
+                },
+                "ServerUrl": {
+                    "type": "string"
+                },
+                "SpaceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceConfiguration"
+                },
+                "Version": {
+                    "type": "string"
+                },
+                "VpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceVpcConfiguration"
+                }
+            },
+            "required": [
+                "SecretArn",
+                "ServerUrl",
+                "Version"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PageFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluencePageFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CrawlArchivedSpaces": {
+                    "type": "boolean"
+                },
+                "CrawlPersonalSpaces": {
+                    "type": "boolean"
+                },
+                "ExcludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "IncludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "SpaceFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::DataSource.ConnectionConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -52512,6 +55702,9 @@ var CloudformationSchema = `{
         "AWS::Kendra::DataSource.DataSourceConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "ConfluenceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceConfiguration"
+                },
                 "DatabaseConfiguration": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DatabaseConfiguration"
                 },
@@ -52639,6 +55832,9 @@ var CloudformationSchema = `{
         "AWS::Kendra::DataSource.OneDriveConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "ExclusionPatterns": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
                 },
@@ -53016,6 +56212,9 @@ var CloudformationSchema = `{
                 "CrawlAttachments": {
                     "type": "boolean"
                 },
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "DocumentTitleFieldName": {
                     "type": "string"
                 },
@@ -53241,6 +56440,12 @@ var CloudformationSchema = `{
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::Kendra::Index.TagList"
+                        },
+                        "UserContextPolicy": {
+                            "type": "string"
+                        },
+                        "UserTokenConfigurations": {
+                            "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfigurationList"
                         }
                     },
                     "required": [
@@ -53321,6 +56526,52 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::Kendra::Index.JsonTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "GroupAttributeField",
+                "UserNameAttributeField"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::Index.JwtTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ClaimRegex": {
+                    "type": "string"
+                },
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "Issuer": {
+                    "type": "string"
+                },
+                "KeyLocation": {
+                    "type": "string"
+                },
+                "SecretManagerArn": {
+                    "type": "string"
+                },
+                "URL": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KeyLocation"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::Index.Relevance": {
             "additionalProperties": false,
             "properties": {
@@ -53375,6 +56626,30 @@ var CloudformationSchema = `{
                 "TagList": {
                     "items": {
                         "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "JsonTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JsonTokenTypeConfiguration"
+                },
+                "JwtTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JwtTokenTypeConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfigurationList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserTokenConfigurationList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfiguration"
                     },
                     "type": "array"
                 }
@@ -56542,6 +59817,12 @@ var CloudformationSchema = `{
                         "FunctionName": {
                             "type": "string"
                         },
+                        "FunctionResponseTypes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "MaximumBatchingWindowInSeconds": {
                             "type": "number"
                         },
@@ -56563,6 +59844,9 @@ var CloudformationSchema = `{
                             },
                             "type": "array"
                         },
+                        "SelfManagedEventSource": {
+                            "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SelfManagedEventSource"
+                        },
                         "SourceAccessConfigurations": {
                             "items": {
                                 "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SourceAccessConfiguration"
@@ -56583,7 +59867,6 @@ var CloudformationSchema = `{
                         }
                     },
                     "required": [
-                        "EventSourceArn",
                         "FunctionName"
                     ],
                     "type": "object"
@@ -56618,11 +59901,32 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::Lambda::EventSourceMapping.Endpoints": {
+            "additionalProperties": false,
+            "properties": {
+                "KafkaBootstrapServers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Lambda::EventSourceMapping.OnFailure": {
             "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::EventSourceMapping.SelfManagedEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Endpoints": {
+                    "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.Endpoints"
                 }
             },
             "type": "object"
@@ -56698,6 +60002,9 @@ var CloudformationSchema = `{
                         "Handler": {
                             "type": "string"
                         },
+                        "ImageConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.ImageConfig"
+                        },
                         "KmsKeyArn": {
                             "type": "string"
                         },
@@ -56709,6 +60016,9 @@ var CloudformationSchema = `{
                         },
                         "MemorySize": {
                             "type": "number"
+                        },
+                        "PackageType": {
+                            "type": "string"
                         },
                         "ReservedConcurrentExecutions": {
                             "type": "number"
@@ -56737,9 +60047,7 @@ var CloudformationSchema = `{
                     },
                     "required": [
                         "Code",
-                        "Handler",
-                        "Role",
-                        "Runtime"
+                        "Role"
                     ],
                     "type": "object"
                 },
@@ -56767,6 +60075,9 @@ var CloudformationSchema = `{
         "AWS::Lambda::Function.Code": {
             "additionalProperties": false,
             "properties": {
+                "ImageUri": {
+                    "type": "string"
+                },
                 "S3Bucket": {
                     "type": "string"
                 },
@@ -56820,6 +60131,27 @@ var CloudformationSchema = `{
                 "Arn",
                 "LocalMountPath"
             ],
+            "type": "object"
+        },
+        "AWS::Lambda::Function.ImageConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Command": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "EntryPoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "WorkingDirectory": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Lambda::Function.TracingConfig": {
@@ -57181,6 +60513,555 @@ var CloudformationSchema = `{
             },
             "required": [
                 "ProvisionedConcurrentExecutions"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.FilterList"
+                        },
+                        "GrantArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "GrantName": {
+                            "type": "string"
+                        },
+                        "GrantStatus": {
+                            "type": "string"
+                        },
+                        "GrantedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "GranteePrincipalArn": {
+                            "type": "string"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "LicenseArn": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ParentArn": {
+                            "type": "string"
+                        },
+                        "Principals": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "StatusReason": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.TagList"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::Grant"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.AllowedOperationList": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedOperationList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::Grant.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::Grant.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Beneficiary": {
+                            "type": "string"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "ConsumptionConfiguration": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ConsumptionConfiguration"
+                        },
+                        "Entitlements": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.EntitlementList"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.FilterList"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "Issuer": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.IssuerData"
+                        },
+                        "LicenseArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ArnList"
+                        },
+                        "LicenseMetadata": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.MetadataList"
+                        },
+                        "LicenseName": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ProductName": {
+                            "type": "string"
+                        },
+                        "ProductSKU": {
+                            "type": "string"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.TagList"
+                        },
+                        "Validity": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ValidityDateFormat"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConsumptionConfiguration",
+                        "Entitlements",
+                        "HomeRegion",
+                        "Issuer",
+                        "Validity"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::License"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.BorrowConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowEarlyCheckIn": {
+                    "type": "boolean"
+                },
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "AllowEarlyCheckIn",
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ConsumptionConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BorrowConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.BorrowConfiguration"
+                },
+                "ProvisionalConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.ProvisionalConfiguration"
+                },
+                "RenewType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Entitlement": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCheckIn": {
+                    "type": "boolean"
+                },
+                "CheckoutRules": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.RuleList"
+                },
+                "MaxCount": {
+                    "type": "number"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Overage": {
+                    "type": "boolean"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.EntitlementList": {
+            "additionalProperties": false,
+            "properties": {
+                "EntitlementList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Entitlement"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.IssuerData": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "SignKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Metadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.MetadataList": {
+            "additionalProperties": false,
+            "properties": {
+                "MetadataList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Metadata"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ProvisionalConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.RuleList": {
+            "additionalProperties": false,
+            "properties": {
+                "RuleList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Rule"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ValidityDateFormat": {
+            "additionalProperties": false,
+            "properties": {
+                "Begin": {
+                    "type": "string"
+                },
+                "End": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Begin",
+                "End"
             ],
             "type": "object"
         },
@@ -57919,6 +61800,224 @@ var CloudformationSchema = `{
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AirflowConfigurationOptions": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.AirflowConfigurationOptions"
+                        },
+                        "AirflowVersion": {
+                            "type": "string"
+                        },
+                        "DagS3Path": {
+                            "type": "string"
+                        },
+                        "EnvironmentClass": {
+                            "type": "string"
+                        },
+                        "ExecutionRoleArn": {
+                            "type": "string"
+                        },
+                        "KmsKey": {
+                            "type": "string"
+                        },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.LoggingConfiguration"
+                        },
+                        "MaxWorkers": {
+                            "type": "number"
+                        },
+                        "NetworkConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.NetworkConfiguration"
+                        },
+                        "PluginsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "PluginsS3Path": {
+                            "type": "string"
+                        },
+                        "RequirementsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "RequirementsS3Path": {
+                            "type": "string"
+                        },
+                        "SourceBucketArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.TagMap"
+                        },
+                        "WebserverAccessMode": {
+                            "type": "string"
+                        },
+                        "WebserverUrl": {
+                            "type": "string"
+                        },
+                        "WeeklyMaintenanceWindowStart": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::MWAA::Environment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.AirflowConfigurationOptions": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LastUpdate": {
+            "additionalProperties": false,
+            "properties": {
+                "CreatedAt": {
+                    "type": "string"
+                },
+                "Error": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.UpdateError"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DagProcessingLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "SchedulerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "TaskLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WebserverLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WorkerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.ModuleLoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogGroupArn": {
+                    "type": "string"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "LogLevel": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SecurityGroupList"
+                },
+                "SubnetIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SubnetList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SecurityGroupList": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SubnetList": {
+            "additionalProperties": false,
+            "properties": {
+                "SubnetList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.TagMap": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.UpdateError": {
+            "additionalProperties": false,
+            "properties": {
+                "ErrorCode": {
+                    "type": "string"
+                },
+                "ErrorMessage": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -63231,7 +67330,10 @@ var CloudformationSchema = `{
                             "type": "array"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::Firewall.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VpcId": {
                             "type": "string"
@@ -63278,18 +67380,6 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
-        "AWS::NetworkFirewall::Firewall.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::FirewallPolicy": {
             "additionalProperties": false,
             "properties": {
@@ -63332,7 +67422,10 @@ var CloudformationSchema = `{
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::FirewallPolicy.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -63524,18 +67617,6 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
-        "AWS::NetworkFirewall::FirewallPolicy.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::LoggingConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -63568,11 +67649,18 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "FirewallArn": {
+                            "type": "string"
+                        },
+                        "FirewallName": {
+                            "type": "string"
+                        },
                         "LoggingConfiguration": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::LoggingConfiguration.LoggingConfiguration"
                         }
                     },
                     "required": [
+                        "FirewallArn",
                         "LoggingConfiguration"
                     ],
                     "type": "object"
@@ -63689,14 +67777,14 @@ var CloudformationSchema = `{
                         "RuleGroup": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.RuleGroup"
                         },
-                        "RuleGroupId": {
-                            "type": "string"
-                        },
                         "RuleGroupName": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "Type": {
                             "type": "string"
@@ -64178,18 +68266,6 @@ var CloudformationSchema = `{
                 "TCPFlags": {
                     "items": {
                         "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.TCPFlagField"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::NetworkFirewall::RuleGroup.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
                 }
@@ -73032,6 +77108,18 @@ var CloudformationSchema = `{
             },
             "type": "object"
         },
+        "AWS::S3::Bucket.ReplicaModifications": {
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Status"
+            ],
+            "type": "object"
+        },
         "AWS::S3::Bucket.ReplicationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -73287,6 +77375,9 @@ var CloudformationSchema = `{
         "AWS::S3::Bucket.ServerSideEncryptionRule": {
             "additionalProperties": false,
             "properties": {
+                "BucketKeyEnabled": {
+                    "type": "boolean"
+                },
                 "ServerSideEncryptionByDefault": {
                     "$ref": "#/definitions/AWS::S3::Bucket.ServerSideEncryptionByDefault"
                 }
@@ -73296,6 +77387,9 @@ var CloudformationSchema = `{
         "AWS::S3::Bucket.SourceSelectionCriteria": {
             "additionalProperties": false,
             "properties": {
+                "ReplicaModifications": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.ReplicaModifications"
+                },
                 "SseKmsEncryptedObjects": {
                     "$ref": "#/definitions/AWS::S3::Bucket.SseKmsEncryptedObjects"
                 }
@@ -76112,6 +80206,72 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SSO::InstanceAccessControlAttributeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InstanceAccessControlAttributeConfiguration": {
+                            "type": "object"
+                        },
+                        "InstanceArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "InstanceAccessControlAttributeConfiguration",
+                        "InstanceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::SSO::PermissionSet": {
             "additionalProperties": false,
             "properties": {
@@ -76285,6 +80445,502 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SageMaker::DataQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DataQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification"
+                        },
+                        "DataQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig"
+                        },
+                        "DataQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput"
+                        },
+                        "DataQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringResources"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DataQualityAppSpecification",
+                        "DataQualityJobInput",
+                        "DataQualityJobOutputConfig",
+                        "JobResources",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DataQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource"
+                },
+                "StatisticsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StatisticsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StatisticsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Device": {
+                            "type": "object"
+                        },
+                        "Tags": {}
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Device"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device.Device": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "DeviceName": {
+                    "type": "string"
+                },
+                "IotThingName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "OutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet.EdgeOutputConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {}
+                    },
+                    "required": [
+                        "OutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DeviceFleet"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet.EdgeOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "S3OutputLocation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3OutputLocation"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -76317,6 +80973,9 @@ var CloudformationSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "DeploymentConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::Endpoint.DeploymentConfig"
+                        },
                         "EndpointConfigName": {
                             "type": "string"
                         },
@@ -76362,6 +81021,100 @@ var CloudformationSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.Alarm": {
+            "additionalProperties": false,
+            "properties": {
+                "AlarmName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AlarmName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.AutoRollbackConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Alarms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::Endpoint.Alarm"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Alarms"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "MaximumExecutionTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TerminationWaitInSeconds": {
+                    "type": "number"
+                },
+                "TrafficRoutingConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.TrafficRoutingConfig"
+                }
+            },
+            "required": [
+                "TrafficRoutingConfiguration"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.CapacitySize": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.DeploymentConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AutoRollbackConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.AutoRollbackConfig"
+                },
+                "BlueGreenUpdatePolicy": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy"
+                }
+            },
+            "required": [
+                "BlueGreenUpdatePolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.TrafficRoutingConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "CanarySize": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.CapacitySize"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "WaitIntervalInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -76706,6 +81459,1096 @@ var CloudformationSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SageMaker::ModelBiasJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources"
+                        },
+                        "ModelBiasAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification"
+                        },
+                        "ModelBiasBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig"
+                        },
+                        "ModelBiasJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput"
+                        },
+                        "ModelBiasJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelBiasAppSpecification",
+                        "ModelBiasJobInput",
+                        "ModelBiasJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelBiasJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources"
+                        },
+                        "ModelExplainabilityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification"
+                        },
+                        "ModelExplainabilityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig"
+                        },
+                        "ModelExplainabilityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput"
+                        },
+                        "ModelExplainabilityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelExplainabilityAppSpecification",
+                        "ModelExplainabilityJobInput",
+                        "ModelExplainabilityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelExplainabilityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelPackageGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModelPackageGroupDescription": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupName": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupPolicy": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ModelPackageGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelPackageGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources"
+                        },
+                        "ModelQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification"
+                        },
+                        "ModelQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig"
+                        },
+                        "ModelQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput"
+                        },
+                        "ModelQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelQualityAppSpecification",
+                        "ModelQualityJobInput",
+                        "ModelQualityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "ProblemType": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri",
+                "ProblemType"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::MonitoringSchedule": {
             "additionalProperties": false,
             "properties": {
@@ -76746,9 +82589,6 @@ var CloudformationSchema = `{
                         },
                         "LastMonitoringExecutionSummary": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringExecutionSummary"
-                        },
-                        "MonitoringScheduleArn": {
-                            "type": "string"
                         },
                         "MonitoringScheduleConfig": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringScheduleConfig"
@@ -77043,13 +82883,16 @@ var CloudformationSchema = `{
                 "MonitoringJobDefinition": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringJobDefinition"
                 },
+                "MonitoringJobDefinitionName": {
+                    "type": "string"
+                },
+                "MonitoringType": {
+                    "type": "string"
+                },
                 "ScheduleConfig": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.ScheduleConfig"
                 }
             },
-            "required": [
-                "MonitoringJobDefinition"
-            ],
             "type": "object"
         },
         "AWS::SageMaker::MonitoringSchedule.NetworkConfig": {
@@ -77332,6 +83175,163 @@ var CloudformationSchema = `{
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Pipeline": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PipelineDefinition": {
+                            "type": "object"
+                        },
+                        "PipelineDescription": {
+                            "type": "string"
+                        },
+                        "PipelineDisplayName": {
+                            "type": "string"
+                        },
+                        "PipelineName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PipelineDefinition",
+                        "PipelineName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Pipeline"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "ServiceCatalogProvisioningDetails": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ProjectName",
+                        "ServiceCatalogProvisioningDetails"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::SageMaker::Workteam": {
@@ -80322,7 +86322,7 @@ var CloudformationSchema = `{
                 },
                 "SecurityGroupIds": {
                     "items": {
-                        "$ref": "#/definitions/AWS::Transfer::Server.SecurityGroupId"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -80358,11 +86358,6 @@ var CloudformationSchema = `{
             "type": "object"
         },
         "AWS::Transfer::Server.Protocol": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::Transfer::Server.SecurityGroupId": {
             "additionalProperties": false,
             "properties": {},
             "type": "object"
@@ -84468,6 +90463,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Athena::WorkGroup"
                         },
                         {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup"
                         },
                         {
@@ -84529,6 +90527,12 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Macro"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleDefaultVersion"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleVersion"
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Stack"
@@ -84756,6 +90760,12 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Detective::MemberInvitation"
                         },
                         {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD"
                         },
                         {
@@ -84844,6 +90854,12 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkAclEntry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsPath"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkInterface"
@@ -84966,6 +90982,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::EC2::VolumeAttachment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::ECR::PublicRepository"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::ECR::Repository"
                         },
                         {
@@ -85036,6 +91055,12 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::ElastiCache::SubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::User"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup"
                         },
                         {
                             "$ref": "#/definitions/AWS::ElasticBeanstalk::Application"
@@ -85236,6 +91261,9 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Greengrass::SubscriptionDefinitionVersion"
                         },
                         {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::GuardDuty::Detector"
                         },
                         {
@@ -85374,16 +91402,43 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::IoTEvents::Input"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Asset"
                         },
                         {
                             "$ref": "#/definitions/AWS::IoTSiteWise::AssetModel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Dashboard"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Gateway"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Portal"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Project"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTThingsGraph::FlowTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::Destination"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway"
                         },
                         {
                             "$ref": "#/definitions/AWS::KMS::Alias"
@@ -85467,6 +91522,12 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::Lambda::Version"
                         },
                         {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::LicenseManager::License"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Logs::Destination"
                         },
                         {
@@ -85483,6 +91544,9 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::MSK::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::MWAA::Environment"
                         },
                         {
                             "$ref": "#/definitions/AWS::Macie::CustomDataIdentifier"
@@ -85857,10 +91921,22 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::SSO::Assignment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSO::PermissionSet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Device"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -85872,6 +91948,18 @@ var CloudformationSchema = `{
                             "$ref": "#/definitions/AWS::SageMaker::Model"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelPackageGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule"
                         },
                         {
@@ -85879,6 +91967,12 @@ var CloudformationSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Pipeline"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Project"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Workteam"

--- a/schema/cloudformation.schema.json
+++ b/schema/cloudformation.schema.json
@@ -6165,6 +6165,9 @@
                 },
                 "Snowflake": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SnowflakeDestinationProperties"
+                },
+                "Upsolver": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverDestinationProperties"
                 }
             },
             "type": "object"
@@ -6240,6 +6243,15 @@
             "required": [
                 "Object"
             ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.IncrementalPullConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DatetimeTypeFieldName": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::AppFlow::Flow.InforNexusSourceProperties": {
@@ -6521,6 +6533,9 @@
                 "ConnectorType": {
                     "type": "string"
                 },
+                "IncrementalPullConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.IncrementalPullConfig"
+                },
                 "SourceConnectorProperties": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SourceConnectorProperties"
                 }
@@ -6602,6 +6617,43 @@
             },
             "required": [
                 "TriggerType"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketName": {
+                    "type": "string"
+                },
+                "BucketPrefix": {
+                    "type": "string"
+                },
+                "S3OutputFormatConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig"
+                }
+            },
+            "required": [
+                "BucketName",
+                "S3OutputFormatConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AggregationConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.AggregationConfig"
+                },
+                "FileType": {
+                    "type": "string"
+                },
+                "PrefixConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.PrefixConfig"
+                }
+            },
+            "required": [
+                "PrefixConfig"
             ],
             "type": "object"
         },
@@ -10883,6 +10935,9 @@
                     },
                     "type": "array"
                 },
+                "JMXPrometheusExporter": {
+                    "$ref": "#/definitions/AWS::ApplicationInsights::Application.JMXPrometheusExporter"
+                },
                 "Logs": {
                     "items": {
                         "$ref": "#/definitions/AWS::ApplicationInsights::Application.Log"
@@ -10915,6 +10970,21 @@
                 "ComponentName",
                 "ResourceList"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationInsights::Application.JMXPrometheusExporter": {
+            "additionalProperties": false,
+            "properties": {
+                "HostPort": {
+                    "type": "string"
+                },
+                "JMXURL": {
+                    "type": "string"
+                },
+                "PrometheusPort": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationInsights::Application.Log": {
@@ -11396,6 +11466,247 @@
             },
             "type": "object"
         },
+        "AWS::AuditManager::Assessment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "assessmentReportsDestination": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AssessmentReportsDestination"
+                        },
+                        "awsAccount": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "frameworkId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "roles": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Roles"
+                        },
+                        "scope": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Scope"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Tags"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AuditManager::Assessment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccount": {
+            "additionalProperties": false,
+            "properties": {
+                "emailAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccounts": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSAccounts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSService": {
+            "additionalProperties": false,
+            "properties": {
+                "serviceName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSServices": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSServices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSService"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AssessmentReportsDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "destination": {
+                    "type": "string"
+                },
+                "destinationType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegation": {
+            "additionalProperties": false,
+            "properties": {
+                "assessmentId": {
+                    "type": "string"
+                },
+                "assessmentName": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "controlSetId": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "type": "string"
+                },
+                "creationTime": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastUpdated": {
+                    "type": "number"
+                },
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegations": {
+            "additionalProperties": false,
+            "properties": {
+                "Delegations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Delegation"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Role": {
+            "additionalProperties": false,
+            "properties": {
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Roles": {
+            "additionalProperties": false,
+            "properties": {
+                "Roles": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Role"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Scope": {
+            "additionalProperties": false,
+            "properties": {
+                "awsAccounts": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccounts"
+                },
+                "awsServices": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSServices"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Tags": {
+            "additionalProperties": false,
+            "properties": {
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::AutoScaling::AutoScalingGroup": {
             "additionalProperties": false,
             "properties": {
@@ -11819,7 +12130,7 @@
                             "type": "string"
                         },
                         "MetadataOptions": {
-                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOption"
+                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOptions"
                         },
                         "PlacementTenancy": {
                             "type": "string"
@@ -11912,7 +12223,7 @@
             ],
             "type": "object"
         },
-        "AWS::AutoScaling::LaunchConfiguration.MetadataOption": {
+        "AWS::AutoScaling::LaunchConfiguration.MetadataOptions": {
             "additionalProperties": false,
             "properties": {
                 "HttpEndpoint": {
@@ -13100,10 +13411,7 @@
                 }
             },
             "required": [
-                "InstanceRole",
-                "InstanceTypes",
                 "MaxvCpus",
-                "MinvCpus",
                 "Subnets",
                 "Type"
             ],
@@ -13183,6 +13491,15 @@
                         "Parameters": {
                             "type": "object"
                         },
+                        "PlatformCapabilities": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PropagateTags": {
+                            "type": "boolean"
+                        },
                         "RetryStrategy": {
                             "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
                         },
@@ -13240,6 +13557,9 @@
                 "ExecutionRoleArn": {
                     "type": "string"
                 },
+                "FargatePlatformConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.FargatePlatformConfiguration"
+                },
                 "Image": {
                     "type": "string"
                 },
@@ -13263,6 +13583,9 @@
                         "$ref": "#/definitions/AWS::Batch::JobDefinition.MountPoints"
                     },
                     "type": "array"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.NetworkConfiguration"
                 },
                 "Privileged": {
                     "type": "boolean"
@@ -13357,6 +13680,15 @@
             ],
             "type": "object"
         },
+        "AWS::Batch::JobDefinition.FargatePlatformConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PlatformVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Batch::JobDefinition.LinuxParameters": {
             "additionalProperties": false,
             "properties": {
@@ -13418,6 +13750,15 @@
                     "type": "boolean"
                 },
                 "SourceVolume": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
                     "type": "string"
                 }
             },
@@ -14609,6 +14950,135 @@
             ],
             "type": "object"
         },
+        "AWS::CloudFormation::ModuleDefaultVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Arn": {
+                            "type": "string"
+                        },
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "VersionId": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleDefaultVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::ModuleVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "ModulePackage": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ModuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::CloudFormation::Stack": {
             "additionalProperties": false,
             "properties": {
@@ -14779,6 +15249,10 @@
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "PermissionModel",
+                        "StackSetName"
+                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -14797,7 +15271,8 @@
                 }
             },
             "required": [
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
@@ -17357,6 +17832,9 @@
                         "DomainName": {
                             "type": "string"
                         },
+                        "EncryptionKey": {
+                            "type": "string"
+                        },
                         "PermissionsPolicyDocument": {
                             "type": "object"
                         },
@@ -17428,6 +17906,12 @@
                         "Description": {
                             "type": "string"
                         },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainOwner": {
+                            "type": "string"
+                        },
                         "ExternalConnections": {
                             "items": {
                                 "type": "string"
@@ -17454,6 +17938,7 @@
                         }
                     },
                     "required": [
+                        "DomainName",
                         "RepositoryName"
                     ],
                     "type": "object"
@@ -19000,6 +19485,12 @@
                         "Owner": {
                             "type": "string"
                         },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
                         "Type": {
                             "type": "string"
                         }
@@ -20332,6 +20823,30 @@
             },
             "type": "object"
         },
+        "AWS::Cognito::UserPool.CustomEmailSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.CustomSMSSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Cognito::UserPool.DeviceConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -20386,10 +20901,19 @@
                 "CreateAuthChallenge": {
                     "type": "string"
                 },
+                "CustomEmailSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomEmailSender"
+                },
                 "CustomMessage": {
                     "type": "string"
                 },
+                "CustomSMSSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomSMSSender"
+                },
                 "DefineAuthChallenge": {
+                    "type": "string"
+                },
+                "KMSKeyID": {
                     "type": "string"
                 },
                 "PostAuthentication": {
@@ -22813,6 +23337,12 @@
                         },
                         "State": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
@@ -25058,6 +25588,169 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Config": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig"
+                        }
+                    },
+                    "required": [
+                        "Config"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::NotificationChannel"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Sns": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TopicArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResourceCollectionFilter": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter"
+                        }
+                    },
+                    "required": [
+                        "ResourceCollectionFilter"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::ResourceCollection"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "StackNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudFormation": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter"
+                }
+            },
             "type": "object"
         },
         "AWS::DirectoryService::MicrosoftAD": {
@@ -27493,6 +28186,9 @@
                             },
                             "type": "array"
                         },
+                        "EnclaveOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.EnclaveOptions"
+                        },
                         "HibernationOptions": {
                             "$ref": "#/definitions/AWS::EC2::Instance.HibernationOptions"
                         },
@@ -27734,6 +28430,15 @@
             "required": [
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.EnclaveOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::Instance.HibernationOptions": {
@@ -28864,6 +29569,552 @@
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FilterInArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetworkInsightsPathId": {
+                            "type": "string"
+                        },
+                        "StatusMessage": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkInsightsPathId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsAnalysis"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AlternatePathHint": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentArn": {
+                    "type": "string"
+                },
+                "ComponentId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Egress": {
+                    "type": "boolean"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "RuleAction": {
+                    "type": "string"
+                },
+                "RuleNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener": {
+            "additionalProperties": false,
+            "properties": {
+                "InstancePort": {
+                    "type": "number"
+                },
+                "LoadBalancerPort": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Address": {
+                    "type": "string"
+                },
+                "AvailabilityZone": {
+                    "type": "string"
+                },
+                "Instance": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Port": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "DestinationAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "DestinationPortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SourceAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SourcePortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "NatGatewayId": {
+                    "type": "string"
+                },
+                "NetworkInterfaceId": {
+                    "type": "string"
+                },
+                "Origin": {
+                    "type": "string"
+                },
+                "TransitGatewayId": {
+                    "type": "string"
+                },
+                "VpcPeeringConnectionId": {
+                    "type": "string"
+                },
+                "destinationCidr": {
+                    "type": "string"
+                },
+                "destinationPrefixListId": {
+                    "type": "string"
+                },
+                "egressOnlyInternetGatewayId": {
+                    "type": "string"
+                },
+                "gatewayId": {
+                    "type": "string"
+                },
+                "instanceId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "PrefixListId": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SecurityGroupId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.Explanation": {
+            "additionalProperties": false,
+            "properties": {
+                "Acl": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Address": {
+                    "type": "string"
+                },
+                "Addresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AttachedTo": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AvailabilityZones": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Cidrs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ClassicLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "CustomerGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Destination": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "ElasticLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "ExplanationCode": {
+                    "type": "string"
+                },
+                "IngressRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InternetGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerArn": {
+                    "type": "string"
+                },
+                "LoadBalancerListenerPort": {
+                    "type": "number"
+                },
+                "LoadBalancerTarget": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget"
+                },
+                "LoadBalancerTargetGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerTargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "LoadBalancerTargetPort": {
+                    "type": "number"
+                },
+                "MissingComponent": {
+                    "type": "string"
+                },
+                "NatGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "NetworkInterface": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "PacketField": {
+                    "type": "string"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "PortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "PrefixList": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Protocols": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "State": {
+                    "type": "string"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SubnetRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpcPeeringConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "vpcEndpoint": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PathComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "OutboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SequenceNumber": {
+                    "type": "number"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PortRange": {
+            "additionalProperties": false,
+            "properties": {
+                "From": {
+                    "type": "number"
+                },
+                "To": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsPath": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Destination": {
+                            "type": "string"
+                        },
+                        "DestinationIp": {
+                            "type": "string"
+                        },
+                        "DestinationPort": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "Source": {
+                            "type": "string"
+                        },
+                        "SourceIp": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Destination",
+                        "Protocol",
+                        "Source"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsPath"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::EC2::NetworkInterface": {
@@ -30059,6 +31310,9 @@
                 "InstanceType": {
                     "type": "string"
                 },
+                "Priority": {
+                    "type": "number"
+                },
                 "SpotPrice": {
                     "type": "string"
                 },
@@ -30096,6 +31350,15 @@
             "required": [
                 "PrivateIpAddress"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotCapacityRebalance": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplacementStrategy": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetLaunchSpecification": {
@@ -30195,6 +31458,9 @@
                 "InstanceInterruptionBehavior": {
                     "type": "string"
                 },
+                "InstancePoolsToUseCount": {
+                    "type": "number"
+                },
                 "LaunchSpecifications": {
                     "items": {
                         "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetLaunchSpecification"
@@ -30210,8 +31476,23 @@
                 "LoadBalancersConfig": {
                     "$ref": "#/definitions/AWS::EC2::SpotFleet.LoadBalancersConfig"
                 },
+                "OnDemandAllocationStrategy": {
+                    "type": "string"
+                },
+                "OnDemandMaxTotalPrice": {
+                    "type": "string"
+                },
+                "OnDemandTargetCapacity": {
+                    "type": "number"
+                },
                 "ReplaceUnhealthyInstances": {
                     "type": "boolean"
+                },
+                "SpotMaintenanceStrategies": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotMaintenanceStrategies"
+                },
+                "SpotMaxTotalPrice": {
+                    "type": "string"
                 },
                 "SpotPrice": {
                     "type": "string"
@@ -30249,6 +31530,15 @@
                         "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotMaintenanceStrategies": {
+            "additionalProperties": false,
+            "properties": {
+                "CapacityRebalance": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotCapacityRebalance"
                 }
             },
             "type": "object"
@@ -32390,6 +33680,9 @@
                             },
                             "type": "array"
                         },
+                        "Throughput": {
+                            "type": "number"
+                        },
                         "VolumeType": {
                             "type": "string"
                         }
@@ -32487,6 +33780,70 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECR::PublicRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryCatalogData": {
+                            "type": "object"
+                        },
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "RepositoryPolicyText": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECR::PublicRepository"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -33036,9 +34393,28 @@
             },
             "type": "object"
         },
+        "AWS::ECS::Service.DeploymentCircuitBreaker": {
+            "additionalProperties": false,
+            "properties": {
+                "Enable": {
+                    "type": "boolean"
+                },
+                "Rollback": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "Enable",
+                "Rollback"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::Service.DeploymentConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentCircuitBreaker": {
+                    "$ref": "#/definitions/AWS::ECS::Service.DeploymentCircuitBreaker"
+                },
                 "MaximumPercent": {
                     "type": "number"
                 },
@@ -34711,6 +36087,9 @@
                     "additionalProperties": false,
                     "properties": {
                         "AmiType": {
+                            "type": "string"
+                        },
+                        "CapacityType": {
                             "type": "string"
                         },
                         "ClusterName": {
@@ -36705,6 +38084,12 @@
                         },
                         "TransitEncryptionEnabled": {
                             "type": "boolean"
+                        },
+                        "UserGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -36958,6 +38343,232 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessString": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "NoPasswordRequired": {
+                            "type": "boolean"
+                        },
+                        "Passwords": {
+                            "$ref": "#/definitions/AWS::ElastiCache::User.PasswordList"
+                        },
+                        "UserId": {
+                            "type": "string"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserId",
+                        "UserName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::User"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.Authentication": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordCount": {
+                    "type": "number"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.PasswordList": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.UserGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "UserGroupId": {
+                            "type": "string"
+                        },
+                        "UserIds": {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup.UserIdList"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::UserGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.ReplicationGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplicationGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserGroupPendingChanges": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdsToAdd": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "UserIdsToRemove": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application": {
@@ -38959,6 +40570,15 @@
         "AWS::Elasticsearch::Domain.DomainEndpointOptions": {
             "additionalProperties": false,
             "properties": {
+                "CustomEndpoint": {
+                    "type": "string"
+                },
+                "CustomEndpointCertificateArn": {
+                    "type": "string"
+                },
+                "CustomEndpointEnabled": {
+                    "type": "boolean"
+                },
                 "EnforceHTTPS": {
                     "type": "boolean"
                 },
@@ -39475,6 +41095,9 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "ArchiveName": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
@@ -42394,15 +44017,6 @@
             ],
             "type": "object"
         },
-        "AWS::Glue::Database.DataLakePrincipal": {
-            "additionalProperties": false,
-            "properties": {
-                "DataLakePrincipalIdentifier": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "AWS::Glue::Database.DatabaseIdentifier": {
             "additionalProperties": false,
             "properties": {
@@ -42418,12 +44032,6 @@
         "AWS::Glue::Database.DatabaseInput": {
             "additionalProperties": false,
             "properties": {
-                "CreateTableDefaultPermissions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Glue::Database.PrincipalPrivileges"
-                    },
-                    "type": "array"
-                },
                 "Description": {
                     "type": "string"
                 },
@@ -42438,21 +44046,6 @@
                 },
                 "TargetDatabase": {
                     "$ref": "#/definitions/AWS::Glue::Database.DatabaseIdentifier"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::Glue::Database.PrincipalPrivileges": {
-            "additionalProperties": false,
-            "properties": {
-                "Permissions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Principal": {
-                    "$ref": "#/definitions/AWS::Glue::Database.DataLakePrincipal"
                 }
             },
             "type": "object"
@@ -43051,6 +44644,36 @@
             ],
             "type": "object"
         },
+        "AWS::Glue::Partition.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Partition.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Partition.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43119,6 +44742,9 @@
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Partition.SerdeInfo"
@@ -43699,6 +45325,36 @@
             ],
             "type": "object"
         },
+        "AWS::Glue::Table.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Table.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Table.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43767,6 +45423,9 @@
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Table.SerdeInfo"
@@ -46112,6 +47771,271 @@
                 "Subject",
                 "Target"
             ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InlineRecipe": {
+                            "type": "string"
+                        },
+                        "LambdaFunction": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource"
+                        },
+                        "Tags": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GreengrassV2::ComponentVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement": {
+            "additionalProperties": false,
+            "properties": {
+                "DependencyType": {
+                    "type": "string"
+                },
+                "VersionRequirement": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentPlatform": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaContainerParams": {
+            "additionalProperties": false,
+            "properties": {
+                "Devices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount"
+                    },
+                    "type": "array"
+                },
+                "MemorySizeInKB": {
+                    "type": "number"
+                },
+                "MountROSysfs": {
+                    "type": "boolean"
+                },
+                "Volumes": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Topic": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "EnvironmentVariables": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "EventSources": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaEventSource"
+                    },
+                    "type": "array"
+                },
+                "ExecArgs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "InputPayloadEncodingType": {
+                    "type": "string"
+                },
+                "LinuxProcessParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams"
+                },
+                "MaxIdleTimeInSeconds": {
+                    "type": "number"
+                },
+                "MaxInstancesCount": {
+                    "type": "number"
+                },
+                "MaxQueueSize": {
+                    "type": "number"
+                },
+                "Pinned": {
+                    "type": "boolean"
+                },
+                "StatusTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TimeoutInSeconds": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentDependencies": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ComponentLambdaParameters": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters"
+                },
+                "ComponentName": {
+                    "type": "string"
+                },
+                "ComponentPlatforms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentPlatform"
+                    },
+                    "type": "array"
+                },
+                "ComponentVersion": {
+                    "type": "string"
+                },
+                "LambdaArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaContainerParams"
+                },
+                "IsolationMode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "DestinationPath": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                },
+                "SourcePath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::GuardDuty::Detector": {
@@ -50101,6 +52025,9 @@
                         },
                         "Status": {
                             "type": "string"
+                        },
+                        "VpcProperties": {
+                            "$ref": "#/definitions/AWS::IoT::TopicRuleDestination.VpcDestinationProperties"
                         }
                     },
                     "type": "object"
@@ -50129,6 +52056,30 @@
             "additionalProperties": false,
             "properties": {
                 "ConfirmationUrl": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRuleDestination.VpcDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "RoleArn": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "VpcId": {
                     "type": "string"
                 }
             },
@@ -51612,6 +53563,124 @@
             },
             "type": "object"
         },
+        "AWS::IoTSiteWise::AccessPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessPolicyIdentity": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity"
+                        },
+                        "AccessPolicyPermission": {
+                            "type": "string"
+                        },
+                        "AccessPolicyResource": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource"
+                        }
+                    },
+                    "required": [
+                        "AccessPolicyIdentity",
+                        "AccessPolicyPermission",
+                        "AccessPolicyResource"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::AccessPolicy"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity": {
+            "additionalProperties": false,
+            "properties": {
+                "User": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.User"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource": {
+            "additionalProperties": false,
+            "properties": {
+                "Portal": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Portal"
+                },
+                "Project": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Project"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Project": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.User": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Asset": {
             "additionalProperties": false,
             "properties": {
@@ -51984,6 +54053,85 @@
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Dashboard": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DashboardDefinition": {
+                            "type": "string"
+                        },
+                        "DashboardDescription": {
+                            "type": "string"
+                        },
+                        "DashboardName": {
+                            "type": "string"
+                        },
+                        "ProjectId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DashboardDefinition",
+                        "DashboardDescription",
+                        "DashboardName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Dashboard"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Gateway": {
             "additionalProperties": false,
             "properties": {
@@ -52101,6 +54249,187 @@
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalContactEmail": {
+                            "type": "string"
+                        },
+                        "PortalDescription": {
+                            "type": "string"
+                        },
+                        "PortalName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalContactEmail",
+                        "PortalName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Portal"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.MonitorErrorDetails": {
+            "additionalProperties": false,
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.PortalStatus": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::Portal.MonitorErrorDetails"
+                },
+                "state": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "state"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalId": {
+                            "type": "string"
+                        },
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalId",
+                        "ProjectName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTThingsGraph::FlowTemplate": {
             "additionalProperties": false,
             "properties": {
@@ -52180,6 +54509,639 @@
                 "Language",
                 "Text"
             ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::Destination": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Expression": {
+                            "type": "string"
+                        },
+                        "ExpressionType": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Expression",
+                        "ExpressionType",
+                        "Name",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::Destination"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANDeviceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::DeviceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "ClassBTimeout": {
+                    "type": "number"
+                },
+                "ClassCTimeout": {
+                    "type": "number"
+                },
+                "MacVersion": {
+                    "type": "string"
+                },
+                "MaxDutyCycle": {
+                    "type": "number"
+                },
+                "MaxEirp": {
+                    "type": "number"
+                },
+                "PingSlotDr": {
+                    "type": "number"
+                },
+                "PingSlotFreq": {
+                    "type": "number"
+                },
+                "PingSlotPeriod": {
+                    "type": "number"
+                },
+                "RegParamsRevision": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                },
+                "Supports32BitFCnt": {
+                    "type": "boolean"
+                },
+                "SupportsClassB": {
+                    "type": "boolean"
+                },
+                "SupportsClassC": {
+                    "type": "boolean"
+                },
+                "SupportsJoin": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANGetServiceProfileInfo": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo"
+                        },
+                        "LoRaWANServiceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::ServiceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                },
+                "ChannelMask": {
+                    "type": "string"
+                },
+                "DevStatusReqFreq": {
+                    "type": "number"
+                },
+                "DlBucketSize": {
+                    "type": "number"
+                },
+                "DlRate": {
+                    "type": "number"
+                },
+                "DlRatePolicy": {
+                    "type": "string"
+                },
+                "DrMax": {
+                    "type": "number"
+                },
+                "DrMin": {
+                    "type": "number"
+                },
+                "HrAllowed": {
+                    "type": "boolean"
+                },
+                "MinGwDiversity": {
+                    "type": "number"
+                },
+                "NwkGeoLoc": {
+                    "type": "boolean"
+                },
+                "PrAllowed": {
+                    "type": "boolean"
+                },
+                "RaAllowed": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusBattery": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusMargin": {
+                    "type": "boolean"
+                },
+                "TargetPer": {
+                    "type": "number"
+                },
+                "UlBucketSize": {
+                    "type": "number"
+                },
+                "UlRate": {
+                    "type": "number"
+                },
+                "UlRatePolicy": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DestinationName": {
+                            "type": "string"
+                        },
+                        "LoRaWANDevice": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.LoRaWANDevice"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessDevice"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.LoRaWANDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "AbpV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV10X"
+                },
+                "AbpV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV11"
+                },
+                "DevEui": {
+                    "type": "string"
+                },
+                "DeviceProfileId": {
+                    "type": "string"
+                },
+                "OtaaV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV10X"
+                },
+                "OtaaV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV11"
+                },
+                "ServiceProfileId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppEui": {
+                    "type": "string"
+                },
+                "AppKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppKey": {
+                    "type": "string"
+                },
+                "JoinEui": {
+                    "type": "string"
+                },
+                "NwkKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "NwkSKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "FNwkSIntKey": {
+                    "type": "string"
+                },
+                "NwkSEncKey": {
+                    "type": "string"
+                },
+                "SNwkSIntKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "LoRaWANGateway": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway.LoRaWANGateway"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LoRaWANGateway"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessGateway"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway.LoRaWANGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "GatewayEui": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::KMS::Alias": {
@@ -52478,6 +55440,234 @@
             ],
             "type": "object"
         },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList"
+                },
+                "CrawlAttachments": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceAttachmentFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlogFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceBlogFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration"
+                },
+                "BlogConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogConfiguration"
+                },
+                "ExclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "InclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "PageConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageConfiguration"
+                },
+                "SecretArn": {
+                    "type": "string"
+                },
+                "ServerUrl": {
+                    "type": "string"
+                },
+                "SpaceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceConfiguration"
+                },
+                "Version": {
+                    "type": "string"
+                },
+                "VpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceVpcConfiguration"
+                }
+            },
+            "required": [
+                "SecretArn",
+                "ServerUrl",
+                "Version"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PageFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluencePageFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CrawlArchivedSpaces": {
+                    "type": "boolean"
+                },
+                "CrawlPersonalSpaces": {
+                    "type": "boolean"
+                },
+                "ExcludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "IncludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "SpaceFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::DataSource.ConnectionConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -52509,6 +55699,9 @@
         "AWS::Kendra::DataSource.DataSourceConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "ConfluenceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceConfiguration"
+                },
                 "DatabaseConfiguration": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DatabaseConfiguration"
                 },
@@ -52636,6 +55829,9 @@
         "AWS::Kendra::DataSource.OneDriveConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "ExclusionPatterns": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
                 },
@@ -53013,6 +56209,9 @@
                 "CrawlAttachments": {
                     "type": "boolean"
                 },
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "DocumentTitleFieldName": {
                     "type": "string"
                 },
@@ -53238,6 +56437,12 @@
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::Kendra::Index.TagList"
+                        },
+                        "UserContextPolicy": {
+                            "type": "string"
+                        },
+                        "UserTokenConfigurations": {
+                            "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfigurationList"
                         }
                     },
                     "required": [
@@ -53318,6 +56523,52 @@
             },
             "type": "object"
         },
+        "AWS::Kendra::Index.JsonTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "GroupAttributeField",
+                "UserNameAttributeField"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::Index.JwtTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ClaimRegex": {
+                    "type": "string"
+                },
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "Issuer": {
+                    "type": "string"
+                },
+                "KeyLocation": {
+                    "type": "string"
+                },
+                "SecretManagerArn": {
+                    "type": "string"
+                },
+                "URL": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KeyLocation"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::Index.Relevance": {
             "additionalProperties": false,
             "properties": {
@@ -53372,6 +56623,30 @@
                 "TagList": {
                     "items": {
                         "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "JsonTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JsonTokenTypeConfiguration"
+                },
+                "JwtTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JwtTokenTypeConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfigurationList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserTokenConfigurationList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfiguration"
                     },
                     "type": "array"
                 }
@@ -56539,6 +59814,12 @@
                         "FunctionName": {
                             "type": "string"
                         },
+                        "FunctionResponseTypes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "MaximumBatchingWindowInSeconds": {
                             "type": "number"
                         },
@@ -56560,6 +59841,9 @@
                             },
                             "type": "array"
                         },
+                        "SelfManagedEventSource": {
+                            "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SelfManagedEventSource"
+                        },
                         "SourceAccessConfigurations": {
                             "items": {
                                 "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SourceAccessConfiguration"
@@ -56580,7 +59864,6 @@
                         }
                     },
                     "required": [
-                        "EventSourceArn",
                         "FunctionName"
                     ],
                     "type": "object"
@@ -56615,11 +59898,32 @@
             },
             "type": "object"
         },
+        "AWS::Lambda::EventSourceMapping.Endpoints": {
+            "additionalProperties": false,
+            "properties": {
+                "KafkaBootstrapServers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Lambda::EventSourceMapping.OnFailure": {
             "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::EventSourceMapping.SelfManagedEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Endpoints": {
+                    "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.Endpoints"
                 }
             },
             "type": "object"
@@ -56695,6 +59999,9 @@
                         "Handler": {
                             "type": "string"
                         },
+                        "ImageConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.ImageConfig"
+                        },
                         "KmsKeyArn": {
                             "type": "string"
                         },
@@ -56706,6 +60013,9 @@
                         },
                         "MemorySize": {
                             "type": "number"
+                        },
+                        "PackageType": {
+                            "type": "string"
                         },
                         "ReservedConcurrentExecutions": {
                             "type": "number"
@@ -56734,9 +60044,7 @@
                     },
                     "required": [
                         "Code",
-                        "Handler",
-                        "Role",
-                        "Runtime"
+                        "Role"
                     ],
                     "type": "object"
                 },
@@ -56764,6 +60072,9 @@
         "AWS::Lambda::Function.Code": {
             "additionalProperties": false,
             "properties": {
+                "ImageUri": {
+                    "type": "string"
+                },
                 "S3Bucket": {
                     "type": "string"
                 },
@@ -56817,6 +60128,27 @@
                 "Arn",
                 "LocalMountPath"
             ],
+            "type": "object"
+        },
+        "AWS::Lambda::Function.ImageConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Command": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "EntryPoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "WorkingDirectory": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Lambda::Function.TracingConfig": {
@@ -57178,6 +60510,555 @@
             },
             "required": [
                 "ProvisionedConcurrentExecutions"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.FilterList"
+                        },
+                        "GrantArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "GrantName": {
+                            "type": "string"
+                        },
+                        "GrantStatus": {
+                            "type": "string"
+                        },
+                        "GrantedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "GranteePrincipalArn": {
+                            "type": "string"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "LicenseArn": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ParentArn": {
+                            "type": "string"
+                        },
+                        "Principals": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "StatusReason": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.TagList"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::Grant"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.AllowedOperationList": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedOperationList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::Grant.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::Grant.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Beneficiary": {
+                            "type": "string"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "ConsumptionConfiguration": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ConsumptionConfiguration"
+                        },
+                        "Entitlements": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.EntitlementList"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.FilterList"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "Issuer": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.IssuerData"
+                        },
+                        "LicenseArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ArnList"
+                        },
+                        "LicenseMetadata": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.MetadataList"
+                        },
+                        "LicenseName": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ProductName": {
+                            "type": "string"
+                        },
+                        "ProductSKU": {
+                            "type": "string"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.TagList"
+                        },
+                        "Validity": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ValidityDateFormat"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConsumptionConfiguration",
+                        "Entitlements",
+                        "HomeRegion",
+                        "Issuer",
+                        "Validity"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::License"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.BorrowConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowEarlyCheckIn": {
+                    "type": "boolean"
+                },
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "AllowEarlyCheckIn",
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ConsumptionConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BorrowConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.BorrowConfiguration"
+                },
+                "ProvisionalConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.ProvisionalConfiguration"
+                },
+                "RenewType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Entitlement": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCheckIn": {
+                    "type": "boolean"
+                },
+                "CheckoutRules": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.RuleList"
+                },
+                "MaxCount": {
+                    "type": "number"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Overage": {
+                    "type": "boolean"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.EntitlementList": {
+            "additionalProperties": false,
+            "properties": {
+                "EntitlementList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Entitlement"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.IssuerData": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "SignKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Metadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.MetadataList": {
+            "additionalProperties": false,
+            "properties": {
+                "MetadataList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Metadata"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ProvisionalConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.RuleList": {
+            "additionalProperties": false,
+            "properties": {
+                "RuleList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Rule"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ValidityDateFormat": {
+            "additionalProperties": false,
+            "properties": {
+                "Begin": {
+                    "type": "string"
+                },
+                "End": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Begin",
+                "End"
             ],
             "type": "object"
         },
@@ -57916,6 +61797,224 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AirflowConfigurationOptions": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.AirflowConfigurationOptions"
+                        },
+                        "AirflowVersion": {
+                            "type": "string"
+                        },
+                        "DagS3Path": {
+                            "type": "string"
+                        },
+                        "EnvironmentClass": {
+                            "type": "string"
+                        },
+                        "ExecutionRoleArn": {
+                            "type": "string"
+                        },
+                        "KmsKey": {
+                            "type": "string"
+                        },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.LoggingConfiguration"
+                        },
+                        "MaxWorkers": {
+                            "type": "number"
+                        },
+                        "NetworkConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.NetworkConfiguration"
+                        },
+                        "PluginsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "PluginsS3Path": {
+                            "type": "string"
+                        },
+                        "RequirementsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "RequirementsS3Path": {
+                            "type": "string"
+                        },
+                        "SourceBucketArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.TagMap"
+                        },
+                        "WebserverAccessMode": {
+                            "type": "string"
+                        },
+                        "WebserverUrl": {
+                            "type": "string"
+                        },
+                        "WeeklyMaintenanceWindowStart": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::MWAA::Environment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.AirflowConfigurationOptions": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LastUpdate": {
+            "additionalProperties": false,
+            "properties": {
+                "CreatedAt": {
+                    "type": "string"
+                },
+                "Error": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.UpdateError"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DagProcessingLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "SchedulerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "TaskLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WebserverLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WorkerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.ModuleLoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogGroupArn": {
+                    "type": "string"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "LogLevel": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SecurityGroupList"
+                },
+                "SubnetIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SubnetList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SecurityGroupList": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SubnetList": {
+            "additionalProperties": false,
+            "properties": {
+                "SubnetList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.TagMap": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.UpdateError": {
+            "additionalProperties": false,
+            "properties": {
+                "ErrorCode": {
+                    "type": "string"
+                },
+                "ErrorMessage": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -63228,7 +67327,10 @@
                             "type": "array"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::Firewall.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VpcId": {
                             "type": "string"
@@ -63275,18 +67377,6 @@
             ],
             "type": "object"
         },
-        "AWS::NetworkFirewall::Firewall.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::FirewallPolicy": {
             "additionalProperties": false,
             "properties": {
@@ -63329,7 +67419,10 @@
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::FirewallPolicy.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -63521,18 +67614,6 @@
             },
             "type": "object"
         },
-        "AWS::NetworkFirewall::FirewallPolicy.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::LoggingConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -63565,11 +67646,18 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "FirewallArn": {
+                            "type": "string"
+                        },
+                        "FirewallName": {
+                            "type": "string"
+                        },
                         "LoggingConfiguration": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::LoggingConfiguration.LoggingConfiguration"
                         }
                     },
                     "required": [
+                        "FirewallArn",
                         "LoggingConfiguration"
                     ],
                     "type": "object"
@@ -63686,14 +67774,14 @@
                         "RuleGroup": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.RuleGroup"
                         },
-                        "RuleGroupId": {
-                            "type": "string"
-                        },
                         "RuleGroupName": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "Type": {
                             "type": "string"
@@ -64175,18 +68263,6 @@
                 "TCPFlags": {
                     "items": {
                         "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.TCPFlagField"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::NetworkFirewall::RuleGroup.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
                 }
@@ -73029,6 +77105,18 @@
             },
             "type": "object"
         },
+        "AWS::S3::Bucket.ReplicaModifications": {
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Status"
+            ],
+            "type": "object"
+        },
         "AWS::S3::Bucket.ReplicationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -73284,6 +77372,9 @@
         "AWS::S3::Bucket.ServerSideEncryptionRule": {
             "additionalProperties": false,
             "properties": {
+                "BucketKeyEnabled": {
+                    "type": "boolean"
+                },
                 "ServerSideEncryptionByDefault": {
                     "$ref": "#/definitions/AWS::S3::Bucket.ServerSideEncryptionByDefault"
                 }
@@ -73293,6 +77384,9 @@
         "AWS::S3::Bucket.SourceSelectionCriteria": {
             "additionalProperties": false,
             "properties": {
+                "ReplicaModifications": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.ReplicaModifications"
+                },
                 "SseKmsEncryptedObjects": {
                     "$ref": "#/definitions/AWS::S3::Bucket.SseKmsEncryptedObjects"
                 }
@@ -76109,6 +80203,72 @@
             ],
             "type": "object"
         },
+        "AWS::SSO::InstanceAccessControlAttributeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InstanceAccessControlAttributeConfiguration": {
+                            "type": "object"
+                        },
+                        "InstanceArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "InstanceAccessControlAttributeConfiguration",
+                        "InstanceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::SSO::PermissionSet": {
             "additionalProperties": false,
             "properties": {
@@ -76282,6 +80442,502 @@
             ],
             "type": "object"
         },
+        "AWS::SageMaker::DataQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DataQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification"
+                        },
+                        "DataQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig"
+                        },
+                        "DataQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput"
+                        },
+                        "DataQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringResources"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DataQualityAppSpecification",
+                        "DataQualityJobInput",
+                        "DataQualityJobOutputConfig",
+                        "JobResources",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DataQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource"
+                },
+                "StatisticsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StatisticsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StatisticsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Device": {
+                            "type": "object"
+                        },
+                        "Tags": {}
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Device"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device.Device": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "DeviceName": {
+                    "type": "string"
+                },
+                "IotThingName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "OutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet.EdgeOutputConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {}
+                    },
+                    "required": [
+                        "OutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DeviceFleet"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet.EdgeOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "S3OutputLocation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3OutputLocation"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -76314,6 +80970,9 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "DeploymentConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::Endpoint.DeploymentConfig"
+                        },
                         "EndpointConfigName": {
                             "type": "string"
                         },
@@ -76359,6 +81018,100 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.Alarm": {
+            "additionalProperties": false,
+            "properties": {
+                "AlarmName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AlarmName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.AutoRollbackConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Alarms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::Endpoint.Alarm"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Alarms"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "MaximumExecutionTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TerminationWaitInSeconds": {
+                    "type": "number"
+                },
+                "TrafficRoutingConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.TrafficRoutingConfig"
+                }
+            },
+            "required": [
+                "TrafficRoutingConfiguration"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.CapacitySize": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.DeploymentConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AutoRollbackConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.AutoRollbackConfig"
+                },
+                "BlueGreenUpdatePolicy": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy"
+                }
+            },
+            "required": [
+                "BlueGreenUpdatePolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.TrafficRoutingConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "CanarySize": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.CapacitySize"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "WaitIntervalInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -76703,6 +81456,1096 @@
             ],
             "type": "object"
         },
+        "AWS::SageMaker::ModelBiasJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources"
+                        },
+                        "ModelBiasAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification"
+                        },
+                        "ModelBiasBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig"
+                        },
+                        "ModelBiasJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput"
+                        },
+                        "ModelBiasJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelBiasAppSpecification",
+                        "ModelBiasJobInput",
+                        "ModelBiasJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelBiasJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources"
+                        },
+                        "ModelExplainabilityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification"
+                        },
+                        "ModelExplainabilityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig"
+                        },
+                        "ModelExplainabilityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput"
+                        },
+                        "ModelExplainabilityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelExplainabilityAppSpecification",
+                        "ModelExplainabilityJobInput",
+                        "ModelExplainabilityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelExplainabilityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelPackageGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModelPackageGroupDescription": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupName": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupPolicy": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ModelPackageGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelPackageGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources"
+                        },
+                        "ModelQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification"
+                        },
+                        "ModelQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig"
+                        },
+                        "ModelQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput"
+                        },
+                        "ModelQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelQualityAppSpecification",
+                        "ModelQualityJobInput",
+                        "ModelQualityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "ProblemType": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri",
+                "ProblemType"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::MonitoringSchedule": {
             "additionalProperties": false,
             "properties": {
@@ -76743,9 +82586,6 @@
                         },
                         "LastMonitoringExecutionSummary": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringExecutionSummary"
-                        },
-                        "MonitoringScheduleArn": {
-                            "type": "string"
                         },
                         "MonitoringScheduleConfig": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringScheduleConfig"
@@ -77040,13 +82880,16 @@
                 "MonitoringJobDefinition": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringJobDefinition"
                 },
+                "MonitoringJobDefinitionName": {
+                    "type": "string"
+                },
+                "MonitoringType": {
+                    "type": "string"
+                },
                 "ScheduleConfig": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.ScheduleConfig"
                 }
             },
-            "required": [
-                "MonitoringJobDefinition"
-            ],
             "type": "object"
         },
         "AWS::SageMaker::MonitoringSchedule.NetworkConfig": {
@@ -77329,6 +83172,163 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Pipeline": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PipelineDefinition": {
+                            "type": "object"
+                        },
+                        "PipelineDescription": {
+                            "type": "string"
+                        },
+                        "PipelineDisplayName": {
+                            "type": "string"
+                        },
+                        "PipelineName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PipelineDefinition",
+                        "PipelineName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Pipeline"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "ServiceCatalogProvisioningDetails": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ProjectName",
+                        "ServiceCatalogProvisioningDetails"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::SageMaker::Workteam": {
@@ -80319,7 +86319,7 @@
                 },
                 "SecurityGroupIds": {
                     "items": {
-                        "$ref": "#/definitions/AWS::Transfer::Server.SecurityGroupId"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -80355,11 +86355,6 @@
             "type": "object"
         },
         "AWS::Transfer::Server.Protocol": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::Transfer::Server.SecurityGroupId": {
             "additionalProperties": false,
             "properties": {},
             "type": "object"
@@ -84465,6 +90460,9 @@
                             "$ref": "#/definitions/AWS::Athena::WorkGroup"
                         },
                         {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup"
                         },
                         {
@@ -84526,6 +90524,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Macro"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleDefaultVersion"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleVersion"
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Stack"
@@ -84753,6 +90757,12 @@
                             "$ref": "#/definitions/AWS::Detective::MemberInvitation"
                         },
                         {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD"
                         },
                         {
@@ -84841,6 +90851,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkAclEntry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsPath"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkInterface"
@@ -84963,6 +90979,9 @@
                             "$ref": "#/definitions/AWS::EC2::VolumeAttachment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::ECR::PublicRepository"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::ECR::Repository"
                         },
                         {
@@ -85033,6 +91052,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::ElastiCache::SubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::User"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup"
                         },
                         {
                             "$ref": "#/definitions/AWS::ElasticBeanstalk::Application"
@@ -85233,6 +91258,9 @@
                             "$ref": "#/definitions/AWS::Greengrass::SubscriptionDefinitionVersion"
                         },
                         {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::GuardDuty::Detector"
                         },
                         {
@@ -85371,16 +91399,43 @@
                             "$ref": "#/definitions/AWS::IoTEvents::Input"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Asset"
                         },
                         {
                             "$ref": "#/definitions/AWS::IoTSiteWise::AssetModel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Dashboard"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Gateway"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Portal"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Project"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTThingsGraph::FlowTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::Destination"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway"
                         },
                         {
                             "$ref": "#/definitions/AWS::KMS::Alias"
@@ -85464,6 +91519,12 @@
                             "$ref": "#/definitions/AWS::Lambda::Version"
                         },
                         {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::LicenseManager::License"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Logs::Destination"
                         },
                         {
@@ -85480,6 +91541,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::MSK::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::MWAA::Environment"
                         },
                         {
                             "$ref": "#/definitions/AWS::Macie::CustomDataIdentifier"
@@ -85854,10 +91918,22 @@
                             "$ref": "#/definitions/AWS::SSO::Assignment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSO::PermissionSet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Device"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -85869,6 +91945,18 @@
                             "$ref": "#/definitions/AWS::SageMaker::Model"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelPackageGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule"
                         },
                         {
@@ -85876,6 +91964,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Pipeline"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Project"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Workteam"

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -6168,6 +6168,9 @@ var SamSchema = `{
                 },
                 "Snowflake": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SnowflakeDestinationProperties"
+                },
+                "Upsolver": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverDestinationProperties"
                 }
             },
             "type": "object"
@@ -6243,6 +6246,15 @@ var SamSchema = `{
             "required": [
                 "Object"
             ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.IncrementalPullConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DatetimeTypeFieldName": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::AppFlow::Flow.InforNexusSourceProperties": {
@@ -6524,6 +6536,9 @@ var SamSchema = `{
                 "ConnectorType": {
                     "type": "string"
                 },
+                "IncrementalPullConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.IncrementalPullConfig"
+                },
                 "SourceConnectorProperties": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SourceConnectorProperties"
                 }
@@ -6605,6 +6620,43 @@ var SamSchema = `{
             },
             "required": [
                 "TriggerType"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketName": {
+                    "type": "string"
+                },
+                "BucketPrefix": {
+                    "type": "string"
+                },
+                "S3OutputFormatConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig"
+                }
+            },
+            "required": [
+                "BucketName",
+                "S3OutputFormatConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AggregationConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.AggregationConfig"
+                },
+                "FileType": {
+                    "type": "string"
+                },
+                "PrefixConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.PrefixConfig"
+                }
+            },
+            "required": [
+                "PrefixConfig"
             ],
             "type": "object"
         },
@@ -10886,6 +10938,9 @@ var SamSchema = `{
                     },
                     "type": "array"
                 },
+                "JMXPrometheusExporter": {
+                    "$ref": "#/definitions/AWS::ApplicationInsights::Application.JMXPrometheusExporter"
+                },
                 "Logs": {
                     "items": {
                         "$ref": "#/definitions/AWS::ApplicationInsights::Application.Log"
@@ -10918,6 +10973,21 @@ var SamSchema = `{
                 "ComponentName",
                 "ResourceList"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationInsights::Application.JMXPrometheusExporter": {
+            "additionalProperties": false,
+            "properties": {
+                "HostPort": {
+                    "type": "string"
+                },
+                "JMXURL": {
+                    "type": "string"
+                },
+                "PrometheusPort": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationInsights::Application.Log": {
@@ -11399,6 +11469,247 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::AuditManager::Assessment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "assessmentReportsDestination": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AssessmentReportsDestination"
+                        },
+                        "awsAccount": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "frameworkId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "roles": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Roles"
+                        },
+                        "scope": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Scope"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Tags"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AuditManager::Assessment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccount": {
+            "additionalProperties": false,
+            "properties": {
+                "emailAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccounts": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSAccounts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSService": {
+            "additionalProperties": false,
+            "properties": {
+                "serviceName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSServices": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSServices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSService"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AssessmentReportsDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "destination": {
+                    "type": "string"
+                },
+                "destinationType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegation": {
+            "additionalProperties": false,
+            "properties": {
+                "assessmentId": {
+                    "type": "string"
+                },
+                "assessmentName": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "controlSetId": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "type": "string"
+                },
+                "creationTime": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastUpdated": {
+                    "type": "number"
+                },
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegations": {
+            "additionalProperties": false,
+            "properties": {
+                "Delegations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Delegation"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Role": {
+            "additionalProperties": false,
+            "properties": {
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Roles": {
+            "additionalProperties": false,
+            "properties": {
+                "Roles": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Role"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Scope": {
+            "additionalProperties": false,
+            "properties": {
+                "awsAccounts": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccounts"
+                },
+                "awsServices": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSServices"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Tags": {
+            "additionalProperties": false,
+            "properties": {
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::AutoScaling::AutoScalingGroup": {
             "additionalProperties": false,
             "properties": {
@@ -11822,7 +12133,7 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "MetadataOptions": {
-                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOption"
+                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOptions"
                         },
                         "PlacementTenancy": {
                             "type": "string"
@@ -11915,7 +12226,7 @@ var SamSchema = `{
             ],
             "type": "object"
         },
-        "AWS::AutoScaling::LaunchConfiguration.MetadataOption": {
+        "AWS::AutoScaling::LaunchConfiguration.MetadataOptions": {
             "additionalProperties": false,
             "properties": {
                 "HttpEndpoint": {
@@ -13103,10 +13414,7 @@ var SamSchema = `{
                 }
             },
             "required": [
-                "InstanceRole",
-                "InstanceTypes",
                 "MaxvCpus",
-                "MinvCpus",
                 "Subnets",
                 "Type"
             ],
@@ -13186,6 +13494,15 @@ var SamSchema = `{
                         "Parameters": {
                             "type": "object"
                         },
+                        "PlatformCapabilities": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PropagateTags": {
+                            "type": "boolean"
+                        },
                         "RetryStrategy": {
                             "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
                         },
@@ -13243,6 +13560,9 @@ var SamSchema = `{
                 "ExecutionRoleArn": {
                     "type": "string"
                 },
+                "FargatePlatformConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.FargatePlatformConfiguration"
+                },
                 "Image": {
                     "type": "string"
                 },
@@ -13266,6 +13586,9 @@ var SamSchema = `{
                         "$ref": "#/definitions/AWS::Batch::JobDefinition.MountPoints"
                     },
                     "type": "array"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.NetworkConfiguration"
                 },
                 "Privileged": {
                     "type": "boolean"
@@ -13360,6 +13683,15 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Batch::JobDefinition.FargatePlatformConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PlatformVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Batch::JobDefinition.LinuxParameters": {
             "additionalProperties": false,
             "properties": {
@@ -13421,6 +13753,15 @@ var SamSchema = `{
                     "type": "boolean"
                 },
                 "SourceVolume": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
                     "type": "string"
                 }
             },
@@ -14612,6 +14953,135 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::CloudFormation::ModuleDefaultVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Arn": {
+                            "type": "string"
+                        },
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "VersionId": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleDefaultVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::ModuleVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "ModulePackage": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ModuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::CloudFormation::Stack": {
             "additionalProperties": false,
             "properties": {
@@ -14782,6 +15252,10 @@ var SamSchema = `{
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "PermissionModel",
+                        "StackSetName"
+                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -14800,7 +15274,8 @@ var SamSchema = `{
                 }
             },
             "required": [
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
@@ -17360,6 +17835,9 @@ var SamSchema = `{
                         "DomainName": {
                             "type": "string"
                         },
+                        "EncryptionKey": {
+                            "type": "string"
+                        },
                         "PermissionsPolicyDocument": {
                             "type": "object"
                         },
@@ -17431,6 +17909,12 @@ var SamSchema = `{
                         "Description": {
                             "type": "string"
                         },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainOwner": {
+                            "type": "string"
+                        },
                         "ExternalConnections": {
                             "items": {
                                 "type": "string"
@@ -17457,6 +17941,7 @@ var SamSchema = `{
                         }
                     },
                     "required": [
+                        "DomainName",
                         "RepositoryName"
                     ],
                     "type": "object"
@@ -19003,6 +19488,12 @@ var SamSchema = `{
                         "Owner": {
                             "type": "string"
                         },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
                         "Type": {
                             "type": "string"
                         }
@@ -20335,6 +20826,30 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::Cognito::UserPool.CustomEmailSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.CustomSMSSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Cognito::UserPool.DeviceConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -20389,10 +20904,19 @@ var SamSchema = `{
                 "CreateAuthChallenge": {
                     "type": "string"
                 },
+                "CustomEmailSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomEmailSender"
+                },
                 "CustomMessage": {
                     "type": "string"
                 },
+                "CustomSMSSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomSMSSender"
+                },
                 "DefineAuthChallenge": {
+                    "type": "string"
+                },
+                "KMSKeyID": {
                     "type": "string"
                 },
                 "PostAuthentication": {
@@ -22816,6 +23340,12 @@ var SamSchema = `{
                         },
                         "State": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
@@ -25061,6 +25591,169 @@ var SamSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Config": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig"
+                        }
+                    },
+                    "required": [
+                        "Config"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::NotificationChannel"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Sns": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TopicArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResourceCollectionFilter": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter"
+                        }
+                    },
+                    "required": [
+                        "ResourceCollectionFilter"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::ResourceCollection"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "StackNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudFormation": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter"
+                }
+            },
             "type": "object"
         },
         "AWS::DirectoryService::MicrosoftAD": {
@@ -27496,6 +28189,9 @@ var SamSchema = `{
                             },
                             "type": "array"
                         },
+                        "EnclaveOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.EnclaveOptions"
+                        },
                         "HibernationOptions": {
                             "$ref": "#/definitions/AWS::EC2::Instance.HibernationOptions"
                         },
@@ -27737,6 +28433,15 @@ var SamSchema = `{
             "required": [
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.EnclaveOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::Instance.HibernationOptions": {
@@ -28867,6 +29572,552 @@ var SamSchema = `{
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FilterInArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetworkInsightsPathId": {
+                            "type": "string"
+                        },
+                        "StatusMessage": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkInsightsPathId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsAnalysis"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AlternatePathHint": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentArn": {
+                    "type": "string"
+                },
+                "ComponentId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Egress": {
+                    "type": "boolean"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "RuleAction": {
+                    "type": "string"
+                },
+                "RuleNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener": {
+            "additionalProperties": false,
+            "properties": {
+                "InstancePort": {
+                    "type": "number"
+                },
+                "LoadBalancerPort": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Address": {
+                    "type": "string"
+                },
+                "AvailabilityZone": {
+                    "type": "string"
+                },
+                "Instance": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Port": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "DestinationAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "DestinationPortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SourceAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SourcePortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "NatGatewayId": {
+                    "type": "string"
+                },
+                "NetworkInterfaceId": {
+                    "type": "string"
+                },
+                "Origin": {
+                    "type": "string"
+                },
+                "TransitGatewayId": {
+                    "type": "string"
+                },
+                "VpcPeeringConnectionId": {
+                    "type": "string"
+                },
+                "destinationCidr": {
+                    "type": "string"
+                },
+                "destinationPrefixListId": {
+                    "type": "string"
+                },
+                "egressOnlyInternetGatewayId": {
+                    "type": "string"
+                },
+                "gatewayId": {
+                    "type": "string"
+                },
+                "instanceId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "PrefixListId": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SecurityGroupId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.Explanation": {
+            "additionalProperties": false,
+            "properties": {
+                "Acl": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Address": {
+                    "type": "string"
+                },
+                "Addresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AttachedTo": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AvailabilityZones": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Cidrs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ClassicLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "CustomerGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Destination": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "ElasticLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "ExplanationCode": {
+                    "type": "string"
+                },
+                "IngressRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InternetGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerArn": {
+                    "type": "string"
+                },
+                "LoadBalancerListenerPort": {
+                    "type": "number"
+                },
+                "LoadBalancerTarget": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget"
+                },
+                "LoadBalancerTargetGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerTargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "LoadBalancerTargetPort": {
+                    "type": "number"
+                },
+                "MissingComponent": {
+                    "type": "string"
+                },
+                "NatGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "NetworkInterface": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "PacketField": {
+                    "type": "string"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "PortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "PrefixList": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Protocols": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "State": {
+                    "type": "string"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SubnetRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpcPeeringConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "vpcEndpoint": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PathComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "OutboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SequenceNumber": {
+                    "type": "number"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PortRange": {
+            "additionalProperties": false,
+            "properties": {
+                "From": {
+                    "type": "number"
+                },
+                "To": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsPath": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Destination": {
+                            "type": "string"
+                        },
+                        "DestinationIp": {
+                            "type": "string"
+                        },
+                        "DestinationPort": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "Source": {
+                            "type": "string"
+                        },
+                        "SourceIp": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Destination",
+                        "Protocol",
+                        "Source"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsPath"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::EC2::NetworkInterface": {
@@ -30062,6 +31313,9 @@ var SamSchema = `{
                 "InstanceType": {
                     "type": "string"
                 },
+                "Priority": {
+                    "type": "number"
+                },
                 "SpotPrice": {
                     "type": "string"
                 },
@@ -30099,6 +31353,15 @@ var SamSchema = `{
             "required": [
                 "PrivateIpAddress"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotCapacityRebalance": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplacementStrategy": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetLaunchSpecification": {
@@ -30198,6 +31461,9 @@ var SamSchema = `{
                 "InstanceInterruptionBehavior": {
                     "type": "string"
                 },
+                "InstancePoolsToUseCount": {
+                    "type": "number"
+                },
                 "LaunchSpecifications": {
                     "items": {
                         "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetLaunchSpecification"
@@ -30213,8 +31479,23 @@ var SamSchema = `{
                 "LoadBalancersConfig": {
                     "$ref": "#/definitions/AWS::EC2::SpotFleet.LoadBalancersConfig"
                 },
+                "OnDemandAllocationStrategy": {
+                    "type": "string"
+                },
+                "OnDemandMaxTotalPrice": {
+                    "type": "string"
+                },
+                "OnDemandTargetCapacity": {
+                    "type": "number"
+                },
                 "ReplaceUnhealthyInstances": {
                     "type": "boolean"
+                },
+                "SpotMaintenanceStrategies": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotMaintenanceStrategies"
+                },
+                "SpotMaxTotalPrice": {
+                    "type": "string"
                 },
                 "SpotPrice": {
                     "type": "string"
@@ -30252,6 +31533,15 @@ var SamSchema = `{
                         "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotMaintenanceStrategies": {
+            "additionalProperties": false,
+            "properties": {
+                "CapacityRebalance": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotCapacityRebalance"
                 }
             },
             "type": "object"
@@ -32393,6 +33683,9 @@ var SamSchema = `{
                             },
                             "type": "array"
                         },
+                        "Throughput": {
+                            "type": "number"
+                        },
                         "VolumeType": {
                             "type": "string"
                         }
@@ -32490,6 +33783,70 @@ var SamSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECR::PublicRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryCatalogData": {
+                            "type": "object"
+                        },
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "RepositoryPolicyText": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECR::PublicRepository"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -33039,9 +34396,28 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::ECS::Service.DeploymentCircuitBreaker": {
+            "additionalProperties": false,
+            "properties": {
+                "Enable": {
+                    "type": "boolean"
+                },
+                "Rollback": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "Enable",
+                "Rollback"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::Service.DeploymentConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentCircuitBreaker": {
+                    "$ref": "#/definitions/AWS::ECS::Service.DeploymentCircuitBreaker"
+                },
                 "MaximumPercent": {
                     "type": "number"
                 },
@@ -34714,6 +36090,9 @@ var SamSchema = `{
                     "additionalProperties": false,
                     "properties": {
                         "AmiType": {
+                            "type": "string"
+                        },
+                        "CapacityType": {
                             "type": "string"
                         },
                         "ClusterName": {
@@ -36708,6 +38087,12 @@ var SamSchema = `{
                         },
                         "TransitEncryptionEnabled": {
                             "type": "boolean"
+                        },
+                        "UserGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -36961,6 +38346,232 @@ var SamSchema = `{
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessString": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "NoPasswordRequired": {
+                            "type": "boolean"
+                        },
+                        "Passwords": {
+                            "$ref": "#/definitions/AWS::ElastiCache::User.PasswordList"
+                        },
+                        "UserId": {
+                            "type": "string"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserId",
+                        "UserName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::User"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.Authentication": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordCount": {
+                    "type": "number"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.PasswordList": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.UserGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "UserGroupId": {
+                            "type": "string"
+                        },
+                        "UserIds": {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup.UserIdList"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::UserGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.ReplicationGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplicationGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserGroupPendingChanges": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdsToAdd": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "UserIdsToRemove": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application": {
@@ -38962,6 +40573,15 @@ var SamSchema = `{
         "AWS::Elasticsearch::Domain.DomainEndpointOptions": {
             "additionalProperties": false,
             "properties": {
+                "CustomEndpoint": {
+                    "type": "string"
+                },
+                "CustomEndpointCertificateArn": {
+                    "type": "string"
+                },
+                "CustomEndpointEnabled": {
+                    "type": "boolean"
+                },
                 "EnforceHTTPS": {
                     "type": "boolean"
                 },
@@ -39478,6 +41098,9 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "ArchiveName": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
@@ -42397,15 +44020,6 @@ var SamSchema = `{
             ],
             "type": "object"
         },
-        "AWS::Glue::Database.DataLakePrincipal": {
-            "additionalProperties": false,
-            "properties": {
-                "DataLakePrincipalIdentifier": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "AWS::Glue::Database.DatabaseIdentifier": {
             "additionalProperties": false,
             "properties": {
@@ -42421,12 +44035,6 @@ var SamSchema = `{
         "AWS::Glue::Database.DatabaseInput": {
             "additionalProperties": false,
             "properties": {
-                "CreateTableDefaultPermissions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Glue::Database.PrincipalPrivileges"
-                    },
-                    "type": "array"
-                },
                 "Description": {
                     "type": "string"
                 },
@@ -42441,21 +44049,6 @@ var SamSchema = `{
                 },
                 "TargetDatabase": {
                     "$ref": "#/definitions/AWS::Glue::Database.DatabaseIdentifier"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::Glue::Database.PrincipalPrivileges": {
-            "additionalProperties": false,
-            "properties": {
-                "Permissions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Principal": {
-                    "$ref": "#/definitions/AWS::Glue::Database.DataLakePrincipal"
                 }
             },
             "type": "object"
@@ -43054,6 +44647,36 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Glue::Partition.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Partition.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Partition.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43122,6 +44745,9 @@ var SamSchema = `{
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Partition.SerdeInfo"
@@ -43702,6 +45328,36 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Glue::Table.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Table.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Table.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43770,6 +45426,9 @@ var SamSchema = `{
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Table.SerdeInfo"
@@ -46115,6 +47774,271 @@ var SamSchema = `{
                 "Subject",
                 "Target"
             ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InlineRecipe": {
+                            "type": "string"
+                        },
+                        "LambdaFunction": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource"
+                        },
+                        "Tags": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GreengrassV2::ComponentVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement": {
+            "additionalProperties": false,
+            "properties": {
+                "DependencyType": {
+                    "type": "string"
+                },
+                "VersionRequirement": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentPlatform": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaContainerParams": {
+            "additionalProperties": false,
+            "properties": {
+                "Devices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount"
+                    },
+                    "type": "array"
+                },
+                "MemorySizeInKB": {
+                    "type": "number"
+                },
+                "MountROSysfs": {
+                    "type": "boolean"
+                },
+                "Volumes": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Topic": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "EnvironmentVariables": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "EventSources": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaEventSource"
+                    },
+                    "type": "array"
+                },
+                "ExecArgs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "InputPayloadEncodingType": {
+                    "type": "string"
+                },
+                "LinuxProcessParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams"
+                },
+                "MaxIdleTimeInSeconds": {
+                    "type": "number"
+                },
+                "MaxInstancesCount": {
+                    "type": "number"
+                },
+                "MaxQueueSize": {
+                    "type": "number"
+                },
+                "Pinned": {
+                    "type": "boolean"
+                },
+                "StatusTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TimeoutInSeconds": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentDependencies": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ComponentLambdaParameters": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters"
+                },
+                "ComponentName": {
+                    "type": "string"
+                },
+                "ComponentPlatforms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentPlatform"
+                    },
+                    "type": "array"
+                },
+                "ComponentVersion": {
+                    "type": "string"
+                },
+                "LambdaArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaContainerParams"
+                },
+                "IsolationMode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "DestinationPath": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                },
+                "SourcePath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::GuardDuty::Detector": {
@@ -50104,6 +52028,9 @@ var SamSchema = `{
                         },
                         "Status": {
                             "type": "string"
+                        },
+                        "VpcProperties": {
+                            "$ref": "#/definitions/AWS::IoT::TopicRuleDestination.VpcDestinationProperties"
                         }
                     },
                     "type": "object"
@@ -50132,6 +52059,30 @@ var SamSchema = `{
             "additionalProperties": false,
             "properties": {
                 "ConfirmationUrl": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRuleDestination.VpcDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "RoleArn": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "VpcId": {
                     "type": "string"
                 }
             },
@@ -51615,6 +53566,124 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::IoTSiteWise::AccessPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessPolicyIdentity": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity"
+                        },
+                        "AccessPolicyPermission": {
+                            "type": "string"
+                        },
+                        "AccessPolicyResource": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource"
+                        }
+                    },
+                    "required": [
+                        "AccessPolicyIdentity",
+                        "AccessPolicyPermission",
+                        "AccessPolicyResource"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::AccessPolicy"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity": {
+            "additionalProperties": false,
+            "properties": {
+                "User": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.User"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource": {
+            "additionalProperties": false,
+            "properties": {
+                "Portal": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Portal"
+                },
+                "Project": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Project"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Project": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.User": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Asset": {
             "additionalProperties": false,
             "properties": {
@@ -51987,6 +54056,85 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Dashboard": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DashboardDefinition": {
+                            "type": "string"
+                        },
+                        "DashboardDescription": {
+                            "type": "string"
+                        },
+                        "DashboardName": {
+                            "type": "string"
+                        },
+                        "ProjectId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DashboardDefinition",
+                        "DashboardDescription",
+                        "DashboardName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Dashboard"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Gateway": {
             "additionalProperties": false,
             "properties": {
@@ -52104,6 +54252,187 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalContactEmail": {
+                            "type": "string"
+                        },
+                        "PortalDescription": {
+                            "type": "string"
+                        },
+                        "PortalName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalContactEmail",
+                        "PortalName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Portal"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.MonitorErrorDetails": {
+            "additionalProperties": false,
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.PortalStatus": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::Portal.MonitorErrorDetails"
+                },
+                "state": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "state"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalId": {
+                            "type": "string"
+                        },
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalId",
+                        "ProjectName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTThingsGraph::FlowTemplate": {
             "additionalProperties": false,
             "properties": {
@@ -52183,6 +54512,639 @@ var SamSchema = `{
                 "Language",
                 "Text"
             ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::Destination": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Expression": {
+                            "type": "string"
+                        },
+                        "ExpressionType": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Expression",
+                        "ExpressionType",
+                        "Name",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::Destination"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANDeviceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::DeviceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "ClassBTimeout": {
+                    "type": "number"
+                },
+                "ClassCTimeout": {
+                    "type": "number"
+                },
+                "MacVersion": {
+                    "type": "string"
+                },
+                "MaxDutyCycle": {
+                    "type": "number"
+                },
+                "MaxEirp": {
+                    "type": "number"
+                },
+                "PingSlotDr": {
+                    "type": "number"
+                },
+                "PingSlotFreq": {
+                    "type": "number"
+                },
+                "PingSlotPeriod": {
+                    "type": "number"
+                },
+                "RegParamsRevision": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                },
+                "Supports32BitFCnt": {
+                    "type": "boolean"
+                },
+                "SupportsClassB": {
+                    "type": "boolean"
+                },
+                "SupportsClassC": {
+                    "type": "boolean"
+                },
+                "SupportsJoin": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANGetServiceProfileInfo": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo"
+                        },
+                        "LoRaWANServiceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::ServiceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                },
+                "ChannelMask": {
+                    "type": "string"
+                },
+                "DevStatusReqFreq": {
+                    "type": "number"
+                },
+                "DlBucketSize": {
+                    "type": "number"
+                },
+                "DlRate": {
+                    "type": "number"
+                },
+                "DlRatePolicy": {
+                    "type": "string"
+                },
+                "DrMax": {
+                    "type": "number"
+                },
+                "DrMin": {
+                    "type": "number"
+                },
+                "HrAllowed": {
+                    "type": "boolean"
+                },
+                "MinGwDiversity": {
+                    "type": "number"
+                },
+                "NwkGeoLoc": {
+                    "type": "boolean"
+                },
+                "PrAllowed": {
+                    "type": "boolean"
+                },
+                "RaAllowed": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusBattery": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusMargin": {
+                    "type": "boolean"
+                },
+                "TargetPer": {
+                    "type": "number"
+                },
+                "UlBucketSize": {
+                    "type": "number"
+                },
+                "UlRate": {
+                    "type": "number"
+                },
+                "UlRatePolicy": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DestinationName": {
+                            "type": "string"
+                        },
+                        "LoRaWANDevice": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.LoRaWANDevice"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessDevice"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.LoRaWANDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "AbpV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV10X"
+                },
+                "AbpV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV11"
+                },
+                "DevEui": {
+                    "type": "string"
+                },
+                "DeviceProfileId": {
+                    "type": "string"
+                },
+                "OtaaV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV10X"
+                },
+                "OtaaV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV11"
+                },
+                "ServiceProfileId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppEui": {
+                    "type": "string"
+                },
+                "AppKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppKey": {
+                    "type": "string"
+                },
+                "JoinEui": {
+                    "type": "string"
+                },
+                "NwkKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "NwkSKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "FNwkSIntKey": {
+                    "type": "string"
+                },
+                "NwkSEncKey": {
+                    "type": "string"
+                },
+                "SNwkSIntKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "LoRaWANGateway": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway.LoRaWANGateway"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LoRaWANGateway"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessGateway"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway.LoRaWANGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "GatewayEui": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::KMS::Alias": {
@@ -52481,6 +55443,234 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList"
+                },
+                "CrawlAttachments": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceAttachmentFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlogFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceBlogFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration"
+                },
+                "BlogConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogConfiguration"
+                },
+                "ExclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "InclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "PageConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageConfiguration"
+                },
+                "SecretArn": {
+                    "type": "string"
+                },
+                "ServerUrl": {
+                    "type": "string"
+                },
+                "SpaceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceConfiguration"
+                },
+                "Version": {
+                    "type": "string"
+                },
+                "VpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceVpcConfiguration"
+                }
+            },
+            "required": [
+                "SecretArn",
+                "ServerUrl",
+                "Version"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PageFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluencePageFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CrawlArchivedSpaces": {
+                    "type": "boolean"
+                },
+                "CrawlPersonalSpaces": {
+                    "type": "boolean"
+                },
+                "ExcludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "IncludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "SpaceFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::DataSource.ConnectionConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -52512,6 +55702,9 @@ var SamSchema = `{
         "AWS::Kendra::DataSource.DataSourceConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "ConfluenceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceConfiguration"
+                },
                 "DatabaseConfiguration": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DatabaseConfiguration"
                 },
@@ -52639,6 +55832,9 @@ var SamSchema = `{
         "AWS::Kendra::DataSource.OneDriveConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "ExclusionPatterns": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
                 },
@@ -53016,6 +56212,9 @@ var SamSchema = `{
                 "CrawlAttachments": {
                     "type": "boolean"
                 },
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "DocumentTitleFieldName": {
                     "type": "string"
                 },
@@ -53241,6 +56440,12 @@ var SamSchema = `{
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::Kendra::Index.TagList"
+                        },
+                        "UserContextPolicy": {
+                            "type": "string"
+                        },
+                        "UserTokenConfigurations": {
+                            "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfigurationList"
                         }
                     },
                     "required": [
@@ -53321,6 +56526,52 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::Kendra::Index.JsonTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "GroupAttributeField",
+                "UserNameAttributeField"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::Index.JwtTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ClaimRegex": {
+                    "type": "string"
+                },
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "Issuer": {
+                    "type": "string"
+                },
+                "KeyLocation": {
+                    "type": "string"
+                },
+                "SecretManagerArn": {
+                    "type": "string"
+                },
+                "URL": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KeyLocation"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::Index.Relevance": {
             "additionalProperties": false,
             "properties": {
@@ -53375,6 +56626,30 @@ var SamSchema = `{
                 "TagList": {
                     "items": {
                         "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "JsonTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JsonTokenTypeConfiguration"
+                },
+                "JwtTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JwtTokenTypeConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfigurationList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserTokenConfigurationList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfiguration"
                     },
                     "type": "array"
                 }
@@ -56542,6 +59817,12 @@ var SamSchema = `{
                         "FunctionName": {
                             "type": "string"
                         },
+                        "FunctionResponseTypes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "MaximumBatchingWindowInSeconds": {
                             "type": "number"
                         },
@@ -56563,6 +59844,9 @@ var SamSchema = `{
                             },
                             "type": "array"
                         },
+                        "SelfManagedEventSource": {
+                            "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SelfManagedEventSource"
+                        },
                         "SourceAccessConfigurations": {
                             "items": {
                                 "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SourceAccessConfiguration"
@@ -56583,7 +59867,6 @@ var SamSchema = `{
                         }
                     },
                     "required": [
-                        "EventSourceArn",
                         "FunctionName"
                     ],
                     "type": "object"
@@ -56618,11 +59901,32 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::Lambda::EventSourceMapping.Endpoints": {
+            "additionalProperties": false,
+            "properties": {
+                "KafkaBootstrapServers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Lambda::EventSourceMapping.OnFailure": {
             "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::EventSourceMapping.SelfManagedEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Endpoints": {
+                    "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.Endpoints"
                 }
             },
             "type": "object"
@@ -56698,6 +60002,9 @@ var SamSchema = `{
                         "Handler": {
                             "type": "string"
                         },
+                        "ImageConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.ImageConfig"
+                        },
                         "KmsKeyArn": {
                             "type": "string"
                         },
@@ -56709,6 +60016,9 @@ var SamSchema = `{
                         },
                         "MemorySize": {
                             "type": "number"
+                        },
+                        "PackageType": {
+                            "type": "string"
                         },
                         "ReservedConcurrentExecutions": {
                             "type": "number"
@@ -56737,9 +60047,7 @@ var SamSchema = `{
                     },
                     "required": [
                         "Code",
-                        "Handler",
-                        "Role",
-                        "Runtime"
+                        "Role"
                     ],
                     "type": "object"
                 },
@@ -56767,6 +60075,9 @@ var SamSchema = `{
         "AWS::Lambda::Function.Code": {
             "additionalProperties": false,
             "properties": {
+                "ImageUri": {
+                    "type": "string"
+                },
                 "S3Bucket": {
                     "type": "string"
                 },
@@ -56820,6 +60131,27 @@ var SamSchema = `{
                 "Arn",
                 "LocalMountPath"
             ],
+            "type": "object"
+        },
+        "AWS::Lambda::Function.ImageConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Command": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "EntryPoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "WorkingDirectory": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Lambda::Function.TracingConfig": {
@@ -57181,6 +60513,555 @@ var SamSchema = `{
             },
             "required": [
                 "ProvisionedConcurrentExecutions"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.FilterList"
+                        },
+                        "GrantArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "GrantName": {
+                            "type": "string"
+                        },
+                        "GrantStatus": {
+                            "type": "string"
+                        },
+                        "GrantedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "GranteePrincipalArn": {
+                            "type": "string"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "LicenseArn": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ParentArn": {
+                            "type": "string"
+                        },
+                        "Principals": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "StatusReason": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.TagList"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::Grant"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.AllowedOperationList": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedOperationList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::Grant.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::Grant.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Beneficiary": {
+                            "type": "string"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "ConsumptionConfiguration": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ConsumptionConfiguration"
+                        },
+                        "Entitlements": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.EntitlementList"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.FilterList"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "Issuer": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.IssuerData"
+                        },
+                        "LicenseArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ArnList"
+                        },
+                        "LicenseMetadata": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.MetadataList"
+                        },
+                        "LicenseName": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ProductName": {
+                            "type": "string"
+                        },
+                        "ProductSKU": {
+                            "type": "string"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.TagList"
+                        },
+                        "Validity": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ValidityDateFormat"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConsumptionConfiguration",
+                        "Entitlements",
+                        "HomeRegion",
+                        "Issuer",
+                        "Validity"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::License"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.BorrowConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowEarlyCheckIn": {
+                    "type": "boolean"
+                },
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "AllowEarlyCheckIn",
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ConsumptionConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BorrowConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.BorrowConfiguration"
+                },
+                "ProvisionalConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.ProvisionalConfiguration"
+                },
+                "RenewType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Entitlement": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCheckIn": {
+                    "type": "boolean"
+                },
+                "CheckoutRules": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.RuleList"
+                },
+                "MaxCount": {
+                    "type": "number"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Overage": {
+                    "type": "boolean"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.EntitlementList": {
+            "additionalProperties": false,
+            "properties": {
+                "EntitlementList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Entitlement"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.IssuerData": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "SignKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Metadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.MetadataList": {
+            "additionalProperties": false,
+            "properties": {
+                "MetadataList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Metadata"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ProvisionalConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.RuleList": {
+            "additionalProperties": false,
+            "properties": {
+                "RuleList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Rule"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ValidityDateFormat": {
+            "additionalProperties": false,
+            "properties": {
+                "Begin": {
+                    "type": "string"
+                },
+                "End": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Begin",
+                "End"
             ],
             "type": "object"
         },
@@ -57919,6 +61800,224 @@ var SamSchema = `{
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AirflowConfigurationOptions": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.AirflowConfigurationOptions"
+                        },
+                        "AirflowVersion": {
+                            "type": "string"
+                        },
+                        "DagS3Path": {
+                            "type": "string"
+                        },
+                        "EnvironmentClass": {
+                            "type": "string"
+                        },
+                        "ExecutionRoleArn": {
+                            "type": "string"
+                        },
+                        "KmsKey": {
+                            "type": "string"
+                        },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.LoggingConfiguration"
+                        },
+                        "MaxWorkers": {
+                            "type": "number"
+                        },
+                        "NetworkConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.NetworkConfiguration"
+                        },
+                        "PluginsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "PluginsS3Path": {
+                            "type": "string"
+                        },
+                        "RequirementsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "RequirementsS3Path": {
+                            "type": "string"
+                        },
+                        "SourceBucketArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.TagMap"
+                        },
+                        "WebserverAccessMode": {
+                            "type": "string"
+                        },
+                        "WebserverUrl": {
+                            "type": "string"
+                        },
+                        "WeeklyMaintenanceWindowStart": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::MWAA::Environment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.AirflowConfigurationOptions": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LastUpdate": {
+            "additionalProperties": false,
+            "properties": {
+                "CreatedAt": {
+                    "type": "string"
+                },
+                "Error": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.UpdateError"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DagProcessingLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "SchedulerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "TaskLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WebserverLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WorkerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.ModuleLoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogGroupArn": {
+                    "type": "string"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "LogLevel": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SecurityGroupList"
+                },
+                "SubnetIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SubnetList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SecurityGroupList": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SubnetList": {
+            "additionalProperties": false,
+            "properties": {
+                "SubnetList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.TagMap": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.UpdateError": {
+            "additionalProperties": false,
+            "properties": {
+                "ErrorCode": {
+                    "type": "string"
+                },
+                "ErrorMessage": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -63231,7 +67330,10 @@ var SamSchema = `{
                             "type": "array"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::Firewall.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VpcId": {
                             "type": "string"
@@ -63278,18 +67380,6 @@ var SamSchema = `{
             ],
             "type": "object"
         },
-        "AWS::NetworkFirewall::Firewall.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::FirewallPolicy": {
             "additionalProperties": false,
             "properties": {
@@ -63332,7 +67422,10 @@ var SamSchema = `{
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::FirewallPolicy.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -63524,18 +67617,6 @@ var SamSchema = `{
             },
             "type": "object"
         },
-        "AWS::NetworkFirewall::FirewallPolicy.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::LoggingConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -63568,11 +67649,18 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "FirewallArn": {
+                            "type": "string"
+                        },
+                        "FirewallName": {
+                            "type": "string"
+                        },
                         "LoggingConfiguration": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::LoggingConfiguration.LoggingConfiguration"
                         }
                     },
                     "required": [
+                        "FirewallArn",
                         "LoggingConfiguration"
                     ],
                     "type": "object"
@@ -63689,14 +67777,14 @@ var SamSchema = `{
                         "RuleGroup": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.RuleGroup"
                         },
-                        "RuleGroupId": {
-                            "type": "string"
-                        },
                         "RuleGroupName": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "Type": {
                             "type": "string"
@@ -64178,18 +68266,6 @@ var SamSchema = `{
                 "TCPFlags": {
                     "items": {
                         "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.TCPFlagField"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::NetworkFirewall::RuleGroup.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
                 }
@@ -73032,6 +77108,18 @@ var SamSchema = `{
             },
             "type": "object"
         },
+        "AWS::S3::Bucket.ReplicaModifications": {
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Status"
+            ],
+            "type": "object"
+        },
         "AWS::S3::Bucket.ReplicationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -73287,6 +77375,9 @@ var SamSchema = `{
         "AWS::S3::Bucket.ServerSideEncryptionRule": {
             "additionalProperties": false,
             "properties": {
+                "BucketKeyEnabled": {
+                    "type": "boolean"
+                },
                 "ServerSideEncryptionByDefault": {
                     "$ref": "#/definitions/AWS::S3::Bucket.ServerSideEncryptionByDefault"
                 }
@@ -73296,6 +77387,9 @@ var SamSchema = `{
         "AWS::S3::Bucket.SourceSelectionCriteria": {
             "additionalProperties": false,
             "properties": {
+                "ReplicaModifications": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.ReplicaModifications"
+                },
                 "SseKmsEncryptedObjects": {
                     "$ref": "#/definitions/AWS::S3::Bucket.SseKmsEncryptedObjects"
                 }
@@ -76112,6 +80206,72 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SSO::InstanceAccessControlAttributeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InstanceAccessControlAttributeConfiguration": {
+                            "type": "object"
+                        },
+                        "InstanceArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "InstanceAccessControlAttributeConfiguration",
+                        "InstanceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::SSO::PermissionSet": {
             "additionalProperties": false,
             "properties": {
@@ -76285,6 +80445,502 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SageMaker::DataQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DataQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification"
+                        },
+                        "DataQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig"
+                        },
+                        "DataQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput"
+                        },
+                        "DataQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringResources"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DataQualityAppSpecification",
+                        "DataQualityJobInput",
+                        "DataQualityJobOutputConfig",
+                        "JobResources",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DataQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource"
+                },
+                "StatisticsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StatisticsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StatisticsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Device": {
+                            "type": "object"
+                        },
+                        "Tags": {}
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Device"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device.Device": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "DeviceName": {
+                    "type": "string"
+                },
+                "IotThingName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "OutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet.EdgeOutputConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {}
+                    },
+                    "required": [
+                        "OutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DeviceFleet"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet.EdgeOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "S3OutputLocation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3OutputLocation"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -76317,6 +80973,9 @@ var SamSchema = `{
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "DeploymentConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::Endpoint.DeploymentConfig"
+                        },
                         "EndpointConfigName": {
                             "type": "string"
                         },
@@ -76362,6 +81021,100 @@ var SamSchema = `{
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.Alarm": {
+            "additionalProperties": false,
+            "properties": {
+                "AlarmName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AlarmName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.AutoRollbackConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Alarms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::Endpoint.Alarm"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Alarms"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "MaximumExecutionTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TerminationWaitInSeconds": {
+                    "type": "number"
+                },
+                "TrafficRoutingConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.TrafficRoutingConfig"
+                }
+            },
+            "required": [
+                "TrafficRoutingConfiguration"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.CapacitySize": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.DeploymentConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AutoRollbackConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.AutoRollbackConfig"
+                },
+                "BlueGreenUpdatePolicy": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy"
+                }
+            },
+            "required": [
+                "BlueGreenUpdatePolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.TrafficRoutingConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "CanarySize": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.CapacitySize"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "WaitIntervalInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -76706,6 +81459,1096 @@ var SamSchema = `{
             ],
             "type": "object"
         },
+        "AWS::SageMaker::ModelBiasJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources"
+                        },
+                        "ModelBiasAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification"
+                        },
+                        "ModelBiasBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig"
+                        },
+                        "ModelBiasJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput"
+                        },
+                        "ModelBiasJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelBiasAppSpecification",
+                        "ModelBiasJobInput",
+                        "ModelBiasJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelBiasJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources"
+                        },
+                        "ModelExplainabilityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification"
+                        },
+                        "ModelExplainabilityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig"
+                        },
+                        "ModelExplainabilityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput"
+                        },
+                        "ModelExplainabilityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelExplainabilityAppSpecification",
+                        "ModelExplainabilityJobInput",
+                        "ModelExplainabilityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelExplainabilityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelPackageGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModelPackageGroupDescription": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupName": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupPolicy": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ModelPackageGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelPackageGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources"
+                        },
+                        "ModelQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification"
+                        },
+                        "ModelQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig"
+                        },
+                        "ModelQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput"
+                        },
+                        "ModelQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelQualityAppSpecification",
+                        "ModelQualityJobInput",
+                        "ModelQualityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "ProblemType": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri",
+                "ProblemType"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::MonitoringSchedule": {
             "additionalProperties": false,
             "properties": {
@@ -76746,9 +82589,6 @@ var SamSchema = `{
                         },
                         "LastMonitoringExecutionSummary": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringExecutionSummary"
-                        },
-                        "MonitoringScheduleArn": {
-                            "type": "string"
                         },
                         "MonitoringScheduleConfig": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringScheduleConfig"
@@ -77043,13 +82883,16 @@ var SamSchema = `{
                 "MonitoringJobDefinition": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringJobDefinition"
                 },
+                "MonitoringJobDefinitionName": {
+                    "type": "string"
+                },
+                "MonitoringType": {
+                    "type": "string"
+                },
                 "ScheduleConfig": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.ScheduleConfig"
                 }
             },
-            "required": [
-                "MonitoringJobDefinition"
-            ],
             "type": "object"
         },
         "AWS::SageMaker::MonitoringSchedule.NetworkConfig": {
@@ -77332,6 +83175,163 @@ var SamSchema = `{
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Pipeline": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PipelineDefinition": {
+                            "type": "object"
+                        },
+                        "PipelineDescription": {
+                            "type": "string"
+                        },
+                        "PipelineDisplayName": {
+                            "type": "string"
+                        },
+                        "PipelineName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PipelineDefinition",
+                        "PipelineName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Pipeline"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "ServiceCatalogProvisioningDetails": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ProjectName",
+                        "ServiceCatalogProvisioningDetails"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::SageMaker::Workteam": {
@@ -78314,6 +84314,9 @@ var SamSchema = `{
                                 }
                             ]
                         },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Serverless::Function.ProvisionedConcurrencyConfig"
+                        },
                         "ReservedConcurrentExecutions": {
                             "type": "number"
                         },
@@ -78790,6 +84793,18 @@ var SamSchema = `{
             },
             "required": [
                 "Destination"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::Function.ProvisionedConcurrencyConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -82123,7 +88138,7 @@ var SamSchema = `{
                 },
                 "SecurityGroupIds": {
                     "items": {
-                        "$ref": "#/definitions/AWS::Transfer::Server.SecurityGroupId"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -82159,11 +88174,6 @@ var SamSchema = `{
             "type": "object"
         },
         "AWS::Transfer::Server.Protocol": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::Transfer::Server.SecurityGroupId": {
             "additionalProperties": false,
             "properties": {},
             "type": "object"
@@ -86269,6 +92279,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Athena::WorkGroup"
                         },
                         {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup"
                         },
                         {
@@ -86330,6 +92343,12 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Macro"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleDefaultVersion"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleVersion"
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Stack"
@@ -86557,6 +92576,12 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Detective::MemberInvitation"
                         },
                         {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD"
                         },
                         {
@@ -86645,6 +92670,12 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkAclEntry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsPath"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkInterface"
@@ -86767,6 +92798,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::EC2::VolumeAttachment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::ECR::PublicRepository"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::ECR::Repository"
                         },
                         {
@@ -86837,6 +92871,12 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::ElastiCache::SubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::User"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup"
                         },
                         {
                             "$ref": "#/definitions/AWS::ElasticBeanstalk::Application"
@@ -87037,6 +93077,9 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Greengrass::SubscriptionDefinitionVersion"
                         },
                         {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::GuardDuty::Detector"
                         },
                         {
@@ -87175,16 +93218,43 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::IoTEvents::Input"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Asset"
                         },
                         {
                             "$ref": "#/definitions/AWS::IoTSiteWise::AssetModel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Dashboard"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Gateway"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Portal"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Project"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTThingsGraph::FlowTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::Destination"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway"
                         },
                         {
                             "$ref": "#/definitions/AWS::KMS::Alias"
@@ -87268,6 +93338,12 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::Lambda::Version"
                         },
                         {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::LicenseManager::License"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Logs::Destination"
                         },
                         {
@@ -87284,6 +93360,9 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::MSK::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::MWAA::Environment"
                         },
                         {
                             "$ref": "#/definitions/AWS::Macie::CustomDataIdentifier"
@@ -87658,10 +93737,22 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::SSO::Assignment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSO::PermissionSet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Device"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -87673,6 +93764,18 @@ var SamSchema = `{
                             "$ref": "#/definitions/AWS::SageMaker::Model"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelPackageGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule"
                         },
                         {
@@ -87680,6 +93783,12 @@ var SamSchema = `{
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Pipeline"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Project"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Workteam"

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -6165,6 +6165,9 @@
                 },
                 "Snowflake": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SnowflakeDestinationProperties"
+                },
+                "Upsolver": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverDestinationProperties"
                 }
             },
             "type": "object"
@@ -6240,6 +6243,15 @@
             "required": [
                 "Object"
             ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.IncrementalPullConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "DatetimeTypeFieldName": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::AppFlow::Flow.InforNexusSourceProperties": {
@@ -6521,6 +6533,9 @@
                 "ConnectorType": {
                     "type": "string"
                 },
+                "IncrementalPullConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.IncrementalPullConfig"
+                },
                 "SourceConnectorProperties": {
                     "$ref": "#/definitions/AWS::AppFlow::Flow.SourceConnectorProperties"
                 }
@@ -6602,6 +6617,43 @@
             },
             "required": [
                 "TriggerType"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "BucketName": {
+                    "type": "string"
+                },
+                "BucketPrefix": {
+                    "type": "string"
+                },
+                "S3OutputFormatConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig"
+                }
+            },
+            "required": [
+                "BucketName",
+                "S3OutputFormatConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::AppFlow::Flow.UpsolverS3OutputFormatConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AggregationConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.AggregationConfig"
+                },
+                "FileType": {
+                    "type": "string"
+                },
+                "PrefixConfig": {
+                    "$ref": "#/definitions/AWS::AppFlow::Flow.PrefixConfig"
+                }
+            },
+            "required": [
+                "PrefixConfig"
             ],
             "type": "object"
         },
@@ -10883,6 +10935,9 @@
                     },
                     "type": "array"
                 },
+                "JMXPrometheusExporter": {
+                    "$ref": "#/definitions/AWS::ApplicationInsights::Application.JMXPrometheusExporter"
+                },
                 "Logs": {
                     "items": {
                         "$ref": "#/definitions/AWS::ApplicationInsights::Application.Log"
@@ -10915,6 +10970,21 @@
                 "ComponentName",
                 "ResourceList"
             ],
+            "type": "object"
+        },
+        "AWS::ApplicationInsights::Application.JMXPrometheusExporter": {
+            "additionalProperties": false,
+            "properties": {
+                "HostPort": {
+                    "type": "string"
+                },
+                "JMXURL": {
+                    "type": "string"
+                },
+                "PrometheusPort": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::ApplicationInsights::Application.Log": {
@@ -11396,6 +11466,247 @@
             },
             "type": "object"
         },
+        "AWS::AuditManager::Assessment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "assessmentReportsDestination": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AssessmentReportsDestination"
+                        },
+                        "awsAccount": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "frameworkId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "roles": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Roles"
+                        },
+                        "scope": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Scope"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment.Tags"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::AuditManager::Assessment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccount": {
+            "additionalProperties": false,
+            "properties": {
+                "emailAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSAccounts": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSAccounts": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSService": {
+            "additionalProperties": false,
+            "properties": {
+                "serviceName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AWSServices": {
+            "additionalProperties": false,
+            "properties": {
+                "AWSServices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSService"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.AssessmentReportsDestination": {
+            "additionalProperties": false,
+            "properties": {
+                "destination": {
+                    "type": "string"
+                },
+                "destinationType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegation": {
+            "additionalProperties": false,
+            "properties": {
+                "assessmentId": {
+                    "type": "string"
+                },
+                "assessmentName": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "controlSetId": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "type": "string"
+                },
+                "creationTime": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastUpdated": {
+                    "type": "number"
+                },
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Delegations": {
+            "additionalProperties": false,
+            "properties": {
+                "Delegations": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Delegation"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Role": {
+            "additionalProperties": false,
+            "properties": {
+                "roleArn": {
+                    "type": "string"
+                },
+                "roleType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Roles": {
+            "additionalProperties": false,
+            "properties": {
+                "Roles": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::AuditManager::Assessment.Role"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Scope": {
+            "additionalProperties": false,
+            "properties": {
+                "awsAccounts": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSAccounts"
+                },
+                "awsServices": {
+                    "$ref": "#/definitions/AWS::AuditManager::Assessment.AWSServices"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::AuditManager::Assessment.Tags": {
+            "additionalProperties": false,
+            "properties": {
+                "Tags": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::AutoScaling::AutoScalingGroup": {
             "additionalProperties": false,
             "properties": {
@@ -11819,7 +12130,7 @@
                             "type": "string"
                         },
                         "MetadataOptions": {
-                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOption"
+                            "$ref": "#/definitions/AWS::AutoScaling::LaunchConfiguration.MetadataOptions"
                         },
                         "PlacementTenancy": {
                             "type": "string"
@@ -11912,7 +12223,7 @@
             ],
             "type": "object"
         },
-        "AWS::AutoScaling::LaunchConfiguration.MetadataOption": {
+        "AWS::AutoScaling::LaunchConfiguration.MetadataOptions": {
             "additionalProperties": false,
             "properties": {
                 "HttpEndpoint": {
@@ -13100,10 +13411,7 @@
                 }
             },
             "required": [
-                "InstanceRole",
-                "InstanceTypes",
                 "MaxvCpus",
-                "MinvCpus",
                 "Subnets",
                 "Type"
             ],
@@ -13183,6 +13491,15 @@
                         "Parameters": {
                             "type": "object"
                         },
+                        "PlatformCapabilities": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "PropagateTags": {
+                            "type": "boolean"
+                        },
                         "RetryStrategy": {
                             "$ref": "#/definitions/AWS::Batch::JobDefinition.RetryStrategy"
                         },
@@ -13240,6 +13557,9 @@
                 "ExecutionRoleArn": {
                     "type": "string"
                 },
+                "FargatePlatformConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.FargatePlatformConfiguration"
+                },
                 "Image": {
                     "type": "string"
                 },
@@ -13263,6 +13583,9 @@
                         "$ref": "#/definitions/AWS::Batch::JobDefinition.MountPoints"
                     },
                     "type": "array"
+                },
+                "NetworkConfiguration": {
+                    "$ref": "#/definitions/AWS::Batch::JobDefinition.NetworkConfiguration"
                 },
                 "Privileged": {
                     "type": "boolean"
@@ -13357,6 +13680,15 @@
             ],
             "type": "object"
         },
+        "AWS::Batch::JobDefinition.FargatePlatformConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PlatformVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Batch::JobDefinition.LinuxParameters": {
             "additionalProperties": false,
             "properties": {
@@ -13418,6 +13750,15 @@
                     "type": "boolean"
                 },
                 "SourceVolume": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Batch::JobDefinition.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AssignPublicIp": {
                     "type": "string"
                 }
             },
@@ -14609,6 +14950,135 @@
             ],
             "type": "object"
         },
+        "AWS::CloudFormation::ModuleDefaultVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Arn": {
+                            "type": "string"
+                        },
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "VersionId": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleDefaultVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::CloudFormation::ModuleVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModuleName": {
+                            "type": "string"
+                        },
+                        "ModulePackage": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ModuleName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::CloudFormation::ModuleVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::CloudFormation::Stack": {
             "additionalProperties": false,
             "properties": {
@@ -14779,6 +15249,10 @@
                             "type": "string"
                         }
                     },
+                    "required": [
+                        "PermissionModel",
+                        "StackSetName"
+                    ],
                     "type": "object"
                 },
                 "Type": {
@@ -14797,7 +15271,8 @@
                 }
             },
             "required": [
-                "Type"
+                "Type",
+                "Properties"
             ],
             "type": "object"
         },
@@ -17357,6 +17832,9 @@
                         "DomainName": {
                             "type": "string"
                         },
+                        "EncryptionKey": {
+                            "type": "string"
+                        },
                         "PermissionsPolicyDocument": {
                             "type": "object"
                         },
@@ -17428,6 +17906,12 @@
                         "Description": {
                             "type": "string"
                         },
+                        "DomainName": {
+                            "type": "string"
+                        },
+                        "DomainOwner": {
+                            "type": "string"
+                        },
                         "ExternalConnections": {
                             "items": {
                                 "type": "string"
@@ -17454,6 +17938,7 @@
                         }
                     },
                     "required": [
+                        "DomainName",
                         "RepositoryName"
                     ],
                     "type": "object"
@@ -19000,6 +19485,12 @@
                         "Owner": {
                             "type": "string"
                         },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
                         "Type": {
                             "type": "string"
                         }
@@ -20332,6 +20823,30 @@
             },
             "type": "object"
         },
+        "AWS::Cognito::UserPool.CustomEmailSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Cognito::UserPool.CustomSMSSender": {
+            "additionalProperties": false,
+            "properties": {
+                "LambdaArn": {
+                    "type": "string"
+                },
+                "LambdaVersion": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Cognito::UserPool.DeviceConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -20386,10 +20901,19 @@
                 "CreateAuthChallenge": {
                     "type": "string"
                 },
+                "CustomEmailSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomEmailSender"
+                },
                 "CustomMessage": {
                     "type": "string"
                 },
+                "CustomSMSSender": {
+                    "$ref": "#/definitions/AWS::Cognito::UserPool.CustomSMSSender"
+                },
                 "DefineAuthChallenge": {
+                    "type": "string"
+                },
+                "KMSKeyID": {
                     "type": "string"
                 },
                 "PostAuthentication": {
@@ -22813,6 +23337,12 @@
                         },
                         "State": {
                             "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
@@ -25058,6 +25588,169 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Config": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig"
+                        }
+                    },
+                    "required": [
+                        "Config"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::NotificationChannel"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.NotificationChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Sns": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::NotificationChannel.SnsChannelConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "TopicArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ResourceCollectionFilter": {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter"
+                        }
+                    },
+                    "required": [
+                        "ResourceCollectionFilter"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::DevOpsGuru::ResourceCollection"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "StackNames": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::DevOpsGuru::ResourceCollection.ResourceCollectionFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudFormation": {
+                    "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection.CloudFormationCollectionFilter"
+                }
+            },
             "type": "object"
         },
         "AWS::DirectoryService::MicrosoftAD": {
@@ -27493,6 +28186,9 @@
                             },
                             "type": "array"
                         },
+                        "EnclaveOptions": {
+                            "$ref": "#/definitions/AWS::EC2::Instance.EnclaveOptions"
+                        },
                         "HibernationOptions": {
                             "$ref": "#/definitions/AWS::EC2::Instance.HibernationOptions"
                         },
@@ -27734,6 +28430,15 @@
             "required": [
                 "Type"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::Instance.EnclaveOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "Enabled": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::Instance.HibernationOptions": {
@@ -28864,6 +29569,552 @@
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "FilterInArns": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "NetworkInsightsPathId": {
+                            "type": "string"
+                        },
+                        "StatusMessage": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "NetworkInsightsPathId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsAnalysis"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AlternatePathHint": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentArn": {
+                    "type": "string"
+                },
+                "ComponentId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Egress": {
+                    "type": "boolean"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "RuleAction": {
+                    "type": "string"
+                },
+                "RuleNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "Arn": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener": {
+            "additionalProperties": false,
+            "properties": {
+                "InstancePort": {
+                    "type": "number"
+                },
+                "LoadBalancerPort": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget": {
+            "additionalProperties": false,
+            "properties": {
+                "Address": {
+                    "type": "string"
+                },
+                "AvailabilityZone": {
+                    "type": "string"
+                },
+                "Instance": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Port": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader": {
+            "additionalProperties": false,
+            "properties": {
+                "DestinationAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "DestinationPortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SourceAddresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SourcePortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute": {
+            "additionalProperties": false,
+            "properties": {
+                "NatGatewayId": {
+                    "type": "string"
+                },
+                "NetworkInterfaceId": {
+                    "type": "string"
+                },
+                "Origin": {
+                    "type": "string"
+                },
+                "TransitGatewayId": {
+                    "type": "string"
+                },
+                "VpcPeeringConnectionId": {
+                    "type": "string"
+                },
+                "destinationCidr": {
+                    "type": "string"
+                },
+                "destinationPrefixListId": {
+                    "type": "string"
+                },
+                "egressOnlyInternetGatewayId": {
+                    "type": "string"
+                },
+                "gatewayId": {
+                    "type": "string"
+                },
+                "instanceId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule": {
+            "additionalProperties": false,
+            "properties": {
+                "Cidr": {
+                    "type": "string"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "PortRange": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                },
+                "PrefixListId": {
+                    "type": "string"
+                },
+                "Protocol": {
+                    "type": "string"
+                },
+                "SecurityGroupId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.Explanation": {
+            "additionalProperties": false,
+            "properties": {
+                "Acl": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Address": {
+                    "type": "string"
+                },
+                "Addresses": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "AttachedTo": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "AvailabilityZones": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Cidrs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ClassicLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerListener"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "CustomerGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Destination": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Direction": {
+                    "type": "string"
+                },
+                "ElasticLoadBalancerListener": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "ExplanationCode": {
+                    "type": "string"
+                },
+                "IngressRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InternetGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerArn": {
+                    "type": "string"
+                },
+                "LoadBalancerListenerPort": {
+                    "type": "number"
+                },
+                "LoadBalancerTarget": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisLoadBalancerTarget"
+                },
+                "LoadBalancerTargetGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "LoadBalancerTargetGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "LoadBalancerTargetPort": {
+                    "type": "number"
+                },
+                "MissingComponent": {
+                    "type": "string"
+                },
+                "NatGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "NetworkInterface": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "PacketField": {
+                    "type": "string"
+                },
+                "Port": {
+                    "type": "number"
+                },
+                "PortRanges": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.PortRange"
+                    },
+                    "type": "array"
+                },
+                "PrefixList": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Protocols": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "RouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroup": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                    },
+                    "type": "array"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "State": {
+                    "type": "string"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "SubnetRouteTable": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpcPeeringConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnConnection": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "VpnGateway": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "vpcEndpoint": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PathComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "AclRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisAclRule"
+                },
+                "Component": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "DestinationVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "InboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "OutboundHeader": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisPacketHeader"
+                },
+                "RouteTableRoute": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisRouteTableRoute"
+                },
+                "SecurityGroupRule": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisSecurityGroupRule"
+                },
+                "SequenceNumber": {
+                    "type": "number"
+                },
+                "SourceVpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Subnet": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                },
+                "Vpc": {
+                    "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis.AnalysisComponent"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsAnalysis.PortRange": {
+            "additionalProperties": false,
+            "properties": {
+                "From": {
+                    "type": "number"
+                },
+                "To": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::NetworkInsightsPath": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Destination": {
+                            "type": "string"
+                        },
+                        "DestinationIp": {
+                            "type": "string"
+                        },
+                        "DestinationPort": {
+                            "type": "number"
+                        },
+                        "Protocol": {
+                            "type": "string"
+                        },
+                        "Source": {
+                            "type": "string"
+                        },
+                        "SourceIp": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Destination",
+                        "Protocol",
+                        "Source"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::EC2::NetworkInsightsPath"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::EC2::NetworkInterface": {
@@ -30059,6 +31310,9 @@
                 "InstanceType": {
                     "type": "string"
                 },
+                "Priority": {
+                    "type": "number"
+                },
                 "SpotPrice": {
                     "type": "string"
                 },
@@ -30096,6 +31350,15 @@
             "required": [
                 "PrivateIpAddress"
             ],
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotCapacityRebalance": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplacementStrategy": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::EC2::SpotFleet.SpotFleetLaunchSpecification": {
@@ -30195,6 +31458,9 @@
                 "InstanceInterruptionBehavior": {
                     "type": "string"
                 },
+                "InstancePoolsToUseCount": {
+                    "type": "number"
+                },
                 "LaunchSpecifications": {
                     "items": {
                         "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotFleetLaunchSpecification"
@@ -30210,8 +31476,23 @@
                 "LoadBalancersConfig": {
                     "$ref": "#/definitions/AWS::EC2::SpotFleet.LoadBalancersConfig"
                 },
+                "OnDemandAllocationStrategy": {
+                    "type": "string"
+                },
+                "OnDemandMaxTotalPrice": {
+                    "type": "string"
+                },
+                "OnDemandTargetCapacity": {
+                    "type": "number"
+                },
                 "ReplaceUnhealthyInstances": {
                     "type": "boolean"
+                },
+                "SpotMaintenanceStrategies": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotMaintenanceStrategies"
+                },
+                "SpotMaxTotalPrice": {
+                    "type": "string"
                 },
                 "SpotPrice": {
                     "type": "string"
@@ -30249,6 +31530,15 @@
                         "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::EC2::SpotFleet.SpotMaintenanceStrategies": {
+            "additionalProperties": false,
+            "properties": {
+                "CapacityRebalance": {
+                    "$ref": "#/definitions/AWS::EC2::SpotFleet.SpotCapacityRebalance"
                 }
             },
             "type": "object"
@@ -32390,6 +33680,9 @@
                             },
                             "type": "array"
                         },
+                        "Throughput": {
+                            "type": "number"
+                        },
                         "VolumeType": {
                             "type": "string"
                         }
@@ -32487,6 +33780,70 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ECR::PublicRepository": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "RepositoryCatalogData": {
+                            "type": "object"
+                        },
+                        "RepositoryName": {
+                            "type": "string"
+                        },
+                        "RepositoryPolicyText": {
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ECR::PublicRepository"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -33036,9 +34393,28 @@
             },
             "type": "object"
         },
+        "AWS::ECS::Service.DeploymentCircuitBreaker": {
+            "additionalProperties": false,
+            "properties": {
+                "Enable": {
+                    "type": "boolean"
+                },
+                "Rollback": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "Enable",
+                "Rollback"
+            ],
+            "type": "object"
+        },
         "AWS::ECS::Service.DeploymentConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DeploymentCircuitBreaker": {
+                    "$ref": "#/definitions/AWS::ECS::Service.DeploymentCircuitBreaker"
+                },
                 "MaximumPercent": {
                     "type": "number"
                 },
@@ -34711,6 +36087,9 @@
                     "additionalProperties": false,
                     "properties": {
                         "AmiType": {
+                            "type": "string"
+                        },
+                        "CapacityType": {
                             "type": "string"
                         },
                         "ClusterName": {
@@ -36705,6 +38084,12 @@
                         },
                         "TransitEncryptionEnabled": {
                             "type": "boolean"
+                        },
+                        "UserGroupIds": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -36958,6 +38343,232 @@
                 "Type",
                 "Properties"
             ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessString": {
+                            "type": "string"
+                        },
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "NoPasswordRequired": {
+                            "type": "boolean"
+                        },
+                        "Passwords": {
+                            "$ref": "#/definitions/AWS::ElastiCache::User.PasswordList"
+                        },
+                        "UserId": {
+                            "type": "string"
+                        },
+                        "UserName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserId",
+                        "UserName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::User"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.Authentication": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordCount": {
+                    "type": "number"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.PasswordList": {
+            "additionalProperties": false,
+            "properties": {
+                "PasswordList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::User.UserGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Engine": {
+                            "type": "string"
+                        },
+                        "UserGroupId": {
+                            "type": "string"
+                        },
+                        "UserIds": {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup.UserIdList"
+                        }
+                    },
+                    "required": [
+                        "Engine",
+                        "UserGroupId"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::ElastiCache::UserGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.ReplicationGroupIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "ReplicationGroupIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserGroupPendingChanges": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdsToAdd": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "UserIdsToRemove": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::ElastiCache::UserGroup.UserIdList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserIdList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object"
         },
         "AWS::ElasticBeanstalk::Application": {
@@ -38959,6 +40570,15 @@
         "AWS::Elasticsearch::Domain.DomainEndpointOptions": {
             "additionalProperties": false,
             "properties": {
+                "CustomEndpoint": {
+                    "type": "string"
+                },
+                "CustomEndpointCertificateArn": {
+                    "type": "string"
+                },
+                "CustomEndpointEnabled": {
+                    "type": "boolean"
+                },
                 "EnforceHTTPS": {
                     "type": "boolean"
                 },
@@ -39475,6 +41095,9 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "ArchiveName": {
+                            "type": "string"
+                        },
                         "Description": {
                             "type": "string"
                         },
@@ -42394,15 +44017,6 @@
             ],
             "type": "object"
         },
-        "AWS::Glue::Database.DataLakePrincipal": {
-            "additionalProperties": false,
-            "properties": {
-                "DataLakePrincipalIdentifier": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
         "AWS::Glue::Database.DatabaseIdentifier": {
             "additionalProperties": false,
             "properties": {
@@ -42418,12 +44032,6 @@
         "AWS::Glue::Database.DatabaseInput": {
             "additionalProperties": false,
             "properties": {
-                "CreateTableDefaultPermissions": {
-                    "items": {
-                        "$ref": "#/definitions/AWS::Glue::Database.PrincipalPrivileges"
-                    },
-                    "type": "array"
-                },
                 "Description": {
                     "type": "string"
                 },
@@ -42438,21 +44046,6 @@
                 },
                 "TargetDatabase": {
                     "$ref": "#/definitions/AWS::Glue::Database.DatabaseIdentifier"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::Glue::Database.PrincipalPrivileges": {
-            "additionalProperties": false,
-            "properties": {
-                "Permissions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "Principal": {
-                    "$ref": "#/definitions/AWS::Glue::Database.DataLakePrincipal"
                 }
             },
             "type": "object"
@@ -43051,6 +44644,36 @@
             ],
             "type": "object"
         },
+        "AWS::Glue::Partition.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Partition.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Partition.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43119,6 +44742,9 @@
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Partition.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Partition.SerdeInfo"
@@ -43699,6 +45325,36 @@
             ],
             "type": "object"
         },
+        "AWS::Glue::Table.SchemaId": {
+            "additionalProperties": false,
+            "properties": {
+                "RegistryName": {
+                    "type": "string"
+                },
+                "SchemaArn": {
+                    "type": "string"
+                },
+                "SchemaName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Glue::Table.SchemaReference": {
+            "additionalProperties": false,
+            "properties": {
+                "SchameVersionId": {
+                    "type": "string"
+                },
+                "SchemaId": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaId"
+                },
+                "SchemaVersionNumber": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Glue::Table.SerdeInfo": {
             "additionalProperties": false,
             "properties": {
@@ -43767,6 +45423,9 @@
                 },
                 "Parameters": {
                     "type": "object"
+                },
+                "SchemaReference": {
+                    "$ref": "#/definitions/AWS::Glue::Table.SchemaReference"
                 },
                 "SerdeInfo": {
                     "$ref": "#/definitions/AWS::Glue::Table.SerdeInfo"
@@ -46112,6 +47771,271 @@
                 "Subject",
                 "Target"
             ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InlineRecipe": {
+                            "type": "string"
+                        },
+                        "LambdaFunction": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource"
+                        },
+                        "Tags": {
+                            "additionalProperties": true,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9]+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::GreengrassV2::ComponentVersion"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement": {
+            "additionalProperties": false,
+            "properties": {
+                "DependencyType": {
+                    "type": "string"
+                },
+                "VersionRequirement": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.ComponentPlatform": {
+            "additionalProperties": false,
+            "properties": {
+                "Attributes": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaContainerParams": {
+            "additionalProperties": false,
+            "properties": {
+                "Devices": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount"
+                    },
+                    "type": "array"
+                },
+                "MemorySizeInKB": {
+                    "type": "number"
+                },
+                "MountROSysfs": {
+                    "type": "boolean"
+                },
+                "Volumes": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaDeviceMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Topic": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters": {
+            "additionalProperties": false,
+            "properties": {
+                "EnvironmentVariables": {
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "EventSources": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaEventSource"
+                    },
+                    "type": "array"
+                },
+                "ExecArgs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "InputPayloadEncodingType": {
+                    "type": "string"
+                },
+                "LinuxProcessParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams"
+                },
+                "MaxIdleTimeInSeconds": {
+                    "type": "number"
+                },
+                "MaxInstancesCount": {
+                    "type": "number"
+                },
+                "MaxQueueSize": {
+                    "type": "number"
+                },
+                "Pinned": {
+                    "type": "boolean"
+                },
+                "StatusTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TimeoutInSeconds": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaFunctionRecipeSource": {
+            "additionalProperties": false,
+            "properties": {
+                "ComponentDependencies": {
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentDependencyRequirement"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ComponentLambdaParameters": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaExecutionParameters"
+                },
+                "ComponentName": {
+                    "type": "string"
+                },
+                "ComponentPlatforms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.ComponentPlatform"
+                    },
+                    "type": "array"
+                },
+                "ComponentVersion": {
+                    "type": "string"
+                },
+                "LambdaArn": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaLinuxProcessParams": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerParams": {
+                    "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion.LambdaContainerParams"
+                },
+                "IsolationMode": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::GreengrassV2::ComponentVersion.LambdaVolumeMount": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGroupOwner": {
+                    "type": "boolean"
+                },
+                "DestinationPath": {
+                    "type": "string"
+                },
+                "Permission": {
+                    "type": "string"
+                },
+                "SourcePath": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::GuardDuty::Detector": {
@@ -50101,6 +52025,9 @@
                         },
                         "Status": {
                             "type": "string"
+                        },
+                        "VpcProperties": {
+                            "$ref": "#/definitions/AWS::IoT::TopicRuleDestination.VpcDestinationProperties"
                         }
                     },
                     "type": "object"
@@ -50129,6 +52056,30 @@
             "additionalProperties": false,
             "properties": {
                 "ConfirmationUrl": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoT::TopicRuleDestination.VpcDestinationProperties": {
+            "additionalProperties": false,
+            "properties": {
+                "RoleArn": {
+                    "type": "string"
+                },
+                "SecurityGroups": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "SubnetIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "VpcId": {
                     "type": "string"
                 }
             },
@@ -51612,6 +53563,124 @@
             },
             "type": "object"
         },
+        "AWS::IoTSiteWise::AccessPolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AccessPolicyIdentity": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity"
+                        },
+                        "AccessPolicyPermission": {
+                            "type": "string"
+                        },
+                        "AccessPolicyResource": {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource"
+                        }
+                    },
+                    "required": [
+                        "AccessPolicyIdentity",
+                        "AccessPolicyPermission",
+                        "AccessPolicyResource"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::AccessPolicy"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyIdentity": {
+            "additionalProperties": false,
+            "properties": {
+                "User": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.User"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.AccessPolicyResource": {
+            "additionalProperties": false,
+            "properties": {
+                "Portal": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Portal"
+                },
+                "Project": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy.Project"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.Project": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::AccessPolicy.User": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Asset": {
             "additionalProperties": false,
             "properties": {
@@ -51984,6 +54053,85 @@
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Dashboard": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DashboardDefinition": {
+                            "type": "string"
+                        },
+                        "DashboardDescription": {
+                            "type": "string"
+                        },
+                        "DashboardName": {
+                            "type": "string"
+                        },
+                        "ProjectId": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DashboardDefinition",
+                        "DashboardDescription",
+                        "DashboardName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Dashboard"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTSiteWise::Gateway": {
             "additionalProperties": false,
             "properties": {
@@ -52101,6 +54249,187 @@
             ],
             "type": "object"
         },
+        "AWS::IoTSiteWise::Portal": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalContactEmail": {
+                            "type": "string"
+                        },
+                        "PortalDescription": {
+                            "type": "string"
+                        },
+                        "PortalName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalContactEmail",
+                        "PortalName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Portal"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.MonitorErrorDetails": {
+            "additionalProperties": false,
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Portal.PortalStatus": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/AWS::IoTSiteWise::Portal.MonitorErrorDetails"
+                },
+                "state": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "state"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTSiteWise::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PortalId": {
+                            "type": "string"
+                        },
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PortalId",
+                        "ProjectName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTSiteWise::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::IoTThingsGraph::FlowTemplate": {
             "additionalProperties": false,
             "properties": {
@@ -52180,6 +54509,639 @@
                 "Language",
                 "Text"
             ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::Destination": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Expression": {
+                            "type": "string"
+                        },
+                        "ExpressionType": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "Expression",
+                        "ExpressionType",
+                        "Name",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::Destination"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANDeviceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::DeviceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::DeviceProfile.LoRaWANDeviceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "ClassBTimeout": {
+                    "type": "number"
+                },
+                "ClassCTimeout": {
+                    "type": "number"
+                },
+                "MacVersion": {
+                    "type": "string"
+                },
+                "MaxDutyCycle": {
+                    "type": "number"
+                },
+                "MaxEirp": {
+                    "type": "number"
+                },
+                "PingSlotDr": {
+                    "type": "number"
+                },
+                "PingSlotFreq": {
+                    "type": "number"
+                },
+                "PingSlotPeriod": {
+                    "type": "number"
+                },
+                "RegParamsRevision": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                },
+                "Supports32BitFCnt": {
+                    "type": "boolean"
+                },
+                "SupportsClassB": {
+                    "type": "boolean"
+                },
+                "SupportsClassC": {
+                    "type": "boolean"
+                },
+                "SupportsJoin": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "LoRaWANGetServiceProfileInfo": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo"
+                        },
+                        "LoRaWANServiceProfile": {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::ServiceProfile"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANGetServiceProfileInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                },
+                "ChannelMask": {
+                    "type": "string"
+                },
+                "DevStatusReqFreq": {
+                    "type": "number"
+                },
+                "DlBucketSize": {
+                    "type": "number"
+                },
+                "DlRate": {
+                    "type": "number"
+                },
+                "DlRatePolicy": {
+                    "type": "string"
+                },
+                "DrMax": {
+                    "type": "number"
+                },
+                "DrMin": {
+                    "type": "number"
+                },
+                "HrAllowed": {
+                    "type": "boolean"
+                },
+                "MinGwDiversity": {
+                    "type": "number"
+                },
+                "NwkGeoLoc": {
+                    "type": "boolean"
+                },
+                "PrAllowed": {
+                    "type": "boolean"
+                },
+                "RaAllowed": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusBattery": {
+                    "type": "boolean"
+                },
+                "ReportDevStatusMargin": {
+                    "type": "boolean"
+                },
+                "TargetPer": {
+                    "type": "number"
+                },
+                "UlBucketSize": {
+                    "type": "number"
+                },
+                "UlRate": {
+                    "type": "number"
+                },
+                "UlRatePolicy": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::ServiceProfile.LoRaWANServiceProfile": {
+            "additionalProperties": false,
+            "properties": {
+                "AddGwMetadata": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "DestinationName": {
+                            "type": "string"
+                        },
+                        "LoRaWANDevice": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.LoRaWANDevice"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "DestinationName",
+                        "Type"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessDevice"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.AbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "DevAddr": {
+                    "type": "string"
+                },
+                "SessionKeys": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.LoRaWANDevice": {
+            "additionalProperties": false,
+            "properties": {
+                "AbpV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV10X"
+                },
+                "AbpV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.AbpV11"
+                },
+                "DevEui": {
+                    "type": "string"
+                },
+                "DeviceProfileId": {
+                    "type": "string"
+                },
+                "OtaaV10X": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV10X"
+                },
+                "OtaaV11": {
+                    "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice.OtaaV11"
+                },
+                "ServiceProfileId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppEui": {
+                    "type": "string"
+                },
+                "AppKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.OtaaV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppKey": {
+                    "type": "string"
+                },
+                "JoinEui": {
+                    "type": "string"
+                },
+                "NwkKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV10X": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "NwkSKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessDevice.SessionKeysAbpV11": {
+            "additionalProperties": false,
+            "properties": {
+                "AppSKey": {
+                    "type": "string"
+                },
+                "FNwkSIntKey": {
+                    "type": "string"
+                },
+                "NwkSEncKey": {
+                    "type": "string"
+                },
+                "SNwkSIntKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "LoRaWANGateway": {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway.LoRaWANGateway"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        },
+                        "ThingName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "LoRaWANGateway"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::IoTWireless::WirelessGateway"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::IoTWireless::WirelessGateway.LoRaWANGateway": {
+            "additionalProperties": false,
+            "properties": {
+                "GatewayEui": {
+                    "type": "string"
+                },
+                "RfRegion": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::KMS::Alias": {
@@ -52478,6 +55440,234 @@
             ],
             "type": "object"
         },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList"
+                },
+                "CrawlAttachments": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceAttachmentFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceAttachmentToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BlogFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceBlogFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceBlogToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AttachmentConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceAttachmentConfiguration"
+                },
+                "BlogConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceBlogConfiguration"
+                },
+                "ExclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "InclusionPatterns": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
+                },
+                "PageConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageConfiguration"
+                },
+                "SecretArn": {
+                    "type": "string"
+                },
+                "ServerUrl": {
+                    "type": "string"
+                },
+                "SpaceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceConfiguration"
+                },
+                "Version": {
+                    "type": "string"
+                },
+                "VpcConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceVpcConfiguration"
+                }
+            },
+            "required": [
+                "SecretArn",
+                "ServerUrl",
+                "Version"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "PageFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluencePageFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluencePageToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CrawlArchivedSpaces": {
+                    "type": "boolean"
+                },
+                "CrawlPersonalSpaces": {
+                    "type": "boolean"
+                },
+                "ExcludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "IncludeSpaces": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceList"
+                },
+                "SpaceFieldMappings": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceFieldMappingsList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceFieldMappingsList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceList": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfluenceSpaceList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::DataSource.ConfluenceSpaceToIndexFieldMapping": {
+            "additionalProperties": false,
+            "properties": {
+                "DataSourceFieldName": {
+                    "type": "string"
+                },
+                "DateFieldFormat": {
+                    "type": "string"
+                },
+                "IndexFieldName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DataSourceFieldName",
+                "IndexFieldName"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::DataSource.ConnectionConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -52509,6 +55699,9 @@
         "AWS::Kendra::DataSource.DataSourceConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "ConfluenceConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::DataSource.ConfluenceConfiguration"
+                },
                 "DatabaseConfiguration": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DatabaseConfiguration"
                 },
@@ -52636,6 +55829,9 @@
         "AWS::Kendra::DataSource.OneDriveConfiguration": {
             "additionalProperties": false,
             "properties": {
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "ExclusionPatterns": {
                     "$ref": "#/definitions/AWS::Kendra::DataSource.DataSourceInclusionsExclusionsStrings"
                 },
@@ -53013,6 +56209,9 @@
                 "CrawlAttachments": {
                     "type": "boolean"
                 },
+                "DisableLocalGroups": {
+                    "type": "boolean"
+                },
                 "DocumentTitleFieldName": {
                     "type": "string"
                 },
@@ -53238,6 +56437,12 @@
                         },
                         "Tags": {
                             "$ref": "#/definitions/AWS::Kendra::Index.TagList"
+                        },
+                        "UserContextPolicy": {
+                            "type": "string"
+                        },
+                        "UserTokenConfigurations": {
+                            "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfigurationList"
                         }
                     },
                     "required": [
@@ -53318,6 +56523,52 @@
             },
             "type": "object"
         },
+        "AWS::Kendra::Index.JsonTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "GroupAttributeField",
+                "UserNameAttributeField"
+            ],
+            "type": "object"
+        },
+        "AWS::Kendra::Index.JwtTokenTypeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "ClaimRegex": {
+                    "type": "string"
+                },
+                "GroupAttributeField": {
+                    "type": "string"
+                },
+                "Issuer": {
+                    "type": "string"
+                },
+                "KeyLocation": {
+                    "type": "string"
+                },
+                "SecretManagerArn": {
+                    "type": "string"
+                },
+                "URL": {
+                    "type": "string"
+                },
+                "UserNameAttributeField": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KeyLocation"
+            ],
+            "type": "object"
+        },
         "AWS::Kendra::Index.Relevance": {
             "additionalProperties": false,
             "properties": {
@@ -53372,6 +56623,30 @@
                 "TagList": {
                     "items": {
                         "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "JsonTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JsonTokenTypeConfiguration"
+                },
+                "JwtTokenTypeConfiguration": {
+                    "$ref": "#/definitions/AWS::Kendra::Index.JwtTokenTypeConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Kendra::Index.UserTokenConfigurationList": {
+            "additionalProperties": false,
+            "properties": {
+                "UserTokenConfigurationList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::Kendra::Index.UserTokenConfiguration"
                     },
                     "type": "array"
                 }
@@ -56539,6 +59814,12 @@
                         "FunctionName": {
                             "type": "string"
                         },
+                        "FunctionResponseTypes": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "MaximumBatchingWindowInSeconds": {
                             "type": "number"
                         },
@@ -56560,6 +59841,9 @@
                             },
                             "type": "array"
                         },
+                        "SelfManagedEventSource": {
+                            "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SelfManagedEventSource"
+                        },
                         "SourceAccessConfigurations": {
                             "items": {
                                 "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.SourceAccessConfiguration"
@@ -56580,7 +59864,6 @@
                         }
                     },
                     "required": [
-                        "EventSourceArn",
                         "FunctionName"
                     ],
                     "type": "object"
@@ -56615,11 +59898,32 @@
             },
             "type": "object"
         },
+        "AWS::Lambda::EventSourceMapping.Endpoints": {
+            "additionalProperties": false,
+            "properties": {
+                "KafkaBootstrapServers": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "AWS::Lambda::EventSourceMapping.OnFailure": {
             "additionalProperties": false,
             "properties": {
                 "Destination": {
                     "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::Lambda::EventSourceMapping.SelfManagedEventSource": {
+            "additionalProperties": false,
+            "properties": {
+                "Endpoints": {
+                    "$ref": "#/definitions/AWS::Lambda::EventSourceMapping.Endpoints"
                 }
             },
             "type": "object"
@@ -56695,6 +59999,9 @@
                         "Handler": {
                             "type": "string"
                         },
+                        "ImageConfig": {
+                            "$ref": "#/definitions/AWS::Lambda::Function.ImageConfig"
+                        },
                         "KmsKeyArn": {
                             "type": "string"
                         },
@@ -56706,6 +60013,9 @@
                         },
                         "MemorySize": {
                             "type": "number"
+                        },
+                        "PackageType": {
+                            "type": "string"
                         },
                         "ReservedConcurrentExecutions": {
                             "type": "number"
@@ -56734,9 +60044,7 @@
                     },
                     "required": [
                         "Code",
-                        "Handler",
-                        "Role",
-                        "Runtime"
+                        "Role"
                     ],
                     "type": "object"
                 },
@@ -56764,6 +60072,9 @@
         "AWS::Lambda::Function.Code": {
             "additionalProperties": false,
             "properties": {
+                "ImageUri": {
+                    "type": "string"
+                },
                 "S3Bucket": {
                     "type": "string"
                 },
@@ -56817,6 +60128,27 @@
                 "Arn",
                 "LocalMountPath"
             ],
+            "type": "object"
+        },
+        "AWS::Lambda::Function.ImageConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Command": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "EntryPoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "WorkingDirectory": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "AWS::Lambda::Function.TracingConfig": {
@@ -57178,6 +60510,555 @@
             },
             "required": [
                 "ProvisionedConcurrentExecutions"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AllowedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.FilterList"
+                        },
+                        "GrantArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "GrantName": {
+                            "type": "string"
+                        },
+                        "GrantStatus": {
+                            "type": "string"
+                        },
+                        "GrantedOperations": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.AllowedOperationList"
+                        },
+                        "GranteePrincipalArn": {
+                            "type": "string"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "LicenseArn": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ParentArn": {
+                            "type": "string"
+                        },
+                        "Principals": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.ArnList"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "StatusReason": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant.TagList"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::Grant"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.AllowedOperationList": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowedOperationList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::Grant.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::Grant.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::Grant.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Beneficiary": {
+                            "type": "string"
+                        },
+                        "ClientToken": {
+                            "type": "string"
+                        },
+                        "ConsumptionConfiguration": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ConsumptionConfiguration"
+                        },
+                        "Entitlements": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.EntitlementList"
+                        },
+                        "Filters": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.FilterList"
+                        },
+                        "HomeRegion": {
+                            "type": "string"
+                        },
+                        "Issuer": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.IssuerData"
+                        },
+                        "LicenseArns": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ArnList"
+                        },
+                        "LicenseMetadata": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.MetadataList"
+                        },
+                        "LicenseName": {
+                            "type": "string"
+                        },
+                        "MaxResults": {
+                            "type": "number"
+                        },
+                        "NextToken": {
+                            "type": "string"
+                        },
+                        "ProductName": {
+                            "type": "string"
+                        },
+                        "ProductSKU": {
+                            "type": "string"
+                        },
+                        "SourceVersion": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.TagList"
+                        },
+                        "Validity": {
+                            "$ref": "#/definitions/AWS::LicenseManager::License.ValidityDateFormat"
+                        },
+                        "Version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "ConsumptionConfiguration",
+                        "Entitlements",
+                        "HomeRegion",
+                        "Issuer",
+                        "Validity"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::LicenseManager::License"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ArnList": {
+            "additionalProperties": false,
+            "properties": {
+                "ArnList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.BorrowConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowEarlyCheckIn": {
+                    "type": "boolean"
+                },
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "AllowEarlyCheckIn",
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ConsumptionConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "BorrowConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.BorrowConfiguration"
+                },
+                "ProvisionalConfiguration": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.ProvisionalConfiguration"
+                },
+                "RenewType": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Entitlement": {
+            "additionalProperties": false,
+            "properties": {
+                "AllowCheckIn": {
+                    "type": "boolean"
+                },
+                "CheckoutRules": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.RuleList"
+                },
+                "MaxCount": {
+                    "type": "number"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Overage": {
+                    "type": "boolean"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.EntitlementList": {
+            "additionalProperties": false,
+            "properties": {
+                "EntitlementList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Entitlement"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Filter": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Values": {
+                    "$ref": "#/definitions/AWS::LicenseManager::License.StringList"
+                }
+            },
+            "required": [
+                "Name",
+                "Values"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.FilterList": {
+            "additionalProperties": false,
+            "properties": {
+                "FilterList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Filter"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.IssuerData": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "SignKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Metadata": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.MetadataList": {
+            "additionalProperties": false,
+            "properties": {
+                "MetadataList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Metadata"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ProvisionalConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxTimeToLiveInMinutes": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxTimeToLiveInMinutes"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.Rule": {
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Unit": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Unit",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.RuleList": {
+            "additionalProperties": false,
+            "properties": {
+                "RuleList": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::LicenseManager::License.Rule"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.StringList": {
+            "additionalProperties": false,
+            "properties": {
+                "StringList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.TagList": {
+            "additionalProperties": false,
+            "properties": {
+                "TagList": {
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::LicenseManager::License.ValidityDateFormat": {
+            "additionalProperties": false,
+            "properties": {
+                "Begin": {
+                    "type": "string"
+                },
+                "End": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Begin",
+                "End"
             ],
             "type": "object"
         },
@@ -57916,6 +61797,224 @@
                         "type": "string"
                     },
                     "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "AirflowConfigurationOptions": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.AirflowConfigurationOptions"
+                        },
+                        "AirflowVersion": {
+                            "type": "string"
+                        },
+                        "DagS3Path": {
+                            "type": "string"
+                        },
+                        "EnvironmentClass": {
+                            "type": "string"
+                        },
+                        "ExecutionRoleArn": {
+                            "type": "string"
+                        },
+                        "KmsKey": {
+                            "type": "string"
+                        },
+                        "LoggingConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.LoggingConfiguration"
+                        },
+                        "MaxWorkers": {
+                            "type": "number"
+                        },
+                        "NetworkConfiguration": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.NetworkConfiguration"
+                        },
+                        "PluginsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "PluginsS3Path": {
+                            "type": "string"
+                        },
+                        "RequirementsS3ObjectVersion": {
+                            "type": "string"
+                        },
+                        "RequirementsS3Path": {
+                            "type": "string"
+                        },
+                        "SourceBucketArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "$ref": "#/definitions/AWS::MWAA::Environment.TagMap"
+                        },
+                        "WebserverAccessMode": {
+                            "type": "string"
+                        },
+                        "WebserverUrl": {
+                            "type": "string"
+                        },
+                        "WeeklyMaintenanceWindowStart": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::MWAA::Environment"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.AirflowConfigurationOptions": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LastUpdate": {
+            "additionalProperties": false,
+            "properties": {
+                "CreatedAt": {
+                    "type": "string"
+                },
+                "Error": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.UpdateError"
+                },
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.LoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DagProcessingLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "SchedulerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "TaskLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WebserverLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                },
+                "WorkerLogs": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.ModuleLoggingConfiguration"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.ModuleLoggingConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "CloudWatchLogGroupArn": {
+                    "type": "string"
+                },
+                "Enabled": {
+                    "type": "boolean"
+                },
+                "LogLevel": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.NetworkConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SecurityGroupList"
+                },
+                "SubnetIds": {
+                    "$ref": "#/definitions/AWS::MWAA::Environment.SubnetList"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SecurityGroupList": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.SubnetList": {
+            "additionalProperties": false,
+            "properties": {
+                "SubnetList": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.TagMap": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::MWAA::Environment.UpdateError": {
+            "additionalProperties": false,
+            "properties": {
+                "ErrorCode": {
+                    "type": "string"
+                },
+                "ErrorMessage": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -63228,7 +67327,10 @@
                             "type": "array"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::Firewall.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "VpcId": {
                             "type": "string"
@@ -63275,18 +67377,6 @@
             ],
             "type": "object"
         },
-        "AWS::NetworkFirewall::Firewall.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::FirewallPolicy": {
             "additionalProperties": false,
             "properties": {
@@ -63329,7 +67419,10 @@
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::FirewallPolicy.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -63521,18 +67614,6 @@
             },
             "type": "object"
         },
-        "AWS::NetworkFirewall::FirewallPolicy.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
         "AWS::NetworkFirewall::LoggingConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -63565,11 +67646,18 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "FirewallArn": {
+                            "type": "string"
+                        },
+                        "FirewallName": {
+                            "type": "string"
+                        },
                         "LoggingConfiguration": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::LoggingConfiguration.LoggingConfiguration"
                         }
                     },
                     "required": [
+                        "FirewallArn",
                         "LoggingConfiguration"
                     ],
                     "type": "object"
@@ -63686,14 +67774,14 @@
                         "RuleGroup": {
                             "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.RuleGroup"
                         },
-                        "RuleGroupId": {
-                            "type": "string"
-                        },
                         "RuleGroupName": {
                             "type": "string"
                         },
                         "Tags": {
-                            "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.Tags"
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
                         },
                         "Type": {
                             "type": "string"
@@ -64175,18 +68263,6 @@
                 "TCPFlags": {
                     "items": {
                         "$ref": "#/definitions/AWS::NetworkFirewall::RuleGroup.TCPFlagField"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "AWS::NetworkFirewall::RuleGroup.Tags": {
-            "additionalProperties": false,
-            "properties": {
-                "Tags": {
-                    "items": {
-                        "$ref": "#/definitions/Tag"
                     },
                     "type": "array"
                 }
@@ -73029,6 +77105,18 @@
             },
             "type": "object"
         },
+        "AWS::S3::Bucket.ReplicaModifications": {
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Status"
+            ],
+            "type": "object"
+        },
         "AWS::S3::Bucket.ReplicationConfiguration": {
             "additionalProperties": false,
             "properties": {
@@ -73284,6 +77372,9 @@
         "AWS::S3::Bucket.ServerSideEncryptionRule": {
             "additionalProperties": false,
             "properties": {
+                "BucketKeyEnabled": {
+                    "type": "boolean"
+                },
                 "ServerSideEncryptionByDefault": {
                     "$ref": "#/definitions/AWS::S3::Bucket.ServerSideEncryptionByDefault"
                 }
@@ -73293,6 +77384,9 @@
         "AWS::S3::Bucket.SourceSelectionCriteria": {
             "additionalProperties": false,
             "properties": {
+                "ReplicaModifications": {
+                    "$ref": "#/definitions/AWS::S3::Bucket.ReplicaModifications"
+                },
                 "SseKmsEncryptedObjects": {
                     "$ref": "#/definitions/AWS::S3::Bucket.SseKmsEncryptedObjects"
                 }
@@ -76109,6 +80203,72 @@
             ],
             "type": "object"
         },
+        "AWS::SSO::InstanceAccessControlAttributeConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "InstanceAccessControlAttributeConfiguration": {
+                            "type": "object"
+                        },
+                        "InstanceArn": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "InstanceAccessControlAttributeConfiguration",
+                        "InstanceArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
         "AWS::SSO::PermissionSet": {
             "additionalProperties": false,
             "properties": {
@@ -76282,6 +80442,502 @@
             ],
             "type": "object"
         },
+        "AWS::SageMaker::DataQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "DataQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification"
+                        },
+                        "DataQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig"
+                        },
+                        "DataQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput"
+                        },
+                        "DataQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringResources"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "DataQualityAppSpecification",
+                        "DataQualityJobInput",
+                        "DataQualityJobOutputConfig",
+                        "JobResources",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DataQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ConstraintsResource"
+                },
+                "StatisticsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.StatisticsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.DataQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StatisticsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DataQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Device": {
+                            "type": "object"
+                        },
+                        "Tags": {}
+                    },
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Device"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Device.Device": {
+            "additionalProperties": false,
+            "properties": {
+                "Description": {
+                    "type": "string"
+                },
+                "DeviceName": {
+                    "type": "string"
+                },
+                "IotThingName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "DeviceName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Description": {
+                            "type": "string"
+                        },
+                        "OutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet.EdgeOutputConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {}
+                    },
+                    "required": [
+                        "OutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::DeviceFleet"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::DeviceFleet.EdgeOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "S3OutputLocation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3OutputLocation"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::Endpoint": {
             "additionalProperties": false,
             "properties": {
@@ -76314,6 +80970,9 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "DeploymentConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::Endpoint.DeploymentConfig"
+                        },
                         "EndpointConfigName": {
                             "type": "string"
                         },
@@ -76359,6 +81018,100 @@
             "required": [
                 "Type",
                 "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.Alarm": {
+            "additionalProperties": false,
+            "properties": {
+                "AlarmName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AlarmName"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.AutoRollbackConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "Alarms": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::Endpoint.Alarm"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "Alarms"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy": {
+            "additionalProperties": false,
+            "properties": {
+                "MaximumExecutionTimeoutInSeconds": {
+                    "type": "number"
+                },
+                "TerminationWaitInSeconds": {
+                    "type": "number"
+                },
+                "TrafficRoutingConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.TrafficRoutingConfig"
+                }
+            },
+            "required": [
+                "TrafficRoutingConfiguration"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.CapacitySize": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type",
+                "Value"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.DeploymentConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "AutoRollbackConfiguration": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.AutoRollbackConfig"
+                },
+                "BlueGreenUpdatePolicy": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.BlueGreenUpdatePolicy"
+                }
+            },
+            "required": [
+                "BlueGreenUpdatePolicy"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Endpoint.TrafficRoutingConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "CanarySize": {
+                    "$ref": "#/definitions/AWS::SageMaker::Endpoint.CapacitySize"
+                },
+                "Type": {
+                    "type": "string"
+                },
+                "WaitIntervalInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "Type"
             ],
             "type": "object"
         },
@@ -76703,6 +81456,1096 @@
             ],
             "type": "object"
         },
+        "AWS::SageMaker::ModelBiasJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources"
+                        },
+                        "ModelBiasAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification"
+                        },
+                        "ModelBiasBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig"
+                        },
+                        "ModelBiasJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput"
+                        },
+                        "ModelBiasJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelBiasAppSpecification",
+                        "ModelBiasJobInput",
+                        "ModelBiasJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelBiasJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.ModelBiasJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelBiasJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources"
+                        },
+                        "ModelExplainabilityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification"
+                        },
+                        "ModelExplainabilityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig"
+                        },
+                        "ModelExplainabilityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput"
+                        },
+                        "ModelExplainabilityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelExplainabilityAppSpecification",
+                        "ModelExplainabilityJobInput",
+                        "ModelExplainabilityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelExplainabilityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointName": {
+                    "type": "string"
+                },
+                "FeaturesAttribute": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ConfigUri": {
+                    "type": "string"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ConfigUri",
+                "ImageUri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.ModelExplainabilityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.EndpointInput"
+                }
+            },
+            "required": [
+                "EndpointInput"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelExplainabilityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelPackageGroup": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ModelPackageGroupDescription": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupName": {
+                            "type": "string"
+                        },
+                        "ModelPackageGroupPolicy": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ModelPackageGroupName"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelPackageGroup"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "JobDefinitionName": {
+                            "type": "string"
+                        },
+                        "JobResources": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources"
+                        },
+                        "ModelQualityAppSpecification": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification"
+                        },
+                        "ModelQualityBaselineConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig"
+                        },
+                        "ModelQualityJobInput": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput"
+                        },
+                        "ModelQualityJobOutputConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig"
+                        },
+                        "NetworkConfig": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "StoppingCondition": {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "JobResources",
+                        "ModelQualityAppSpecification",
+                        "ModelQualityJobInput",
+                        "ModelQualityJobOutputConfig",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::ModelQualityJobDefinition"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "InstanceCount": {
+                    "type": "number"
+                },
+                "InstanceType": {
+                    "type": "string"
+                },
+                "VolumeKmsKeyId": {
+                    "type": "string"
+                },
+                "VolumeSizeInGB": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "InstanceCount",
+                "InstanceType",
+                "VolumeSizeInGB"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.EndpointInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndTimeOffset": {
+                    "type": "string"
+                },
+                "EndpointName": {
+                    "type": "string"
+                },
+                "InferenceAttribute": {
+                    "type": "string"
+                },
+                "LocalPath": {
+                    "type": "string"
+                },
+                "ProbabilityAttribute": {
+                    "type": "string"
+                },
+                "ProbabilityThresholdAttribute": {
+                    "type": "number"
+                },
+                "S3DataDistributionType": {
+                    "type": "string"
+                },
+                "S3InputMode": {
+                    "type": "string"
+                },
+                "StartTimeOffset": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "EndpointName",
+                "LocalPath"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.Environment": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityAppSpecification": {
+            "additionalProperties": false,
+            "properties": {
+                "ContainerArguments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ContainerEntrypoint": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Environment": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.Environment"
+                },
+                "ImageUri": {
+                    "type": "string"
+                },
+                "PostAnalyticsProcessorSourceUri": {
+                    "type": "string"
+                },
+                "ProblemType": {
+                    "type": "string"
+                },
+                "RecordPreprocessorSourceUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ImageUri",
+                "ProblemType"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityBaselineConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "BaseliningJobName": {
+                    "type": "string"
+                },
+                "ConstraintsResource": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ConstraintsResource"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.ModelQualityJobInput": {
+            "additionalProperties": false,
+            "properties": {
+                "EndpointInput": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.EndpointInput"
+                },
+                "GroundTruthS3Input": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input"
+                }
+            },
+            "required": [
+                "EndpointInput",
+                "GroundTruthS3Input"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringGroundTruthS3Input": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput": {
+            "additionalProperties": false,
+            "properties": {
+                "S3Output": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.S3Output"
+                }
+            },
+            "required": [
+                "S3Output"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutputConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "KmsKeyId": {
+                    "type": "string"
+                },
+                "MonitoringOutputs": {
+                    "items": {
+                        "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.MonitoringOutput"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "MonitoringOutputs"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.MonitoringResources": {
+            "additionalProperties": false,
+            "properties": {
+                "ClusterConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.ClusterConfig"
+                }
+            },
+            "required": [
+                "ClusterConfig"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.NetworkConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "EnableInterContainerTrafficEncryption": {
+                    "type": "boolean"
+                },
+                "EnableNetworkIsolation": {
+                    "type": "boolean"
+                },
+                "VpcConfig": {
+                    "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition.VpcConfig"
+                }
+            },
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.S3Output": {
+            "additionalProperties": false,
+            "properties": {
+                "LocalPath": {
+                    "type": "string"
+                },
+                "S3UploadMode": {
+                    "type": "string"
+                },
+                "S3Uri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "LocalPath",
+                "S3Uri"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.StoppingCondition": {
+            "additionalProperties": false,
+            "properties": {
+                "MaxRuntimeInSeconds": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "MaxRuntimeInSeconds"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::ModelQualityJobDefinition.VpcConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "SecurityGroupIds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "Subnets": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "SecurityGroupIds",
+                "Subnets"
+            ],
+            "type": "object"
+        },
         "AWS::SageMaker::MonitoringSchedule": {
             "additionalProperties": false,
             "properties": {
@@ -76743,9 +82586,6 @@
                         },
                         "LastMonitoringExecutionSummary": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringExecutionSummary"
-                        },
-                        "MonitoringScheduleArn": {
-                            "type": "string"
                         },
                         "MonitoringScheduleConfig": {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringScheduleConfig"
@@ -77040,13 +82880,16 @@
                 "MonitoringJobDefinition": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.MonitoringJobDefinition"
                 },
+                "MonitoringJobDefinitionName": {
+                    "type": "string"
+                },
+                "MonitoringType": {
+                    "type": "string"
+                },
                 "ScheduleConfig": {
                     "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule.ScheduleConfig"
                 }
             },
-            "required": [
-                "MonitoringJobDefinition"
-            ],
             "type": "object"
         },
         "AWS::SageMaker::MonitoringSchedule.NetworkConfig": {
@@ -77329,6 +83172,163 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "AWS::SageMaker::Pipeline": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "PipelineDefinition": {
+                            "type": "object"
+                        },
+                        "PipelineDescription": {
+                            "type": "string"
+                        },
+                        "PipelineDisplayName": {
+                            "type": "string"
+                        },
+                        "PipelineName": {
+                            "type": "string"
+                        },
+                        "RoleArn": {
+                            "type": "string"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "PipelineDefinition",
+                        "PipelineName",
+                        "RoleArn"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Pipeline"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
+            "type": "object"
+        },
+        "AWS::SageMaker::Project": {
+            "additionalProperties": false,
+            "properties": {
+                "DeletionPolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                },
+                "DependsOn": {
+                    "anyOf": [
+                        {
+                            "pattern": "^[a-zA-Z0-9]+$",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "pattern": "^[a-zA-Z0-9]+$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "Metadata": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "ProjectDescription": {
+                            "type": "string"
+                        },
+                        "ProjectName": {
+                            "type": "string"
+                        },
+                        "ServiceCatalogProvisioningDetails": {
+                            "type": "object"
+                        },
+                        "Tags": {
+                            "items": {
+                                "$ref": "#/definitions/Tag"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "ProjectName",
+                        "ServiceCatalogProvisioningDetails"
+                    ],
+                    "type": "object"
+                },
+                "Type": {
+                    "enum": [
+                        "AWS::SageMaker::Project"
+                    ],
+                    "type": "string"
+                },
+                "UpdateReplacePolicy": {
+                    "enum": [
+                        "Delete",
+                        "Retain",
+                        "Snapshot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Type",
+                "Properties"
+            ],
             "type": "object"
         },
         "AWS::SageMaker::Workteam": {
@@ -78311,6 +84311,9 @@
                                 }
                             ]
                         },
+                        "ProvisionedConcurrencyConfig": {
+                            "$ref": "#/definitions/AWS::Serverless::Function.ProvisionedConcurrencyConfig"
+                        },
                         "ReservedConcurrentExecutions": {
                             "type": "number"
                         },
@@ -78787,6 +84790,18 @@
             },
             "required": [
                 "Destination"
+            ],
+            "type": "object"
+        },
+        "AWS::Serverless::Function.ProvisionedConcurrencyConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "ProvisionedConcurrentExecutions": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ProvisionedConcurrentExecutions"
             ],
             "type": "object"
         },
@@ -82120,7 +88135,7 @@
                 },
                 "SecurityGroupIds": {
                     "items": {
-                        "$ref": "#/definitions/AWS::Transfer::Server.SecurityGroupId"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -82156,11 +88171,6 @@
             "type": "object"
         },
         "AWS::Transfer::Server.Protocol": {
-            "additionalProperties": false,
-            "properties": {},
-            "type": "object"
-        },
-        "AWS::Transfer::Server.SecurityGroupId": {
             "additionalProperties": false,
             "properties": {},
             "type": "object"
@@ -86266,6 +92276,9 @@
                             "$ref": "#/definitions/AWS::Athena::WorkGroup"
                         },
                         {
+                            "$ref": "#/definitions/AWS::AuditManager::Assessment"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::AutoScaling::AutoScalingGroup"
                         },
                         {
@@ -86327,6 +92340,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Macro"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleDefaultVersion"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::CloudFormation::ModuleVersion"
                         },
                         {
                             "$ref": "#/definitions/AWS::CloudFormation::Stack"
@@ -86554,6 +92573,12 @@
                             "$ref": "#/definitions/AWS::Detective::MemberInvitation"
                         },
                         {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::NotificationChannel"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::DevOpsGuru::ResourceCollection"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::DirectoryService::MicrosoftAD"
                         },
                         {
@@ -86642,6 +92667,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkAclEntry"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsAnalysis"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::EC2::NetworkInsightsPath"
                         },
                         {
                             "$ref": "#/definitions/AWS::EC2::NetworkInterface"
@@ -86764,6 +92795,9 @@
                             "$ref": "#/definitions/AWS::EC2::VolumeAttachment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::ECR::PublicRepository"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::ECR::Repository"
                         },
                         {
@@ -86834,6 +92868,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::ElastiCache::SubnetGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::User"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::ElastiCache::UserGroup"
                         },
                         {
                             "$ref": "#/definitions/AWS::ElasticBeanstalk::Application"
@@ -87034,6 +93074,9 @@
                             "$ref": "#/definitions/AWS::Greengrass::SubscriptionDefinitionVersion"
                         },
                         {
+                            "$ref": "#/definitions/AWS::GreengrassV2::ComponentVersion"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::GuardDuty::Detector"
                         },
                         {
@@ -87172,16 +93215,43 @@
                             "$ref": "#/definitions/AWS::IoTEvents::Input"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::AccessPolicy"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Asset"
                         },
                         {
                             "$ref": "#/definitions/AWS::IoTSiteWise::AssetModel"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Dashboard"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTSiteWise::Gateway"
                         },
                         {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Portal"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTSiteWise::Project"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::IoTThingsGraph::FlowTemplate"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::Destination"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::DeviceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::ServiceProfile"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessDevice"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::IoTWireless::WirelessGateway"
                         },
                         {
                             "$ref": "#/definitions/AWS::KMS::Alias"
@@ -87265,6 +93335,12 @@
                             "$ref": "#/definitions/AWS::Lambda::Version"
                         },
                         {
+                            "$ref": "#/definitions/AWS::LicenseManager::Grant"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::LicenseManager::License"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::Logs::Destination"
                         },
                         {
@@ -87281,6 +93357,9 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::MSK::Cluster"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::MWAA::Environment"
                         },
                         {
                             "$ref": "#/definitions/AWS::Macie::CustomDataIdentifier"
@@ -87655,10 +93734,22 @@
                             "$ref": "#/definitions/AWS::SSO::Assignment"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SSO::InstanceAccessControlAttributeConfiguration"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SSO::PermissionSet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::CodeRepository"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DataQualityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Device"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::DeviceFleet"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Endpoint"
@@ -87670,6 +93761,18 @@
                             "$ref": "#/definitions/AWS::SageMaker::Model"
                         },
                         {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelBiasJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelExplainabilityJobDefinition"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelPackageGroup"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::ModelQualityJobDefinition"
+                        },
+                        {
                             "$ref": "#/definitions/AWS::SageMaker::MonitoringSchedule"
                         },
                         {
@@ -87677,6 +93780,12 @@
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::NotebookInstanceLifecycleConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Pipeline"
+                        },
+                        {
+                            "$ref": "#/definitions/AWS::SageMaker::Project"
                         },
                         {
                             "$ref": "#/definitions/AWS::SageMaker::Workteam"

--- a/test/json/valid-sam-template.json
+++ b/test/json/valid-sam-template.json
@@ -8,7 +8,10 @@
       "Properties": {
         "Handler": "index.handler",
         "CodeUri": "s3://testBucket/mySourceCode.zip",
-        "Runtime": "nodejs10.x"
+        "Runtime": "nodejs10.x",
+        "ProvisionedConcurrencyConfig":{
+          "ProvisionedConcurrentExecutions": "1"
+        }
       }
     },
     "MySNSTopic" : {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for `ProvisionedConcurrencyConfig` to `AWS::Serverless::Function` schemas.

Commits:

1. Change to `sam-2016-10-31.json`
2. `go generate`
3. Fix to add type `Tag` to fields that are missing a type
4. Add onto a unit test to support original use case

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
