### PR TITLE
fix(sam): AWS::Serverless::Function Properties should contain Architectures property

### DIFF
--- a/schema/sam.schema.json
+++ b/schema/sam.schema.json
@@ -106894,6 +106894,12 @@
                 "Properties": {
                     "additionalProperties": false,
                     "properties": {
+                        "Architectures": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
                         "AssumeRolePolicyDocument": {
                             "type": "object"
                         },


### PR DESCRIPTION
*Description of changes:*
The sample generated by SAM CLI 1.33.0 shows AWS::Serverless::Function Properties should contain Architectures property.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
