### PR TITLE
Improve cloudformation If to accept structs

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -2,6 +2,7 @@ package cloudformation
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -180,8 +181,19 @@ func FindInMap(mapName, topLevelKey, secondLevelKey interface{}) string {
 }
 
 // If returns one value if the specified condition evaluates to true and another value if the specified condition evaluates to false. Currently, AWS CloudFormation supports the Fn::If intrinsic function in the metadata attribute, update policy attribute, and property values in the Resources section and Outputs sections of a template. You can use the AWS::NoValue pseudo parameter as a return value to remove the corresponding property.
-func If(value, ifEqual, ifNotEqual interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::If" : [ %q, %q, %q ] }`, value, ifEqual, ifNotEqual))
+func If(value, ifEqual interface{}, ifNotEqual interface{}) string {
+
+	equal, err := json.Marshal(ifEqual)
+	if err != nil {
+		panic(err)
+	}
+
+	notEqual, err := json.Marshal(ifNotEqual)
+	if err != nil {
+		panic(err)
+	}
+
+	return encode(fmt.Sprintf(`{ "Fn::If" : [ %q, %v, %v ] }`, value, string(equal), string(notEqual)))
 }
 
 // (str, []str) -> str


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Cloduformation.If should not able to accept strings but much more complex structs also - example:

```
Policy: cloudformation.If("PrivateApiGateway",
	map[string]interface{}{
		"Version": "2012-10-17",
		"Statement": []map[string]interface{}{
			{
				"Effect":    "Allow",
				"Principal": "*",
				"Action":    "execute-api:Invoke",
				"Resource":  cloudformation.Sub("arn:aws:execute-api:${AWS::Region}:${AWS::AccountId:*/*"),
			},
		},
	},
	map[string]interface{}{},
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
