### PR TITLE
perf: reduce JSON CloudFormation template size

### DIFF
--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -220,7 +220,7 @@ func NewTemplate() *Template {
 // JSON converts an AWS CloudFormation template object to JSON
 func (t *Template) JSON() ([]byte, error) {
 
-	j, err := json.MarshalIndent(t, "", "  ")
+	j, err := json.MarshalIndent(t, "", " ")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
also: https://github.com/aws/serverless-application-model/pull/2368, https://github.com/aws/aws-cdk/pull/19656, https://github.com/cloudtools/troposphere/pull/2028
https://github.com/awslabs/goformation/issues/192
[CloudFormation templates can currently only be 1MB](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html)

Simply reducing indentation from 2 to 1 should remove ~1/4 of the template file size for everyone by default while still preserving indentation formatting. Beyond improving the default, those wishing to reduce readability for further reduced file size could opt into using something like [`jq`](https://stedolan.github.io/jq/) on their own for now