### PR TITLE
feat: bump Golang versions

### DIFF
--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         go:
+          - "1.22"
+          - "1.21"
           - "1.20"
-          - "1.19"
-          - "1.18"
 
     steps:
       - name: Check out code into the Go module directory
@@ -34,6 +34,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-        if: matrix.go == '1.20'
+        if: matrix.go == '1.22'
         with:
           files: ./coverage.txt

--- a/.github/workflows/update_schema.yml
+++ b/.github/workflows/update_schema.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.0'
+          go-version: '^1.22.0'
       
       - name: Update Schema
         run: |

--- a/devenv.nix
+++ b/devenv.nix
@@ -3,6 +3,6 @@
 {
   languages.go = {
     enable = true;
-    package = pkgs.go_1_21;
+    package = pkgs.go_1_22;
   };
 }

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,4 @@ require (
 	golang.org/x/tools v0.16.1 // indirect
 )
 
-go 1.18
+go 1.20


### PR DESCRIPTION
*Description of changes:* This PR bumps the supported Golang versions to the three latest stable versions: 1.20 - 1.22.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
