### PR TITLE
feat(intrinsics): support nested intrinsics

### DIFF
--- a/cloudformation/intrinsics.go
+++ b/cloudformation/intrinsics.go
@@ -112,7 +112,7 @@ var EncoderIntrinsics = map[string]intrinsics.IntrinsicHandler{
 	"Fn::GetAZs":      strWrap(GetAZs),
 	"Fn::ImportValue": strWrap(ImportValue),
 	"Fn::Join":        str2Wrap(Join),
-	"Fn::Select":      str2AWrap(Select),
+	"Fn::Select":      str2Wrap(Select),
 	"Fn::Split":       str2Wrap(Split),
 	"Fn::Sub":         strWrap(Sub),
 	"Ref":             strWrap(Ref),
@@ -159,7 +159,7 @@ func GetAZsPtr(region interface{}) *string {
 
 // Sub substitutes variables in an input string with values that you specify. In your templates, you can use this function to construct commands or outputs that include values that aren't available until you create or update a stack.
 func Sub(value interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Sub" : %q }`, value))
+	return encode(fmt.Sprintf(`{ "Fn::Sub" : %s }`, toJSON(value)))
 }
 
 func SubPtr(value interface{}) *string {
@@ -193,7 +193,7 @@ func GetAttPtr(logicalName string, attribute string) *string {
 
 // Split splits a string into a list of string values so that you can select an element from the resulting string list, use the Fn::Split intrinsic function. Specify the location of splits with a delimiter, such as , (a comma). After you split a string, use the Fn::Select function to pick a specific element.
 func Split(delimiter, source interface{}) string {
-	return encode(fmt.Sprintf(`{ "Fn::Split" : [ %q, %q ] }`, delimiter, source))
+	return encode(fmt.Sprintf(`{ "Fn::Split" : [ %q, %s ] }`, delimiter, toJSON(source)))
 }
 
 func SplitPtr(delimiter, source interface{}) *string {
@@ -287,14 +287,11 @@ func JoinPtr(delimiter interface{}, value interface{}) *string {
 }
 
 // Select returns a single object from a list of objects by index.
-func Select(index interface{}, list []string) string {
-	if len(list) == 1 {
-		return encode(fmt.Sprintf(`{ "Fn::Select": [ %q,  %q ] }`, index, list[0]))
-	}
-	return encode(fmt.Sprintf(`{ "Fn::Select": [ %q, [ %v ] ] }`, index, printList(list)))
+func Select(index , list interface{}) string {
+	return encode(fmt.Sprintf(`{ "Fn::Select": [ %s, %s ] }`, toJSON(index), toJSON(list)))
 }
 
-func SelectPtr(index interface{}, list []string) *string {
+func SelectPtr(index, list interface{}) *string {
 	return String(Select(index, list))
 }
 
@@ -367,4 +364,13 @@ func interfaceAtostrA(values []interface{}) []string {
 func isBase64(s string) bool {
 	_, err := base64.StdEncoding.DecodeString(s)
 	return err == nil
+}
+
+func toJSON(value interface{}) string {
+	j, err := json.Marshal(value)
+	if err != nil {
+		fmt.Printf("Unsupported type for intrinsic JSON: %v\n", err)
+		return fmt.Sprintf("%q", value)
+	}
+	return string(j)
 }

--- a/cloudformation/intrinsics_test.go
+++ b/cloudformation/intrinsics_test.go
@@ -80,9 +80,31 @@ var _ = Describe("Goformation", func() {
 				Expected: `{"Description":{"Fn::Join":["a",["b","c"]]}}`,
 			},
 			{
+				Name:     "Join Nested",
+				Input:    `Description:
+  Fn::Join:
+  - ''
+  - - !Sub '${AWS::Region}'
+    - Fn::If:
+      - 'A'
+      - 'A1'
+      - !ImportValue 'B'`,
+				Expected: `{"Description":{"Fn::Join":["",[{"Fn::Sub":"${AWS::Region}"},{"Fn::If":["A","A1",{"Fn::ImportValue":"B"}]}]]}}`,
+			},
+			{
 				Name:     "Select",
 				Input:    `Description: !Select [a, [b, c]]`,
 				Expected: `{"Description":{"Fn::Select":["a",["b","c"]]}}`,
+			},
+			{
+				Name:     "Select Nested",
+				Input:    `Description:
+  Fn::Select:
+    - 2
+    - Fn::Split:
+      - '/'
+      - !GetAtt: 'site.url'`,
+				Expected: `{"Description":{"Fn::Select":[2,{"Fn::Split":["/","site.url"]}]}}`,
 			},
 			{
 				Name:     "And",


### PR DESCRIPTION
*Description of changes:*

Currently, most intrinsics use string quoted encoded values. This prevents us from being able to nest intrinsics, although CloudFormation supports these statements natively.

This switches a few important intrinsics to use JSON encoding vs string quoting for encoded intrinsic values. This allows us to nest intrinsics.

Newly supported examples:

```golang
SelectPtr(0, GetAZs(""))

Select(2, Split("/", GetAtt("Bucket", "WebsiteURL")))

JoinPtr("", []string{
  Sub("arn:aws:nnnnn:${AWS::Region}:${AWS::AccountId}:identity/"),
  If(
    "SomeAccount",
    canonicalDomainName,
    cloudformation.ImportValue(someOtherDomain),
  ),
})
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
