### PR TITLE
fix(sam): DestinationConfig shouldn't contain OnSuccess property

### DIFF
--- a/cloudformation/serverless/aws-serverless-function_eventinvokeconfig.go
+++ b/cloudformation/serverless/aws-serverless-function_eventinvokeconfig.go
@@ -11,7 +11,7 @@ type Function_EventInvokeConfig struct {
 	// DestinationConfig AWS CloudFormation Property
 	// Required: false
 	// See: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-config-object
-	DestinationConfig *Function_DestinationConfig `json:"DestinationConfig,omitempty"`
+	DestinationConfig *Function_EventInvokeDestinationConfig `json:"DestinationConfig,omitempty"`
 
 	// MaximumEventAgeInSeconds AWS CloudFormation Property
 	// Required: false

--- a/cloudformation/serverless/aws-serverless-function_eventinvokedestinationconfig.go
+++ b/cloudformation/serverless/aws-serverless-function_eventinvokedestinationconfig.go
@@ -4,14 +4,19 @@ import (
 	"github.com/awslabs/goformation/v5/cloudformation/policies"
 )
 
-// Function_DestinationConfig AWS CloudFormation Resource (AWS::Serverless::Function.DestinationConfig)
-// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#destination-config-object
-type Function_DestinationConfig struct {
+// Function_EventInvokeDestinationConfig AWS CloudFormation Resource (AWS::Serverless::Function.EventInvokeDestinationConfig)
+// See: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-destination-config-object
+type Function_EventInvokeDestinationConfig struct {
 
 	// OnFailure AWS CloudFormation Property
 	// Required: true
-	// See: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#destination-config-object
+	// See: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-destination-config-object
 	OnFailure *Function_Destination `json:"OnFailure,omitempty"`
+
+	// OnSuccess AWS CloudFormation Property
+	// Required: true
+	// See: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-destination-config-object
+	OnSuccess *Function_Destination `json:"OnSuccess,omitempty"`
 
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
@@ -30,6 +35,6 @@ type Function_DestinationConfig struct {
 }
 
 // AWSCloudFormationType returns the AWS CloudFormation resource type
-func (r *Function_DestinationConfig) AWSCloudFormationType() string {
-	return "AWS::Serverless::Function.DestinationConfig"
+func (r *Function_EventInvokeDestinationConfig) AWSCloudFormationType() string {
+	return "AWS::Serverless::Function.EventInvokeDestinationConfig"
 }

--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -1244,15 +1244,27 @@
                         "Required": true,
                         "Type": "Destination",
                         "UpdateType": "Immutable"
+                    }
+                }
+        },
+	"AWS::Serverless::Function.EventInvokeDestinationConfig": {
+                "Documentation": "https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-destination-config-object",
+                "Properties": {
+                    "OnFailure": {
+                        "Documentation": "https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-destination-config-object",
+                        "Required": true,
+                        "Type": "Destination",
+                        "UpdateType": "Immutable"
                     },
                     "OnSuccess": {
-                        "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#destination-config-object",
+                        "Documentation": "https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-destination-config-object",
                         "Required": true,
                         "Type": "Destination",
                         "UpdateType": "Immutable"
                     }
                 }
         },
+
         "AWS::Serverless::Function.Destination": {
                 "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#destination-config-object",
                 "Properties": {
@@ -1761,7 +1773,7 @@
                 "DestinationConfig": {
                     "Documentation": "https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#event-invoke-config-object",
                     "Required": false,
-                    "Type": "DestinationConfig",
+                    "Type": "EventInvokeDestinationConfig",
                     "UpdateType": "Immutable"
                 }
             }

--- a/schema/sam.go
+++ b/schema/sam.go
@@ -107324,14 +107324,10 @@ var SamSchema = `{
             "properties": {
                 "OnFailure": {
                     "$ref": "#/definitions/AWS::Serverless::Function.Destination"
-                },
-                "OnSuccess": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.Destination"
                 }
             },
             "required": [
-                "OnFailure",
-                "OnSuccess"
+                "OnFailure"
             ],
             "type": "object"
         },
@@ -107417,7 +107413,7 @@ var SamSchema = `{
             "additionalProperties": false,
             "properties": {
                 "DestinationConfig": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.DestinationConfig"
+                    "$ref": "#/definitions/AWS::Serverless::Function.EventInvokeDestinationConfig"
                 },
                 "MaximumEventAgeInSeconds": {
                     "type": "number"
@@ -107426,6 +107422,22 @@ var SamSchema = `{
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Serverless::Function.EventInvokeDestinationConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "OnFailure": {
+                    "$ref": "#/definitions/AWS::Serverless::Function.Destination"
+                },
+                "OnSuccess": {
+                    "$ref": "#/definitions/AWS::Serverless::Function.Destination"
+                }
+            },
+            "required": [
+                "OnFailure",
+                "OnSuccess"
+            ],
             "type": "object"
         },
         "AWS::Serverless::Function.EventSource": {

--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -107321,14 +107321,10 @@
             "properties": {
                 "OnFailure": {
                     "$ref": "#/definitions/AWS::Serverless::Function.Destination"
-                },
-                "OnSuccess": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.Destination"
                 }
             },
             "required": [
-                "OnFailure",
-                "OnSuccess"
+                "OnFailure"
             ],
             "type": "object"
         },
@@ -107414,7 +107410,7 @@
             "additionalProperties": false,
             "properties": {
                 "DestinationConfig": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.DestinationConfig"
+                    "$ref": "#/definitions/AWS::Serverless::Function.EventInvokeDestinationConfig"
                 },
                 "MaximumEventAgeInSeconds": {
                     "type": "number"
@@ -107423,6 +107419,22 @@
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "AWS::Serverless::Function.EventInvokeDestinationConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "OnFailure": {
+                    "$ref": "#/definitions/AWS::Serverless::Function.Destination"
+                },
+                "OnSuccess": {
+                    "$ref": "#/definitions/AWS::Serverless::Function.Destination"
+                }
+            },
+            "required": [
+                "OnFailure",
+                "OnSuccess"
+            ],
             "type": "object"
         },
         "AWS::Serverless::Function.EventSource": {


### PR DESCRIPTION


*Issue #, if available:* 
https://github.com/awslabs/goformation/issues/404

*Description of changes:*
Added a new type called EventInvokeDestinationCOnfig with OnSUccess and OnFailure properties. Removed OnSuccess from existing DestinationConfig. Updated EventInvoke to use EventInvokeDestinationConfig


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
