### PR TITLE
Add cloudformation.TransformFn()

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -226,6 +226,17 @@ func Or(conditions []string) string {
 	return encode(fmt.Sprintf(`{ "Fn::Or": [ %v ] }`, printList(conditions)))
 }
 
+// (str, map[str]str) -> str
+
+func TransformFn(name string, parameters map[string]string) string {
+	var params []string
+	for key, value := range parameters {
+		params = append(params, fmt.Sprintf(`"%v" : "%v"`, key, value))
+	}
+
+	return encode(fmt.Sprintf(`{ "Fn::Transform" : { "Name" : "%v", "Parameters" : { "%v" } } }`, name, strings.Trim(strings.Join(params, `, `), `, "`)))
+}
+
 // encode takes a string representation of an intrinsic function, and base64 encodes it.
 // This prevents the escaping issues when nesting multiple layers of intrinsic functions.
 func encode(value string) string {

--- a/intrinsics/fntransform.go
+++ b/intrinsics/fntransform.go
@@ -1,0 +1,8 @@
+package intrinsics
+
+func FnTransform(name string, input interface{}, template interface{}) interface{} {
+
+	// { "Fn::Transform" : { "Name" : "macro name", "Parameters" : {"key" : "value", ... } } }
+
+	return nil
+}

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -34,6 +34,7 @@ var defaultIntrinsicHandlers = map[string]IntrinsicHandler{
 	"Fn::Sub":         FnSub,
 	"Ref":             Ref,
 	"Fn::Cidr":        nonResolvingHandler,
+	"Fn::Transform":   FnTransform,
 }
 
 // ProcessorOptions allows customisation of the intrinsic function processor behaviour.


### PR DESCRIPTION
Issue: #335 and refers also to #332 

Thanks to that implementation I can use Macros in my code. Example

- Macro code https://github.com/aws-cloudformation/aws-cloudformation-macros/blob/master/StringFunctions/string.yaml
- My code example - where `${Environment}` is uppercase and I would like to convert it to Lower using TransformFn

```
S3Bucket: cloudformation.TransformFn("String", map[string]string{
   "InputString": cloudformation.Sub("mybucket.${Environment}"),
   "Operation":   "Lower",
}),
````
