### PR TITLE
fix(schema): add FunctionResponseTypes property for kinesis events

### DIFF
--- a/generate/sam-2016-10-31.json
+++ b/generate/sam-2016-10-31.json
@@ -931,6 +931,13 @@
                     "Required": false,
                     "PrimitiveType": "Boolean",
                     "UpdateType": "Immutable"
+                },
+                "FunctionResponseTypes": {
+                    "Documentation": "https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#kinesis",
+                    "Required": false,
+                    "Type": "List",
+                    "PrimitiveItemType": "String",
+                    "UpdateType": "Immutable"
                 }
             }
         },


### PR DESCRIPTION
*Issue #, if available:*
Related schema issue in aws-toolkit-vscode: https://github.com/aws/aws-toolkit-vscode/issues/2924

*Description of changes:*
This PR adds the FunctionResponseTypes property for Kinesis events.

The AWS documentation can be found here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-functionresponsetypes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
