### PR TITLE
Use any type for AllowedValues

### DIFF
--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -25,17 +25,17 @@ type Template struct {
 }
 
 type Parameter struct {
-	Type                  string      `json:"Type"`
-	Description           string      `json:"Description,omitempty"`
-	Default               interface{} `json:"Default,omitempty"`
-	AllowedPattern        string      `json:"AllowedPattern,omitempty"`
-	AllowedValues         []string    `json:"AllowedValues,omitempty"`
-	ConstraintDescription string      `json:"ConstraintDescription,omitempty"`
-	MaxLength             int         `json:"MaxLength,omitempty"`
-	MinLength             int         `json:"MinLength,omitempty"`
-	MaxValue              float64     `json:"MaxValue,omitempty"`
-	MinValue              float64     `json:"MinValue,omitempty"`
-	NoEcho                bool        `json:"NoEcho,omitempty"`
+	Type                  string        `json:"Type"`
+	Description           string        `json:"Description,omitempty"`
+	Default               interface{}   `json:"Default,omitempty"`
+	AllowedPattern        string        `json:"AllowedPattern,omitempty"`
+	AllowedValues         []interface{} `json:"AllowedValues,omitempty"`
+	ConstraintDescription string        `json:"ConstraintDescription,omitempty"`
+	MaxLength             int           `json:"MaxLength,omitempty"`
+	MinLength             int           `json:"MinLength,omitempty"`
+	MaxValue              float64       `json:"MaxValue,omitempty"`
+	MinValue              float64       `json:"MinValue,omitempty"`
+	NoEcho                bool          `json:"NoEcho,omitempty"`
 }
 
 type Output struct {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

According to the docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html The `AllowedValues` field can be an array of any type, not just `string`. Therefore use `[]interface{}` for the type.

A simple example where it doesn't work before this change is if you define a parameter like this:

```yaml
  LogsRetentionInDays:
    Description: >-
      Specifies the number of days you want to retain log events in the
      log group for the Lambda function
    Type:    Number
    Default: 14
    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
```

Where it would fail with the error:

```
json: cannot unmarshal number into Go struct field Parameter.Parameters.AllowedValues of type string
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
