### PR TITLE
feat: switch go-yaml implementation to most recent version

### DIFF
--- a/cloudformation/policies_test.go
+++ b/cloudformation/policies_test.go
@@ -1,7 +1,7 @@
 package cloudformation_test
 
 import (
-	"github.com/sanathkr/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/awslabs/goformation/v7/cloudformation/autoscaling"
@@ -47,9 +47,9 @@ var _ = Describe("Goformation", func() {
 				},
 				Expected: map[string]interface{}{
 					"AutoScalingRollingUpdate": map[string]interface{}{
-						"MaxBatchSize":                  float64(10),
-						"MinInstancesInService":         float64(11),
-						"MinSuccessfulInstancesPercent": float64(12),
+						"MaxBatchSize":                  10,
+						"MinInstancesInService":         11,
+						"MinSuccessfulInstancesPercent": 12,
 						"PauseTime":                     "test-pause-time",
 						"SuspendProcesses":              []interface{}{"test-suspend1", "test-suspend2"},
 						"WaitOnResourceSignals":         true,
@@ -146,10 +146,10 @@ var _ = Describe("Goformation", func() {
 				},
 				Expected: map[string]interface{}{
 					"AutoScalingCreationPolicy": map[string]interface{}{
-						"MinSuccessfulInstancesPercent": float64(10),
+						"MinSuccessfulInstancesPercent": 10,
 					},
 					"ResourceSignal": map[string]interface{}{
-						"Count":   float64(11),
+						"Count":   11,
 						"Timeout": "test-timeout",
 					},
 				},

--- a/cloudformation/template.go
+++ b/cloudformation/template.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/goformation/v7/intrinsics"
-	"github.com/sanathkr/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // Template represents an AWS CloudFormation template
@@ -231,12 +231,22 @@ func (t *Template) JSON() ([]byte, error) {
 
 // YAML converts an AWS CloudFormation template object to YAML
 func (t *Template) YAML() ([]byte, error) {
-
 	j, err := t.JSON()
 	if err != nil {
 		return nil, err
 	}
 
-	return yaml.JSONToYAML(j)
+	var jsonObj interface{}
+	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
+	// Go JSON library doesn't try to pick the right number type (int, float,
+	// etc.) when unmarshalling to interface{}, it just picks float64
+	// universally. go-yaml does go through the effort of picking the right
+	// number type, so we can preserve number type throughout this process.
+	err = yaml.Unmarshal(j, &jsonObj)
+	if err != nil {
+		return nil, err
+	}
 
+	// Marshal this object into YAML
+	return yaml.Marshal(jsonObj)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/awslabs/goformation/v7
 require (
 	github.com/onsi/ginkgo/v2 v2.3.1
 	github.com/onsi/gomega v1.22.1
-	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
-	github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522
 	github.com/xeipuuv/gojsonschema v0.0.0-20181112162635-ac52e6811b56
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -16,7 +15,6 @@ require (
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 go 1.17

--- a/goformation_test.go
+++ b/goformation_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sanathkr/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/awslabs/goformation/v7"
 	"github.com/awslabs/goformation/v7/cloudformation"
@@ -98,19 +98,19 @@ func Example_to_yaml() {
 	}
 
 	// Output:
-	// AWSTemplateFormatVersion: 2010-09-09
+	// AWSTemplateFormatVersion: "2010-09-09"
 	// Resources:
-	//   MyTopic:
-	//     Properties:
-	//       TopicName: my-topic-1575143970
-	//     Type: AWS::SNS::Topic
-	//   MyTopicSubscription:
-	//     Properties:
-	//       Endpoint: some.email@example.com
-	//       Protocol: email
-	//       TopicArn:
-	//         Ref: MyTopic
-	//     Type: AWS::SNS::Subscription
+	//     MyTopic:
+	//         Properties:
+	//             TopicName: my-topic-1575143970
+	//         Type: AWS::SNS::Topic
+	//     MyTopicSubscription:
+	//         Properties:
+	//             Endpoint: some.email@example.com
+	//             Protocol: email
+	//             TopicArn:
+	//                 Ref: MyTopic
+	//         Type: AWS::SNS::Subscription
 
 }
 

--- a/intrinsics/intrinsics.go
+++ b/intrinsics/intrinsics.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	yamlwrapper "github.com/sanathkr/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // IntrinsicHandler is a function that applies an intrinsic function and returns
@@ -61,13 +61,21 @@ func ProcessYAML(input []byte, options *ProcessorOptions) ([]byte, error) {
 	// Convert short form intrinsic functions (e.g. !Sub) to long form
 	registerTagMarshallers()
 
-	data, err := yamlwrapper.YAMLToJSON(input)
+	// Convert YAML to an object
+	var yamlObj interface{}
+	err := yaml.Unmarshal(input, &customTagProcessor{
+		target: &yamlObj,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("invalid YAML template: %s", err)
 	}
 
-	return ProcessJSON(data, options)
+	data, err := json.Marshal(yamlObj)
+	if err != nil {
+		return nil, err
+	}
 
+	return ProcessJSON(data, options)
 }
 
 // ProcessJSON recursively searches through a byte array of JSON data for all

--- a/test/yaml/sam-official-samples/inline_swagger/template.yaml
+++ b/test/yaml/sam-official-samples/inline_swagger/template.yaml
@@ -20,7 +20,6 @@ Resources:
                 uri:
                   Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations
               responses: {}
-        swagger: '2.0'
 
 
             


### PR DESCRIPTION
*Issue #, if available:* #534

*Description of changes:*

This PR bumps go-yaml version to the latest avaialble. This meant that the custom intrinstics parser had to be re-written to accomodate the API changes on go-yaml.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
