### PR TITLE
Add SubVars to Sub with replacement variables

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -146,6 +146,16 @@ func Sub(value interface{}) string {
 	return encode(fmt.Sprintf(`{ "Fn::Sub" : %q }`, value))
 }
 
+// SubVars works like Sub(), except it accepts a map of variable values to replace
+func SubVars(value interface{}, variables map[string]interface{}) string {
+	pairs := make([]string, 0, len(variables))
+	for key, val := range variables {
+		pairs = append(pairs, fmt.Sprintf(`%q : %q`, key, val))
+	}
+
+	return encode(fmt.Sprintf(`{ "Fn::Sub" : [ %q, { %s } ] }`, value, strings.Join(pairs, ",")))
+}
+
 // (str, str) -> str
 
 // GetAtt returns the value of an attribute from a resource in the template.

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -1067,6 +1067,18 @@ var _ = Describe("Goformation", func() {
 				},
 			},
 			{
+				Name:  "Fn::SubVars",
+				Input: cloudformation.SubVars("test-sub", map[string]interface{}{"foo": "bar"}),
+				Expected: map[string]interface{}{
+					"Fn::Sub": []interface{}{
+						"test-sub",
+						map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			{
 				Name:  "Fn::And",
 				Input: cloudformation.And([]string{"test-and-first", "test-and-second", "test-and-third"}),
 				Expected: map[string]interface{}{


### PR DESCRIPTION
*Issue #, if available:*

I believe would help with https://github.com/awslabs/goformation/issues/265, though my use case was slightly different.

*Description of changes:*

I couldn't figure out how to do Sub() with replacement variables, so I added a method that will expand to:
```
{ "Fn::Sub" : [ String, { Var1Name: Var1Value, Var2Name: Var2Value } ] }
```