### PR TITLE
fix(schema): string should be a primitivetype

### DIFF
--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -2085,7 +2085,7 @@
                     "Documentation": "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-api-domainconfiguration.html#sam-api-domainconfiguration-basepath",
                     "Required": false,
                     "Type": "List",
-                    "ItemType": "String",
+                    "PrimitiveItemType": "String",
                     "UpdateType": "Immutable"
                 },
                 "CertificateArn": {


### PR DESCRIPTION
*Issue #

*Description of changes:*

A String needs to be a PrimitiveItemType instead of ItemType. ItemType means it's a complex property, which String isn't.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
