### PR TITLE
fix(sam): AWS::Serverless::Function Properties Architectures property should have a primitive type specified

### DIFF
--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -262,7 +262,7 @@
                     "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-architectures",
                     "Required": false,
                     "Type": "List",
-                    "ItemType": "String",
+                    "PrimitiveItemType": "String",
                     "UpdateType": "Immutable"
                 }
             }


### PR DESCRIPTION
*Description of changes:*

The `Architectures` property from `AWS::Serverless::Function` doesn't have a `PrimitiveItemType`. Instead, it has a `"ItemType": "String"`. This is preventing the CDK from generating the new L1 constructs for SAM.

Change `ItemType` to `PrimitiveItemType`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
