### PR TITLE
Remove required properties from AWS::Serverless::Function

### DIFF
--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -47,19 +47,19 @@
             "Properties": {
                 "Handler": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
-                    "Required": true,
+                    "Required": false,
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 },
                 "Runtime": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
-                    "Required": true,
+                    "Required": false,
                     "PrimitiveType": "String",
                     "UpdateType": "Immutable"
                 },
                 "CodeUri": {
                     "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction",
-                    "Required": true,
+                    "Required": false,
                     "PrimitiveTypes": [
                         "String"
                     ],


### PR DESCRIPTION
Removing required properties from AWS::Serverless::Function resources in order to support Serverless functions using Container Images. For reference, the image below was generated via SAM CLI, is using the latest SAM schema from the Goformation repo, and is syntactically correct.

![image](https://user-images.githubusercontent.com/29374703/123672630-60be2c00-d7f4-11eb-8045-d245cff329b0.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
